### PR TITLE
feat: add template for quota policy rl server and service

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/quota_policy_rate_limit.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/quota_policy_rate_limit.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rateLimiter.enabled }}
+# Rate limit service that reads QuotaPolicy configs via xDS from the AI Gateway controller
 # and enforces quota-based rate limiting for upstream clusters.
 apiVersion: apps/v1
 kind: Deployment
@@ -25,7 +26,7 @@ spec:
             - containerPort: {{ .Values.rateLimiter.port }}
               name: grpc
           env:
-            {{- toYaml .Values.rateLimiter.env | nindent 12 }}
+            {{- tpl (toYaml .Values.rateLimiter.env) $ | nindent 12 }}
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/charts/ai-gateway-helm/templates/quota_policy_rate_limit.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/quota_policy_rate_limit.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.rateLimiter.enabled }}
+# and enforces quota-based rate limiting for upstream clusters.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.rateLimiter.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.rateLimiter.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.rateLimiter.name }}
+    spec:
+      containers:
+        - name: ratelimit
+          command:
+            - /bin/ratelimit
+          image: "{{ .Values.rateLimiter.image.repository }}:{{ .Values.rateLimiter.image.tag }}"
+          imagePullPolicy: {{ .Values.rateLimiter.imagePullPolicy }}
+          ports:
+            - containerPort: {{ .Values.rateLimiter.port }}
+              name: grpc
+          env:
+            {{- toYaml .Values.rateLimiter.env | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.rateLimiter.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: {{ .Values.rateLimiter.name }}
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: {{ .Values.rateLimiter.port }}
+      targetPort: {{ .Values.rateLimiter.port }}
+  type: ClusterIP
+{{- end }}

--- a/manifests/charts/ai-gateway-helm/templates/quota_policy_rate_limit.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/quota_policy_rate_limit.yaml
@@ -1,3 +1,8 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
 {{- if .Values.rateLimiter.enabled }}
 # Rate limit service that reads QuotaPolicy configs via xDS from the AI Gateway controller
 # and enforces quota-based rate limiting for upstream clusters.

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -268,6 +268,36 @@ controller:
         # Number of PBKDF2 iterations to use for deriving the MCP session encryption key with the fallback seed.
         iterations: 100000
 
+rateLimiter:
+  enabled: false
+  name: envoy-ai-gateway-ratelimit
+  image:
+    repository: docker.io/envoyproxy/ratelimit
+    tag: "1631871c"
+  imagePullPolicy: IfNotPresent
+  port: 8081
+  env:
+    - name: LOG_LEVEL
+      value: debug
+    - name: REDIS_SOCKET_TYPE
+      value: tcp
+    - name: REDIS_URL
+      value: redis.redis-system.svc.cluster.local:6379
+    - name: RUNTIME_ROOT
+      value: /data
+    - name: RUNTIME_SUBDIRECTORY
+      value: ratelimit
+    - name: USE_STATSD
+      value: "false"
+    - name: CONFIG_TYPE
+      value: GRPC_XDS_SOTW
+    - name: CONFIG_GRPC_XDS_NODE_ID
+      value: envoy-ai-gateway-ratelimit
+    - name: CONFIG_GRPC_XDS_SERVER_URL
+      value: ai-gateway-controller.envoy-ai-gateway-system.svc.cluster.local:18002
+    - name: GRPC_PORT
+      value: "8081"
+
 # Configuration for the Envoy Gateway component that AI Gateway relies on to program Envoy.
 envoyGateway:
   # The namespace where the Envoy Gateway controller is installed.

--- a/tests/e2e/testdata/backend_quota_ratelimit.yaml
+++ b/tests/e2e/testdata/backend_quota_ratelimit.yaml
@@ -191,8 +191,6 @@ spec:
           ports:
             - containerPort: 8081
               name: grpc
-          args:
-            - --quotaRateLimitServiceAddr=envoy-ai-gateway-ratelimit.envoy-gateway-system
           env:
             - name: LOG_LEVEL
               value: debug


### PR DESCRIPTION
**Description**

Helm template to create quota policy rate limit server and service. The template is derived from the backend_quota_ratelimit.yaml. Guarded by a feature flag

Related to #2177