### PR TITLE
feat: add 'validate' command in AI Gateway CLI

### DIFF
--- a/cmd/aigw/main.go
+++ b/cmd/aigw/main.go
@@ -40,6 +40,8 @@ type (
 		Healthcheck cmdHealthcheck `cmd:"" help:"Docker HEALTHCHECK command."`
 		// DownloadEnvoy downloads the Envoy binary used by Envoy Gateway.
 		DownloadEnvoy cmdDownloadEnvoy `cmd:"" help:"Download Envoy binary for the Envoy Gateway default version."`
+		// Validate is the sub-command to validate AI Gateway config YAML files.
+		Validate cmdValidate `cmd:"" help:"Validate AI Gateway config YAML file(s) against the CRD schemas."`
 	}
 	// cmdRun corresponds to `aigw run` command.
 	cmdRun struct {
@@ -167,7 +169,7 @@ type (
 )
 
 func main() {
-	doMain(ctrl.SetupSignalHandler(), os.Stdout, os.Stderr, os.Args[1:], os.Exit, run, healthcheck, downloadEnvoyCmd)
+	doMain(ctrl.SetupSignalHandler(), os.Stdout, os.Stderr, os.Args[1:], os.Exit, run, healthcheck, downloadEnvoyCmd, validateCmd)
 }
 
 // doMain is the main entry point for the CLI. It parses the command line arguments and executes the appropriate command.
@@ -181,6 +183,7 @@ func doMain(ctx context.Context, stdout, stderr io.Writer, args []string, exitFn
 	rf runFn,
 	hf healthcheckFn,
 	df downloadEnvoyFn,
+	vf validateFn,
 ) {
 	var c cmd
 	parser, err := kong.New(&c,
@@ -212,6 +215,11 @@ func doMain(ctx context.Context, stdout, stderr io.Writer, args []string, exitFn
 		err = df(ctx, &c.DownloadEnvoy, stdout, stderr)
 		if err != nil {
 			log.Fatalf("Download Envoy failed: %v", err)
+		}
+	case "validate", "validate <paths>":
+		err = vf(ctx, &c.Validate, stdout, stderr)
+		if err != nil {
+			log.Fatalf("Validation failed: %v", err)
 		}
 	default:
 		panic("unreachable")

--- a/cmd/aigw/main_test.go
+++ b/cmd/aigw/main_test.go
@@ -29,6 +29,7 @@ func Test_doMain(t *testing.T) {
 		rf           runFn
 		hf           healthcheckFn
 		df           downloadEnvoyFn
+		vf           validateFn
 		expOut       string
 		expPanicCode *int
 	}{
@@ -62,6 +63,9 @@ Commands:
 
   download-envoy [flags]
     Download Envoy binary for the Envoy Gateway default version.
+
+  validate [<paths> ...] [flags]
+    Validate AI Gateway config YAML file(s) against the CRD schemas.
 
 Run "aigw <command> --help" for more information on a command.
 `,
@@ -198,10 +202,10 @@ Flags:
 			out := &bytes.Buffer{}
 			if tt.expPanicCode != nil {
 				require.PanicsWithValue(t, *tt.expPanicCode, func() {
-					doMain(t.Context(), out, os.Stderr, tt.args, func(code int) { panic(code) }, tt.rf, tt.hf, tt.df)
+					doMain(t.Context(), out, os.Stderr, tt.args, func(code int) { panic(code) }, tt.rf, tt.hf, tt.df, tt.vf)
 				})
 			} else {
-				doMain(t.Context(), out, os.Stderr, tt.args, nil, tt.rf, tt.hf, tt.df)
+				doMain(t.Context(), out, os.Stderr, tt.args, nil, tt.rf, tt.hf, tt.df, tt.vf)
 			}
 			fmt.Println(out.String())
 			require.Equal(t, tt.expOut, out.String())

--- a/cmd/aigw/testdata/validate_invalid.yaml
+++ b/cmd/aigw/testdata/validate_invalid.yaml
@@ -1,0 +1,52 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+# AIGatewayRoute with:
+#   - wrong parentRef kind
+#   - dangling backendRef (no matching AIServiceBackend)
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIGatewayRoute
+metadata:
+  name: bad-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: test-gateway
+      kind: HTTPRoute
+      group: gateway.networking.k8s.io
+  rules:
+    - backendRefs:
+        - name: nonexistent-backend
+---
+# AIServiceBackend with:
+#   - unknown schema name
+#   - wrong backendRef kind/group
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: bad-backend
+  namespace: default
+spec:
+  schema:
+    name: UnknownProvider
+  backendRef:
+    name: some-backend
+    kind: Service
+    group: wrong.group.io
+---
+# BackendSecurityPolicy with:
+#   - type/credential field mismatch (type=APIKey but no apiKey)
+#   - targetRef to nonexistent backend
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: BackendSecurityPolicy
+metadata:
+  name: bad-policy
+  namespace: default
+spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: nonexistent-backend
+  type: APIKey

--- a/cmd/aigw/testdata/validate_valid.yaml
+++ b/cmd/aigw/testdata/validate_valid.yaml
@@ -1,0 +1,93 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIGatewayRoute
+metadata:
+  name: test-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: test-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: gpt-4o-mini
+      backendRefs:
+        - name: test-openai
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: claude-3-5-sonnet
+      backendRefs:
+        - name: test-anthropic
+  llmRequestCosts:
+    - metadataKey: llm_input_token
+      type: InputToken
+    - metadataKey: llm_output_token
+      type: OutputToken
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: test-openai
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    name: test-openai-backend
+    kind: Backend
+    group: gateway.envoyproxy.io
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: test-anthropic
+  namespace: default
+spec:
+  schema:
+    name: Anthropic
+  backendRef:
+    name: test-anthropic-backend
+    kind: Backend
+    group: gateway.envoyproxy.io
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: BackendSecurityPolicy
+metadata:
+  name: test-openai-apikey
+  namespace: default
+spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: test-openai
+  type: APIKey
+  apiKey:
+    secretRef:
+      name: test-openai-apikey-secret
+      namespace: default
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: BackendSecurityPolicy
+metadata:
+  name: test-anthropic-apikey
+  namespace: default
+spec:
+  targetRefs:
+    - group: aigateway.envoyproxy.io
+      kind: AIServiceBackend
+      name: test-anthropic
+  type: AnthropicAPIKey
+  anthropicAPIKey:
+    secretRef:
+      name: test-anthropic-apikey-secret
+      namespace: default

--- a/cmd/aigw/validate.go
+++ b/cmd/aigw/validate.go
@@ -1,0 +1,406 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+)
+
+// cmdValidate is the struct for the `aigw validate` command.
+type cmdValidate struct {
+	Paths []string `arg:"" name:"paths" help:"Path(s) to AI Gateway config YAML file(s) to validate." type:"path" optional:""`
+}
+
+// Validate is called by Kong after parsing to enforce that at least one path was given.
+func (c *cmdValidate) Validate() error {
+	if len(c.Paths) == 0 {
+		return fmt.Errorf("at least one path is required")
+	}
+	return nil
+}
+
+type validateFn func(ctx context.Context, c *cmdValidate, stdout, stderr io.Writer) error
+
+// validateCmd checks AI Gateway config YAML files for structural and cross-reference errors
+// without requiring a running Kubernetes cluster.
+func validateCmd(_ context.Context, c *cmdValidate, stdout, stderr io.Writer) error {
+	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{}))
+	yamlContent, err := readYamlsAsString(c.Paths)
+	if err != nil {
+		return err
+	}
+
+	aigwRoutes, _, aigwBackends, backendSecurityPolicies, _, _, _, _, err := collectObjects(yamlContent, io.Discard, logger)
+	if err != nil {
+		return fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	total := len(aigwRoutes) + len(aigwBackends) + len(backendSecurityPolicies)
+	fmt.Fprintf(stdout, "Validating %d resource(s) from %d file(s)...\n\n", total, len(c.Paths))
+
+	results := validateResources(aigwRoutes, aigwBackends, backendSecurityPolicies)
+
+	errorCount := 0
+	for _, r := range results {
+		if len(r.issues) > 0 {
+			errorCount += len(r.issues)
+			fmt.Fprintf(stdout, "ERROR %s %q:\n", r.kind, resourceID(r.namespace, r.name))
+			for _, iss := range r.issues {
+				fmt.Fprintf(stdout, "  [%s] %s\n", iss.field, iss.message)
+			}
+			fmt.Fprintln(stdout)
+		} else {
+			fmt.Fprintf(stdout, "OK    %s %q\n", r.kind, resourceID(r.namespace, r.name))
+		}
+	}
+
+	fmt.Fprintln(stdout)
+	if errorCount > 0 {
+		return fmt.Errorf("validation failed: %d error(s)", errorCount)
+	}
+	_, _ = fmt.Fprintln(stdout, "All resources are valid.")
+	return nil
+}
+
+func resourceID(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
+	return namespace + "/" + name
+}
+
+type validationIssue struct {
+	field   string
+	message string
+}
+
+type validationResult struct {
+	kind      string
+	namespace string
+	name      string
+	issues    []validationIssue
+}
+
+// validateResources runs all structural and cross-reference validation checks.
+func validateResources(
+	aigwRoutes []*aigv1b1.AIGatewayRoute,
+	backends []*aigv1b1.AIServiceBackend,
+	bsps []*aigv1b1.BackendSecurityPolicy,
+) []validationResult {
+	backendSet := make(map[string]bool, len(backends))
+	for _, b := range backends {
+		ns := b.Namespace
+		if ns == "" {
+			ns = "default"
+		}
+		backendSet[ns+"/"+b.Name] = true
+	}
+
+	var results []validationResult
+
+	for _, route := range aigwRoutes {
+		results = append(results, validationResult{
+			kind:      "AIGatewayRoute",
+			namespace: route.Namespace,
+			name:      route.Name,
+			issues:    checkAIGatewayRoute(route, backendSet),
+		})
+	}
+	for _, b := range backends {
+		results = append(results, validationResult{
+			kind:      "AIServiceBackend",
+			namespace: b.Namespace,
+			name:      b.Name,
+			issues:    checkAIServiceBackend(b),
+		})
+	}
+	for _, bsp := range bsps {
+		results = append(results, validationResult{
+			kind:      "BackendSecurityPolicy",
+			namespace: bsp.Namespace,
+			name:      bsp.Name,
+			issues:    checkBackendSecurityPolicy(bsp, backendSet),
+		})
+	}
+
+	return results
+}
+
+func checkAIGatewayRoute(route *aigv1b1.AIGatewayRoute, backendSet map[string]bool) []validationIssue {
+	var issues []validationIssue
+
+	if len(route.Spec.Rules) == 0 {
+		return append(issues, validationIssue{field: "spec.rules", message: "at least one rule is required"})
+	}
+
+	for i, rule := range route.Spec.Rules {
+		hasPool, hasBackend := false, false
+		for _, ref := range rule.BackendRefs {
+			if ref.Group != nil || ref.Kind != nil {
+				hasPool = true
+			} else {
+				hasBackend = true
+			}
+		}
+		if hasPool && hasBackend {
+			issues = append(issues, validationIssue{
+				field:   fmt.Sprintf("spec.rules[%d].backendRefs", i),
+				message: "cannot mix InferencePool and AIServiceBackend references in the same rule",
+			})
+		}
+
+		poolCount := 0
+		for _, ref := range rule.BackendRefs {
+			if ref.Group != nil || ref.Kind != nil {
+				poolCount++
+			}
+		}
+		if poolCount > 1 {
+			issues = append(issues, validationIssue{
+				field:   fmt.Sprintf("spec.rules[%d].backendRefs", i),
+				message: "only one InferencePool backend is allowed per rule",
+			})
+		}
+
+		for j, ref := range rule.BackendRefs {
+			if ref.Group != nil || ref.Kind != nil {
+				g := derefStr(ref.Group)
+				k := derefStr(ref.Kind)
+				if g != "inference.networking.k8s.io" || k != "InferencePool" {
+					issues = append(issues, validationIssue{
+						field:   fmt.Sprintf("spec.rules[%d].backendRefs[%d]", i, j),
+						message: fmt.Sprintf(`only InferencePool from "inference.networking.k8s.io" is supported, got group=%q kind=%q`, g, k),
+					})
+				}
+			} else {
+				ns := route.Namespace
+				if ns == "" {
+					ns = "default"
+				}
+				if ref.Namespace != nil && string(*ref.Namespace) != "" {
+					ns = string(*ref.Namespace)
+				}
+				key := ns + "/" + ref.Name
+				if !backendSet[key] {
+					issues = append(issues, validationIssue{
+						field:   fmt.Sprintf("spec.rules[%d].backendRefs[%d].name", i, j),
+						message: fmt.Sprintf("references AIServiceBackend %q which is not defined in the provided config", key),
+					})
+				}
+			}
+		}
+	}
+
+	for i, ref := range route.Spec.ParentRefs {
+		if ref.Kind != nil && string(*ref.Kind) != "Gateway" {
+			issues = append(issues, validationIssue{
+				field:   fmt.Sprintf("spec.parentRefs[%d].kind", i),
+				message: fmt.Sprintf(`only "Gateway" is supported, got %q`, string(*ref.Kind)),
+			})
+		}
+	}
+
+	seenCostKeys := make(map[string]bool)
+	for i, cost := range route.Spec.LLMRequestCosts {
+		if seenCostKeys[cost.MetadataKey] {
+			issues = append(issues, validationIssue{
+				field:   fmt.Sprintf("spec.llmRequestCosts[%d].metadataKey", i),
+				message: fmt.Sprintf("duplicate metadata key %q", cost.MetadataKey),
+			})
+		}
+		seenCostKeys[cost.MetadataKey] = true
+		if cost.Type == aigv1b1.LLMRequestCostTypeCEL && cost.CEL == nil {
+			issues = append(issues, validationIssue{
+				field:   fmt.Sprintf("spec.llmRequestCosts[%d].cel", i),
+				message: "cel expression is required when type is CEL",
+			})
+		}
+		if cost.Type != aigv1b1.LLMRequestCostTypeCEL && cost.CEL != nil {
+			issues = append(issues, validationIssue{
+				field:   fmt.Sprintf("spec.llmRequestCosts[%d].cel", i),
+				message: "cel expression must only be set when type is CEL",
+			})
+		}
+	}
+
+	return issues
+}
+
+func checkAIServiceBackend(b *aigv1b1.AIServiceBackend) []validationIssue {
+	var issues []validationIssue
+
+	validSchemas := map[aigv1b1.APISchema]bool{
+		aigv1b1.APISchemaOpenAI:       true,
+		aigv1b1.APISchemaCohere:       true,
+		aigv1b1.APISchemaAWSBedrock:   true,
+		aigv1b1.APISchemaAzureOpenAI:  true,
+		aigv1b1.APISchemaGCPVertexAI:  true,
+		aigv1b1.APISchemaGCPAnthropic: true,
+		aigv1b1.APISchemaAnthropic:    true,
+		aigv1b1.APISchemaAWSAnthropic: true,
+	}
+	if !validSchemas[b.Spec.APISchema.Name] {
+		issues = append(issues, validationIssue{
+			field:   "spec.schema.name",
+			message: fmt.Sprintf("invalid value %q, must be one of: OpenAI, Cohere, AWSBedrock, AzureOpenAI, GCPVertexAI, GCPAnthropic, Anthropic, AWSAnthropic", b.Spec.APISchema.Name),
+		})
+	}
+
+	ref := b.Spec.BackendRef
+	if ref.Kind == nil || string(*ref.Kind) != "Backend" {
+		issues = append(issues, validationIssue{
+			field:   "spec.backendRef.kind",
+			message: `must be "Backend" (Envoy Gateway Backend resource)`,
+		})
+	}
+	if ref.Group == nil || string(*ref.Group) != "gateway.envoyproxy.io" {
+		issues = append(issues, validationIssue{
+			field:   "spec.backendRef.group",
+			message: `must be "gateway.envoyproxy.io"`,
+		})
+	}
+	if string(ref.Name) == "" {
+		issues = append(issues, validationIssue{
+			field:   "spec.backendRef.name",
+			message: "name is required",
+		})
+	}
+
+	return issues
+}
+
+func checkBackendSecurityPolicy(bsp *aigv1b1.BackendSecurityPolicy, backendSet map[string]bool) []validationIssue {
+	var issues []validationIssue
+	spec := bsp.Spec
+
+	validTypes := map[aigv1b1.BackendSecurityPolicyType]bool{
+		aigv1b1.BackendSecurityPolicyTypeAPIKey:           true,
+		aigv1b1.BackendSecurityPolicyTypeAWSCredentials:   true,
+		aigv1b1.BackendSecurityPolicyTypeAzureAPIKey:      true,
+		aigv1b1.BackendSecurityPolicyTypeAnthropicAPIKey:  true,
+		aigv1b1.BackendSecurityPolicyTypeAzureCredentials: true,
+		aigv1b1.BackendSecurityPolicyTypeGCPCredentials:   true,
+	}
+	if !validTypes[spec.Type] {
+		return append(issues, validationIssue{
+			field:   "spec.type",
+			message: fmt.Sprintf("invalid value %q, must be one of: APIKey, AWSCredentials, AzureAPIKey, AzureCredentials, GCPCredentials, AnthropicAPIKey", spec.Type),
+		})
+	}
+
+	switch spec.Type {
+	case aigv1b1.BackendSecurityPolicyTypeAPIKey:
+		if spec.APIKey == nil {
+			issues = append(issues, validationIssue{field: "spec.apiKey", message: "required when type is APIKey"})
+		}
+		if spec.AWSCredentials != nil || spec.AzureAPIKey != nil || spec.AzureCredentials != nil || spec.GCPCredentials != nil || spec.AnthropicAPIKey != nil {
+			issues = append(issues, validationIssue{field: "spec", message: "only apiKey field may be set when type is APIKey"})
+		}
+	case aigv1b1.BackendSecurityPolicyTypeAWSCredentials:
+		if spec.AWSCredentials == nil {
+			issues = append(issues, validationIssue{field: "spec.awsCredentials", message: "required when type is AWSCredentials"})
+		} else if spec.AWSCredentials.Region == "" {
+			issues = append(issues, validationIssue{field: "spec.awsCredentials.region", message: "required"})
+		}
+		if spec.APIKey != nil || spec.AzureAPIKey != nil || spec.AzureCredentials != nil || spec.GCPCredentials != nil || spec.AnthropicAPIKey != nil {
+			issues = append(issues, validationIssue{field: "spec", message: "only awsCredentials field may be set when type is AWSCredentials"})
+		}
+	case aigv1b1.BackendSecurityPolicyTypeAzureAPIKey:
+		if spec.AzureAPIKey == nil {
+			issues = append(issues, validationIssue{field: "spec.azureAPIKey", message: "required when type is AzureAPIKey"})
+		}
+		if spec.APIKey != nil || spec.AWSCredentials != nil || spec.AzureCredentials != nil || spec.GCPCredentials != nil || spec.AnthropicAPIKey != nil {
+			issues = append(issues, validationIssue{field: "spec", message: "only azureAPIKey field may be set when type is AzureAPIKey"})
+		}
+	case aigv1b1.BackendSecurityPolicyTypeAzureCredentials:
+		if spec.AzureCredentials == nil {
+			issues = append(issues, validationIssue{field: "spec.azureCredentials", message: "required when type is AzureCredentials"})
+		} else {
+			if spec.AzureCredentials.ClientID == "" {
+				issues = append(issues, validationIssue{field: "spec.azureCredentials.clientID", message: "required"})
+			}
+			if spec.AzureCredentials.TenantID == "" {
+				issues = append(issues, validationIssue{field: "spec.azureCredentials.tenantID", message: "required"})
+			}
+		}
+		if spec.APIKey != nil || spec.AWSCredentials != nil || spec.AzureAPIKey != nil || spec.GCPCredentials != nil || spec.AnthropicAPIKey != nil {
+			issues = append(issues, validationIssue{field: "spec", message: "only azureCredentials field may be set when type is AzureCredentials"})
+		}
+	case aigv1b1.BackendSecurityPolicyTypeGCPCredentials:
+		if spec.GCPCredentials == nil {
+			issues = append(issues, validationIssue{field: "spec.gcpCredentials", message: "required when type is GCPCredentials"})
+		} else {
+			if spec.GCPCredentials.ProjectName == "" {
+				issues = append(issues, validationIssue{field: "spec.gcpCredentials.projectName", message: "required"})
+			}
+			if spec.GCPCredentials.Region == "" {
+				issues = append(issues, validationIssue{field: "spec.gcpCredentials.region", message: "required"})
+			}
+			if spec.GCPCredentials.CredentialsFile == nil && spec.GCPCredentials.WorkloadIdentityFederationConfig == nil {
+				issues = append(issues, validationIssue{
+					field:   "spec.gcpCredentials",
+					message: "exactly one of credentialsFile or workloadIdentityFederationConfig must be specified",
+				})
+			} else if spec.GCPCredentials.CredentialsFile != nil && spec.GCPCredentials.WorkloadIdentityFederationConfig != nil {
+				issues = append(issues, validationIssue{
+					field:   "spec.gcpCredentials",
+					message: "only one of credentialsFile or workloadIdentityFederationConfig may be set",
+				})
+			}
+		}
+		if spec.APIKey != nil || spec.AWSCredentials != nil || spec.AzureAPIKey != nil || spec.AzureCredentials != nil || spec.AnthropicAPIKey != nil {
+			issues = append(issues, validationIssue{field: "spec", message: "only gcpCredentials field may be set when type is GCPCredentials"})
+		}
+	case aigv1b1.BackendSecurityPolicyTypeAnthropicAPIKey:
+		if spec.AnthropicAPIKey == nil {
+			issues = append(issues, validationIssue{field: "spec.anthropicAPIKey", message: "required when type is AnthropicAPIKey"})
+		}
+		if spec.APIKey != nil || spec.AWSCredentials != nil || spec.AzureAPIKey != nil || spec.AzureCredentials != nil || spec.GCPCredentials != nil {
+			issues = append(issues, validationIssue{field: "spec", message: "only anthropicAPIKey field may be set when type is AnthropicAPIKey"})
+		}
+	}
+
+	ns := bsp.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	for i, ref := range spec.TargetRefs {
+		g, k := string(ref.Group), string(ref.Kind)
+		isAIServiceBackend := g == "aigateway.envoyproxy.io" && k == "AIServiceBackend"
+		isInferencePool := g == "inference.networking.k8s.io" && k == "InferencePool"
+		if !isAIServiceBackend && !isInferencePool {
+			issues = append(issues, validationIssue{
+				field:   fmt.Sprintf("spec.targetRefs[%d]", i),
+				message: fmt.Sprintf("must reference AIServiceBackend or InferencePool, got group=%q kind=%q", g, k),
+			})
+			continue
+		}
+		if isAIServiceBackend {
+			key := ns + "/" + string(ref.Name)
+			if !backendSet[key] {
+				issues = append(issues, validationIssue{
+					field:   fmt.Sprintf("spec.targetRefs[%d]", i),
+					message: fmt.Sprintf("references AIServiceBackend %q which is not defined in the provided config", key),
+				})
+			}
+		}
+	}
+
+	return issues
+}
+
+// derefStr safely dereferences a *string, returning "" if nil.
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/cmd/aigw/validate_test.go
+++ b/cmd/aigw/validate_test.go
@@ -1,0 +1,389 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+)
+
+// Test_validateCmd tests the full pipeline using real YAML files.
+func Test_validateCmd(t *testing.T) {
+	tests := []struct {
+		name          string
+		paths         []string
+		expectErr     string
+		expectOutputs []string
+	}{
+		{
+			name:  "valid config passes",
+			paths: []string{"testdata/validate_valid.yaml"},
+			expectOutputs: []string{
+				`OK    AIGatewayRoute "default/test-route"`,
+				`OK    AIServiceBackend "default/test-openai"`,
+				`OK    AIServiceBackend "default/test-anthropic"`,
+				`OK    BackendSecurityPolicy "default/test-openai-apikey"`,
+				`OK    BackendSecurityPolicy "default/test-anthropic-apikey"`,
+				"All resources are valid.",
+			},
+		},
+		{
+			name:      "invalid config reports all errors",
+			paths:     []string{"testdata/validate_invalid.yaml"},
+			expectErr: "validation failed:",
+			expectOutputs: []string{
+				`ERROR AIGatewayRoute "default/bad-route":`,
+				`ERROR AIServiceBackend "default/bad-backend":`,
+				`ERROR BackendSecurityPolicy "default/bad-policy":`,
+			},
+		},
+		{
+			name:  "duplicate resources across files are deduplicated",
+			paths: []string{"testdata/validate_valid.yaml", "testdata/validate_valid.yaml"},
+			expectOutputs: []string{
+				"Validating 5 resource(s) from 2 file(s)",
+				"All resources are valid.",
+			},
+		},
+		{
+			name:      "nonexistent file returns error before validation",
+			paths:     []string{"/nonexistent/config.yaml"},
+			expectErr: "error reading file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			err := validateCmd(t.Context(), &cmdValidate{Paths: tt.paths}, stdout, os.Stderr)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			out := stdout.String()
+			for _, want := range tt.expectOutputs {
+				assert.Contains(t, out, want, "output should contain %q\nfull output:\n%s", want, out)
+			}
+		})
+	}
+}
+
+// Test_doMain_validate tests the validate subcommand wiring through doMain.
+func Test_doMain_validate(t *testing.T) {
+	t.Run("no paths exits with code 80", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		require.PanicsWithValue(t, 80, func() {
+			doMain(t.Context(), out, os.Stderr, []string{"validate"},
+				func(code int) { panic(code) }, nil, nil, nil, validateCmd)
+		})
+	})
+
+	t.Run("valid file succeeds", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		doMain(t.Context(), out, os.Stderr, []string{"validate", "testdata/validate_valid.yaml"},
+			nil, nil, nil, nil, validateCmd)
+		assert.Contains(t, out.String(), "All resources are valid.")
+	})
+}
+
+// Test_checkAIGatewayRoute tests AIGatewayRoute validation rules.
+func Test_checkAIGatewayRoute(t *testing.T) {
+	backendSet := map[string]bool{"default/my-backend": true}
+
+	t.Run("no rules", func(t *testing.T) {
+		route := &aigv1b1.AIGatewayRoute{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"}}
+		issues := checkAIGatewayRoute(route, nil)
+		require.Len(t, issues, 1)
+		assert.Equal(t, "spec.rules", issues[0].field)
+	})
+
+	t.Run("valid route passes", func(t *testing.T) {
+		route := helperRoute("r", "default", "my-backend")
+		assert.Empty(t, checkAIGatewayRoute(route, backendSet))
+	})
+
+	t.Run("wrong parentRef kind", func(t *testing.T) {
+		route := helperRoute("r", "default", "my-backend")
+		wrong := gwapiv1.Kind("HTTPRoute")
+		route.Spec.ParentRefs = []gwapiv1.ParentReference{{Kind: &wrong, Name: "gw"}}
+		issues := checkAIGatewayRoute(route, backendSet)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].field, "parentRefs[0]")
+		assert.Contains(t, issues[0].message, "HTTPRoute")
+	})
+
+	t.Run("dangling backend reference", func(t *testing.T) {
+		route := helperRoute("r", "default", "ghost")
+		issues := checkAIGatewayRoute(route, backendSet)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].message, "ghost")
+	})
+
+	t.Run("mixed InferencePool and AIServiceBackend in same rule", func(t *testing.T) {
+		g := "inference.networking.k8s.io"
+		k := "InferencePool"
+		route := &aigv1b1.AIGatewayRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Rules: []aigv1b1.AIGatewayRouteRule{{
+					BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{
+						{Name: "my-backend"},
+						{Name: "my-pool", Group: &g, Kind: &k},
+					},
+				}},
+			},
+		}
+		issues := checkAIGatewayRoute(route, backendSet)
+		hasMixedErr := false
+		for _, iss := range issues {
+			if strings.Contains(iss.message, "cannot mix") {
+				hasMixedErr = true
+			}
+		}
+		assert.True(t, hasMixedErr)
+	})
+
+	t.Run("more than one InferencePool per rule", func(t *testing.T) {
+		g := "inference.networking.k8s.io"
+		k := "InferencePool"
+		route := &aigv1b1.AIGatewayRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Rules: []aigv1b1.AIGatewayRouteRule{{
+					BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{
+						{Name: "pool-a", Group: &g, Kind: &k},
+						{Name: "pool-b", Group: &g, Kind: &k},
+					},
+				}},
+			},
+		}
+		issues := checkAIGatewayRoute(route, nil)
+		hasOnePoolErr := false
+		for _, iss := range issues {
+			if strings.Contains(iss.message, "only one InferencePool") {
+				hasOnePoolErr = true
+			}
+		}
+		assert.True(t, hasOnePoolErr)
+	})
+
+	t.Run("duplicate LLMRequestCost metadata key", func(t *testing.T) {
+		route := helperRoute("r", "default", "my-backend")
+		route.Spec.LLMRequestCosts = []aigv1b1.LLMRequestCost{
+			{MetadataKey: "tokens", Type: aigv1b1.LLMRequestCostTypeInputToken},
+			{MetadataKey: "tokens", Type: aigv1b1.LLMRequestCostTypeOutputToken},
+		}
+		issues := checkAIGatewayRoute(route, backendSet)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].message, `duplicate metadata key "tokens"`)
+	})
+
+	t.Run("CEL type requires cel expression", func(t *testing.T) {
+		route := helperRoute("r", "default", "my-backend")
+		route.Spec.LLMRequestCosts = []aigv1b1.LLMRequestCost{
+			{MetadataKey: "cost", Type: aigv1b1.LLMRequestCostTypeCEL},
+		}
+		issues := checkAIGatewayRoute(route, backendSet)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].message, "cel expression is required")
+	})
+
+	t.Run("non-CEL type must not have cel expression", func(t *testing.T) {
+		route := helperRoute("r", "default", "my-backend")
+		expr := "input_tokens"
+		route.Spec.LLMRequestCosts = []aigv1b1.LLMRequestCost{
+			{MetadataKey: "cost", Type: aigv1b1.LLMRequestCostTypeInputToken, CEL: &expr},
+		}
+		issues := checkAIGatewayRoute(route, backendSet)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].message, "must only be set when type is CEL")
+	})
+}
+
+// Test_checkAIServiceBackend tests AIServiceBackend validation rules.
+func Test_checkAIServiceBackend(t *testing.T) {
+	t.Run("valid backend passes", func(t *testing.T) {
+		assert.Empty(t, checkAIServiceBackend(helperBackend("b", "default", aigv1b1.APISchemaOpenAI)))
+	})
+
+	t.Run("all valid schema names pass", func(t *testing.T) {
+		for _, schema := range []aigv1b1.APISchema{
+			aigv1b1.APISchemaOpenAI, aigv1b1.APISchemaCohere, aigv1b1.APISchemaAWSBedrock,
+			aigv1b1.APISchemaAzureOpenAI, aigv1b1.APISchemaGCPVertexAI, aigv1b1.APISchemaGCPAnthropic,
+			aigv1b1.APISchemaAnthropic, aigv1b1.APISchemaAWSAnthropic,
+		} {
+			assert.Empty(t, checkAIServiceBackend(helperBackend("b", "default", schema)), "schema %q should be valid", schema)
+		}
+	})
+
+	t.Run("invalid schema name", func(t *testing.T) {
+		b := helperBackend("b", "default", "BadProvider")
+		issues := checkAIServiceBackend(b)
+		require.Len(t, issues, 1)
+		assert.Equal(t, "spec.schema.name", issues[0].field)
+		assert.Contains(t, issues[0].message, "BadProvider")
+	})
+
+	t.Run("wrong backendRef kind", func(t *testing.T) {
+		b := helperBackend("b", "default", aigv1b1.APISchemaOpenAI)
+		svc := gwapiv1.Kind("Service")
+		b.Spec.BackendRef.Kind = &svc
+		issues := checkAIServiceBackend(b)
+		require.Len(t, issues, 1)
+		assert.Equal(t, "spec.backendRef.kind", issues[0].field)
+	})
+
+	t.Run("wrong backendRef group", func(t *testing.T) {
+		b := helperBackend("b", "default", aigv1b1.APISchemaOpenAI)
+		wrong := gwapiv1.Group("wrong.group.io")
+		b.Spec.BackendRef.Group = &wrong
+		issues := checkAIServiceBackend(b)
+		require.Len(t, issues, 1)
+		assert.Equal(t, "spec.backendRef.group", issues[0].field)
+	})
+}
+
+// Test_checkBackendSecurityPolicy tests BackendSecurityPolicy validation rules.
+func Test_checkBackendSecurityPolicy(t *testing.T) {
+	t.Run("valid APIKey policy passes", func(t *testing.T) {
+		bsp := helperAPIKeyPolicy("p", "default", "my-backend")
+		assert.Empty(t, checkBackendSecurityPolicy(bsp, map[string]bool{"default/my-backend": true}))
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		bsp := &aigv1b1.BackendSecurityPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Spec:       aigv1b1.BackendSecurityPolicySpec{Type: "BadType"},
+		}
+		issues := checkBackendSecurityPolicy(bsp, nil)
+		require.Len(t, issues, 1)
+		assert.Equal(t, "spec.type", issues[0].field)
+		assert.Contains(t, issues[0].message, "BadType")
+	})
+
+	t.Run("APIKey type without apiKey field", func(t *testing.T) {
+		bsp := &aigv1b1.BackendSecurityPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Spec:       aigv1b1.BackendSecurityPolicySpec{Type: aigv1b1.BackendSecurityPolicyTypeAPIKey},
+		}
+		issues := checkBackendSecurityPolicy(bsp, nil)
+		require.Len(t, issues, 1)
+		assert.Equal(t, "spec.apiKey", issues[0].field)
+		assert.Contains(t, issues[0].message, "required when type is APIKey")
+	})
+
+	t.Run("AWSCredentials missing region", func(t *testing.T) {
+		bsp := &aigv1b1.BackendSecurityPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Spec: aigv1b1.BackendSecurityPolicySpec{
+				Type:           aigv1b1.BackendSecurityPolicyTypeAWSCredentials,
+				AWSCredentials: &aigv1b1.BackendSecurityPolicyAWSCredentials{},
+			},
+		}
+		issues := checkBackendSecurityPolicy(bsp, nil)
+		require.Len(t, issues, 1)
+		assert.Equal(t, "spec.awsCredentials.region", issues[0].field)
+	})
+
+	t.Run("GCPCredentials with both credentialsFile and workloadIdentity", func(t *testing.T) {
+		bsp := &aigv1b1.BackendSecurityPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Spec: aigv1b1.BackendSecurityPolicySpec{
+				Type: aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+				GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{
+					ProjectName:                      "proj",
+					Region:                           "us-central1",
+					CredentialsFile:                  &aigv1b1.GCPCredentialsFile{},
+					WorkloadIdentityFederationConfig: &aigv1b1.GCPWorkloadIdentityFederationConfig{},
+				},
+			},
+		}
+		issues := checkBackendSecurityPolicy(bsp, nil)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].message, "only one of")
+	})
+
+	t.Run("targetRef to nonexistent AIServiceBackend", func(t *testing.T) {
+		bsp := helperAPIKeyPolicy("p", "default", "ghost")
+		issues := checkBackendSecurityPolicy(bsp, map[string]bool{"default/other": true})
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].message, "ghost")
+	})
+
+	t.Run("targetRef with wrong group/kind", func(t *testing.T) {
+		bsp := &aigv1b1.BackendSecurityPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Spec: aigv1b1.BackendSecurityPolicySpec{
+				Type:   aigv1b1.BackendSecurityPolicyTypeAPIKey,
+				APIKey: &aigv1b1.BackendSecurityPolicyAPIKey{},
+				TargetRefs: []gwapiv1a2.LocalPolicyTargetReference{
+					{Group: "wrong.group", Kind: "Foo", Name: "bar"},
+				},
+			},
+		}
+		issues := checkBackendSecurityPolicy(bsp, nil)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].message, "must reference AIServiceBackend or InferencePool")
+	})
+}
+
+// --- helpers ---
+
+func helperRoute(name, namespace, backendName string) *aigv1b1.AIGatewayRoute {
+	gwKind := gwapiv1.Kind("Gateway")
+	return &aigv1b1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: aigv1b1.AIGatewayRouteSpec{
+			ParentRefs: []gwapiv1.ParentReference{{Kind: &gwKind, Name: "test-gw"}},
+			Rules: []aigv1b1.AIGatewayRouteRule{
+				{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: backendName}}},
+			},
+		},
+	}
+}
+
+func helperBackend(name, namespace string, schema aigv1b1.APISchema) *aigv1b1.AIServiceBackend {
+	kind := gwapiv1.Kind("Backend")
+	group := gwapiv1.Group("gateway.envoyproxy.io")
+	return &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			APISchema: aigv1b1.VersionedAPISchema{Name: schema},
+			BackendRef: gwapiv1.BackendObjectReference{
+				Name:  gwapiv1.ObjectName(name + "-backend"),
+				Kind:  &kind,
+				Group: &group,
+			},
+		},
+	}
+}
+
+func helperAPIKeyPolicy(name, namespace, backendName string) *aigv1b1.BackendSecurityPolicy {
+	return &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: aigv1b1.BackendSecurityPolicySpec{
+			Type:   aigv1b1.BackendSecurityPolicyTypeAPIKey,
+			APIKey: &aigv1b1.BackendSecurityPolicyAPIKey{SecretRef: &gwapiv1.SecretObjectReference{Name: "secret"}},
+			TargetRefs: []gwapiv1a2.LocalPolicyTargetReference{
+				{Group: "aigateway.envoyproxy.io", Kind: "AIServiceBackend", Name: gwapiv1a2.ObjectName(backendName)},
+			},
+		},
+	}
+}


### PR DESCRIPTION
**Description**

Adds aigw validate <paths...> — a new subcommand that statically checks AI Gateway config YAML files for errors without requiring a running Kubernetes cluster or Envoy Gateway.

$ aigw validate config.yaml

  Validating 5 resource(s) from 1 file(s)...

  OK    AIGatewayRoute "default/my-route"
  OK    AIServiceBackend "default/openai-backend"
  ERROR BackendSecurityPolicy "default/my-policy":
    [spec.apiKey] required when type is APIKey
    [spec.targetRefs[0]] references AIServiceBackend "default/ghost" which is not defined in the provided config

  Validation failed: 2 error(s)
