### PR TITLE
fix: namespace _meta.ui.resourceUri and Content URIs in tools/call results

### DIFF
--- a/internal/mcpproxy/handlers.go
+++ b/internal/mcpproxy/handlers.go
@@ -945,21 +945,35 @@ func (m *mcpRequestContext) maybeUpdateProgressTokenMetadata(ctx context.Context
 	return true
 }
 
-// maybeResponseModify modifies the client->server response to include the backend name where needed.
+// maybeResponseModify modifies the server->client response to include the backend name where needed.
 func (m *mcpRequestContext) maybeResponseModify(_ context.Context, req *jsonrpc.Request, msg *jsonrpc.Response, backend filterapi.MCPBackendName) error {
-	if req.Method != "resources/read" || msg.Result == nil {
+	if msg.Result == nil {
 		return nil
 	}
-
-	result := &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{}}
-	if err := json.Unmarshal(msg.Result, result); err != nil {
-		return fmt.Errorf("failed to unmarshal resources/read result: %w", err)
+	switch req.Method {
+	case "resources/read":
+		// No idempotency guard needed here: handleResourceReadRequest strips the backend
+		// prefix from the request URI before forwarding, so the backend always returns a
+		// bare URI and a single downstreamResourceURI call is always correct.
+		result := &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{}}
+		if err := json.Unmarshal(msg.Result, result); err != nil {
+			return fmt.Errorf("failed to unmarshal resources/read result: %w", err)
+		}
+		for _, res := range result.Contents {
+			res.URI = downstreamResourceURI(res.URI, backend)
+		}
+		msg.Result, _ = json.Marshal(result) // Already decoded result, so ignore error.
+	case "tools/call":
+		result := &mcp.CallToolResult{}
+		if err := json.Unmarshal(msg.Result, result); err != nil {
+			// Non-standard result shape — pass through unchanged; the backend owns this payload.
+			m.l.Debug("tools/call result is not a standard CallToolResult, skipping URI rewrite", slog.String("error", err.Error()))
+			return nil
+		}
+		if rewriteToolResultURIs(result, backend) {
+			msg.Result, _ = json.Marshal(result) // Already decoded result, so ignore error.
+		}
 	}
-	for _, res := range result.Contents {
-		res.URI = downstreamResourceURI(res.URI, backend)
-	}
-	msg.Result, _ = json.Marshal(result) // Already decoded result, so ignore error.
-
 	return nil
 }
 
@@ -1230,6 +1244,61 @@ func upstreamResourceURI(fullURI string) (backendName, uri string, err error) {
 		return "", "", fmt.Errorf("invalid resource URI: %s", fullURI)
 	}
 	return parts[0], parts[1], nil
+}
+
+// metaResourceURIPaths lists the _meta key paths whose leaf value is a routable resource
+// URI that must be backend-namespaced in multiplexing mode. Add an entry here to support
+// a new convention; upstreamResourceURI decodes all of them uniformly.
+var metaResourceURIPaths = [][]string{
+	{"ui", "resourceUri"}, // MCP Apps standard (_meta.ui.resourceUri)
+}
+
+// rewriteMetaResourceURIs namespaces every known routable resource URI in meta with the
+// backend name so the agent's later resources/read routes back to the originating backend.
+// Returns true if anything was changed. No-ops (and never panics) on absent or unexpected shapes.
+func rewriteMetaResourceURIs(meta mcp.Meta, backendName filterapi.MCPBackendName) bool {
+	changed := false
+	for _, path := range metaResourceURIPaths {
+		node := map[string]any(meta)
+		for i, key := range path {
+			if node == nil {
+				break
+			}
+			if i == len(path)-1 {
+				uri, ok := node[key].(string)
+				if ok && uri != "" && !strings.HasPrefix(uri, backendName+"+") {
+					node[key] = downstreamResourceURI(uri, backendName)
+					changed = true
+				}
+			} else {
+				node, _ = node[key].(map[string]any)
+			}
+		}
+	}
+	return changed
+}
+
+// rewriteToolResultURIs namespaces all routable resource URIs in a tools/call result:
+// _meta fields (via rewriteMetaResourceURIs) and any ResourceLink / EmbeddedResource
+// entries in Content[]. Returns true if anything was changed.
+func rewriteToolResultURIs(result *mcp.CallToolResult, backendName filterapi.MCPBackendName) bool {
+	changed := rewriteMetaResourceURIs(result.Meta, backendName)
+	prefix := backendName + "+"
+	for _, c := range result.Content {
+		switch v := c.(type) {
+		case *mcp.ResourceLink:
+			if v.URI != "" && !strings.HasPrefix(v.URI, prefix) {
+				v.URI = downstreamResourceURI(v.URI, backendName)
+				changed = true
+			}
+		case *mcp.EmbeddedResource:
+			if v.Resource != nil && v.Resource.URI != "" && !strings.HasPrefix(v.Resource.URI, prefix) {
+				v.Resource.URI = downstreamResourceURI(v.Resource.URI, backendName)
+				changed = true
+			}
+		}
+	}
+	return changed
 }
 
 // extractSubject extracts the "sub" claim from the JWT in the Authorization header.
@@ -1686,6 +1755,7 @@ func (m *mcpRequestContext) mergeToolsList(s *session, responses []broadCastResp
 				}
 			}
 			tool.Name = downstreamResourceName(tool.Name, r.backendName)
+			rewriteMetaResourceURIs(tool.Meta, r.backendName)
 			resp.Tools = append(resp.Tools, tool)
 		}
 	}

--- a/internal/mcpproxy/handlers_test.go
+++ b/internal/mcpproxy/handlers_test.go
@@ -638,6 +638,48 @@ func TestMergeToolsList_AuthorizationFiltering(t *testing.T) {
 	}
 }
 
+func TestMergeToolsList_MetaRewrite(t *testing.T) {
+	responses := []broadCastResponse[mcp.ListToolsResult]{
+		{
+			backendName: "backend1",
+			res: mcp.ListToolsResult{
+				Tools: []*mcp.Tool{
+					{
+						Name: "ui-tool",
+						Meta: mcp.Meta{"ui": map[string]any{"resourceUri": "ui://prefab/tool/renderer.html"}},
+					},
+					{
+						Name: "plain-tool",
+					},
+				},
+			},
+		},
+	}
+	proxy := newTestMCPProxy()
+	proxy.routes["test-route"].toolSelectors = nil
+	proxy.routes["test-route"].authorization = nil
+	proxy.requestHeaders = http.Header{}
+	session := &session{route: "test-route"}
+
+	result := proxy.mergeToolsList(session, responses)
+	require.Len(t, result.Tools, 2)
+
+	byName := map[string]*mcp.Tool{}
+	for _, tool := range result.Tools {
+		byName[tool.Name] = tool
+	}
+
+	uiTool := byName["backend1__ui-tool"]
+	require.NotNil(t, uiTool)
+	uiMeta, ok := uiTool.Meta["ui"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "backend1+ui://prefab/tool/renderer.html", uiMeta["resourceUri"])
+
+	plainTool := byName["backend1__plain-tool"]
+	require.NotNil(t, plainTool)
+	require.Nil(t, plainTool.Meta)
+}
+
 func TestServePOST_ToolsCallRequest(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -1298,6 +1340,192 @@ func Test_upstreamResourceURI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_rewriteMetaResourceURIs(t *testing.T) {
+	cases := []struct {
+		name    string
+		meta    mcp.Meta
+		backend filterapi.MCPBackendName
+		want    mcp.Meta
+		changed bool
+	}{
+		{
+			name:    "rewrite _meta.ui.resourceUri",
+			meta:    mcp.Meta{"ui": map[string]any{"resourceUri": "ui://prefab/tool/xxx/renderer.html"}},
+			backend: "backend1",
+			want:    mcp.Meta{"ui": map[string]any{"resourceUri": "backend1+ui://prefab/tool/xxx/renderer.html"}},
+			changed: true,
+		},
+		{
+			name:    "nil meta — no-op, no panic",
+			meta:    nil,
+			backend: "backend1",
+			want:    nil,
+			changed: false,
+		},
+		{
+			name:    "empty meta — no-op",
+			meta:    mcp.Meta{},
+			backend: "backend1",
+			want:    mcp.Meta{},
+			changed: false,
+		},
+		{
+			name:    "ui present but resourceUri missing — no-op",
+			meta:    mcp.Meta{"ui": map[string]any{"other": "val"}},
+			backend: "backend1",
+			want:    mcp.Meta{"ui": map[string]any{"other": "val"}},
+			changed: false,
+		},
+		{
+			name:    "resourceUri is non-string — no-op, no panic",
+			meta:    mcp.Meta{"ui": map[string]any{"resourceUri": 42}},
+			backend: "backend1",
+			want:    mcp.Meta{"ui": map[string]any{"resourceUri": 42}},
+			changed: false,
+		},
+		{
+			name:    "ui value is non-map — no-op, no panic",
+			meta:    mcp.Meta{"ui": "not-a-map"},
+			backend: "backend1",
+			want:    mcp.Meta{"ui": "not-a-map"},
+			changed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := rewriteMetaResourceURIs(tc.meta, tc.backend)
+			require.Equal(t, tc.changed, changed)
+			require.Equal(t, tc.want, tc.meta)
+		})
+	}
+}
+
+func Test_rewriteToolResultURIs(t *testing.T) {
+	backend := filterapi.MCPBackendName("backend1")
+
+	t.Run("rewrites ResourceLink URI", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.ResourceLink{URI: "ui://prefab/link.html"},
+			},
+		}
+		require.True(t, rewriteToolResultURIs(result, backend))
+		require.Equal(t, "backend1+ui://prefab/link.html", result.Content[0].(*mcp.ResourceLink).URI)
+	})
+
+	t.Run("rewrites EmbeddedResource URI", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{URI: "ui://prefab/embed.html"}},
+			},
+		}
+		require.True(t, rewriteToolResultURIs(result, backend))
+		require.Equal(t, "backend1+ui://prefab/embed.html", result.Content[0].(*mcp.EmbeddedResource).Resource.URI)
+	})
+
+	t.Run("nil EmbeddedResource.Resource — no panic", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.EmbeddedResource{Resource: nil}},
+		}
+		require.False(t, rewriteToolResultURIs(result, backend))
+	})
+
+	t.Run("rewrites _meta.ui.resourceUri", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			Meta: mcp.Meta{"ui": map[string]any{"resourceUri": "ui://meta/renderer.html"}},
+		}
+		require.True(t, rewriteToolResultURIs(result, backend))
+		require.Equal(t, "backend1+ui://meta/renderer.html",
+			result.Meta["ui"].(map[string]any)["resourceUri"])
+	})
+
+	t.Run("no routable URIs — unchanged, returns false", func(t *testing.T) {
+		result := &mcp.CallToolResult{Content: []mcp.Content{}}
+		require.False(t, rewriteToolResultURIs(result, backend))
+	})
+
+	t.Run("idempotent — second call returns false and leaves URIs unchanged", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			Meta:    mcp.Meta{"ui": map[string]any{"resourceUri": "ui://prefab/idem.html"}},
+			Content: []mcp.Content{&mcp.ResourceLink{URI: "ui://prefab/link.html"}},
+		}
+		require.True(t, rewriteToolResultURIs(result, backend))
+		// Second call: URIs are already namespaced; must not double-namespace.
+		require.False(t, rewriteToolResultURIs(result, backend))
+		require.Equal(t, "backend1+ui://prefab/idem.html",
+			result.Meta["ui"].(map[string]any)["resourceUri"])
+		require.Equal(t, "backend1+ui://prefab/link.html", result.Content[0].(*mcp.ResourceLink).URI)
+	})
+}
+
+func Test_maybeResponseModify(t *testing.T) {
+	ctx := context.Background()
+	m := &mcpRequestContext{ProxyConfig: &ProxyConfig{l: slog.Default()}}
+	backend := filterapi.MCPBackendName("backend1")
+
+	t.Run("tools/call rewrites _meta.ui.resourceUri", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			Meta: mcp.Meta{"ui": map[string]any{"resourceUri": "ui://prefab/renderer.html"}},
+		}
+		raw, err := json.Marshal(result)
+		require.NoError(t, err)
+		req := &jsonrpc.Request{Method: "tools/call"}
+		msg := &jsonrpc.Response{Result: raw}
+		require.NoError(t, m.maybeResponseModify(ctx, req, msg, backend))
+		var got mcp.CallToolResult
+		require.NoError(t, json.Unmarshal(msg.Result, &got))
+		require.Equal(t, "backend1+ui://prefab/renderer.html",
+			got.Meta["ui"].(map[string]any)["resourceUri"])
+	})
+
+	t.Run("tools/call rewrites ResourceLink in Content", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.ResourceLink{URI: "ui://prefab/link.html"}},
+		}
+		raw, err := json.Marshal(result)
+		require.NoError(t, err)
+		req := &jsonrpc.Request{Method: "tools/call"}
+		msg := &jsonrpc.Response{Result: raw}
+		require.NoError(t, m.maybeResponseModify(ctx, req, msg, backend))
+		var got mcp.CallToolResult
+		require.NoError(t, json.Unmarshal(msg.Result, &got))
+		require.Equal(t, "backend1+ui://prefab/link.html", got.Content[0].(*mcp.ResourceLink).URI)
+	})
+
+	t.Run("tools/call with no routable URIs — result bytes unchanged", func(t *testing.T) {
+		result := &mcp.CallToolResult{Content: []mcp.Content{}}
+		raw, err := json.Marshal(result)
+		require.NoError(t, err)
+		before := append([]byte(nil), raw...)
+		req := &jsonrpc.Request{Method: "tools/call"}
+		msg := &jsonrpc.Response{Result: raw}
+		require.NoError(t, m.maybeResponseModify(ctx, req, msg, backend))
+		require.Equal(t, before, []byte(msg.Result))
+	})
+
+	t.Run("resources/read still rewrites Contents URIs", func(t *testing.T) {
+		result := &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{URI: "file:///tmp/file.txt"}},
+		}
+		raw, err := json.Marshal(result)
+		require.NoError(t, err)
+		req := &jsonrpc.Request{Method: "resources/read"}
+		msg := &jsonrpc.Response{Result: raw}
+		require.NoError(t, m.maybeResponseModify(ctx, req, msg, backend))
+		var got mcp.ReadResourceResult
+		require.NoError(t, json.Unmarshal(msg.Result, &got))
+		require.Equal(t, "backend1+file:///tmp/file.txt", got.Contents[0].URI)
+	})
+
+	t.Run("nil Result — no-op", func(t *testing.T) {
+		req := &jsonrpc.Request{Method: "tools/call"}
+		msg := &jsonrpc.Response{Result: nil}
+		require.NoError(t, m.maybeResponseModify(ctx, req, msg, backend))
+		require.Nil(t, msg.Result)
+	})
 }
 
 func TestExtractSubject(t *testing.T) {

--- a/tests/data-plane-mcp/mcp_test.go
+++ b/tests/data-plane-mcp/mcp_test.go
@@ -77,6 +77,9 @@ var tests = []struct {
 	{name: "ListPrompts", testFn: testListPrompts},
 	{name: "CodeReviewPrompts", testFn: testCodeReviewPrompts},
 	{name: "PromptChangeNotifications", testFn: testPromptChangeNotifications},
+	{name: "ToolCallUIResourceURI", testFn: testToolCallUIResourceURI},
+	{name: "ToolCallResourceLink", testFn: testToolCallResourceLink},
+	{name: "ToolCallEmbeddedResource", testFn: testToolCallEmbeddedResource},
 	{name: "ListResources", testFn: testListResources},
 	{name: "ReadResource", testFn: testReadResource},
 	{name: "ReadResourceNotFound", testFn: testReadResourceNotFound},
@@ -211,6 +214,9 @@ func testListTools(t *testing.T, m *mcpEnv) {
 		defaultMCPBackendResourcePrefix + testmcp.ToolNotificationCountsName,
 		defaultMCPBackendResourcePrefix + testmcp.ToolElicitEmail.Tool.Name,
 		defaultMCPBackendResourcePrefix + testmcp.ToolCreateMessage.Tool.Name,
+		defaultMCPBackendResourcePrefix + testmcp.ToolUIResource.Tool.Name,
+		defaultMCPBackendResourcePrefix + testmcp.ToolResourceLink.Tool.Name,
+		defaultMCPBackendResourcePrefix + testmcp.ToolEmbeddedResource.Tool.Name,
 	})
 }
 
@@ -330,7 +336,93 @@ func testToolCallError(t *testing.T, m *mcpEnv) {
 	})
 }
 
-// TestToolCountDown tests a tool that sends progress notifications.
+// testToolCallUIResourceURI verifies the full round-trip for issue #2228:
+// tool result carries _meta.ui.resourceUri → gateway rewrites to <backend>+ui://... →
+// agent reads it back via resources/read without a 400.
+func testToolCallUIResourceURI(t *testing.T, m *mcpEnv) {
+	s := m.newSession(t)
+
+	res, err := s.session.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: defaultMCPBackendResourcePrefix + testmcp.ToolUIResource.Tool.Name,
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	wantURI := defaultMCPBackendResourceURIPrefix + testmcp.UIRendererResource.URI
+	uiMeta, ok := res.Meta["ui"].(map[string]any)
+	require.True(t, ok, "_meta.ui must be a map")
+	require.Equal(t, wantURI, uiMeta["resourceUri"], "_meta.ui.resourceUri must be namespaced")
+	requireToolSpan(t, m.collector.TakeSpan(), defaultMCPBackend, testmcp.ToolUIResource.Tool.Name, false, "")
+
+	// Round-trip: read the resource back using the rewritten URI.
+	readRes, err := s.session.ReadResource(t.Context(), &mcp.ReadResourceParams{URI: wantURI})
+	require.NoError(t, err)
+	require.Len(t, readRes.Contents, 1)
+	require.Equal(t, wantURI, readRes.Contents[0].URI)
+	require.Equal(t, testmcp.UIRendererResource.MIMEType, readRes.Contents[0].MIMEType)
+	requireMCPSpan(t, m.collector.TakeSpan(), "ReadResource", map[string]string{
+		"mcp.method.name":  "resources/read",
+		"mcp.resource.uri": wantURI,
+	})
+}
+
+// testToolCallResourceLink verifies the full round-trip for the ResourceLink surface of #2228.
+func testToolCallResourceLink(t *testing.T, m *mcpEnv) {
+	s := m.newSession(t)
+
+	res, err := s.session.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: defaultMCPBackendResourcePrefix + testmcp.ToolResourceLink.Tool.Name,
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Len(t, res.Content, 1)
+
+	wantURI := defaultMCPBackendResourceURIPrefix + testmcp.UIRendererResource.URI
+	link, ok := res.Content[0].(*mcp.ResourceLink)
+	require.True(t, ok, "Content[0] must be a ResourceLink")
+	require.Equal(t, wantURI, link.URI, "ResourceLink.URI must be namespaced")
+	requireToolSpan(t, m.collector.TakeSpan(), defaultMCPBackend, testmcp.ToolResourceLink.Tool.Name, false, "")
+
+	// Round-trip: read the resource back using the rewritten URI.
+	readRes, err := s.session.ReadResource(t.Context(), &mcp.ReadResourceParams{URI: wantURI})
+	require.NoError(t, err)
+	require.Len(t, readRes.Contents, 1)
+	require.Equal(t, wantURI, readRes.Contents[0].URI)
+	requireMCPSpan(t, m.collector.TakeSpan(), "ReadResource", map[string]string{
+		"mcp.method.name":  "resources/read",
+		"mcp.resource.uri": wantURI,
+	})
+}
+
+// testToolCallEmbeddedResource verifies the full round-trip for the EmbeddedResource surface of #2228.
+func testToolCallEmbeddedResource(t *testing.T, m *mcpEnv) {
+	s := m.newSession(t)
+
+	res, err := s.session.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: defaultMCPBackendResourcePrefix + testmcp.ToolEmbeddedResource.Tool.Name,
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Len(t, res.Content, 1)
+
+	wantURI := defaultMCPBackendResourceURIPrefix + testmcp.UIRendererResource.URI
+	embedded, ok := res.Content[0].(*mcp.EmbeddedResource)
+	require.True(t, ok, "Content[0] must be an EmbeddedResource")
+	require.Equal(t, wantURI, embedded.Resource.URI, "EmbeddedResource.Resource.URI must be namespaced")
+	requireToolSpan(t, m.collector.TakeSpan(), defaultMCPBackend, testmcp.ToolEmbeddedResource.Tool.Name, false, "")
+
+	// Round-trip: read the resource back using the rewritten URI.
+	readRes, err := s.session.ReadResource(t.Context(), &mcp.ReadResourceParams{URI: wantURI})
+	require.NoError(t, err)
+	require.Len(t, readRes.Contents, 1)
+	require.Equal(t, wantURI, readRes.Contents[0].URI)
+	requireMCPSpan(t, m.collector.TakeSpan(), "ReadResource", map[string]string{
+		"mcp.method.name":  "resources/read",
+		"mcp.resource.uri": wantURI,
+	})
+}
+
+// testToolCountDown tests a tool that sends progress notifications.
 //
 // Inside the tool handler, it will send progress notifications every interval
 // until it reaches zero. The test verifies that the notifications are received
@@ -521,10 +613,15 @@ func testListResources(t *testing.T, m *mcpEnv) {
 	s := m.newSession(t)
 	list, err := s.session.ListResources(t.Context(), &mcp.ListResourcesParams{})
 	require.NoError(t, err)
-	require.Len(t, list.Resources, 1)
-	require.Equal(t, defaultMCPBackendResourcePrefix+testmcp.DummyResource.Name, list.Resources[0].Name)
-	require.Equal(t, defaultMCPBackendResourceURIPrefix+testmcp.DummyResource.URI, list.Resources[0].URI)
-	require.Equal(t, testmcp.DummyResource.Description, list.Resources[0].Description)
+	require.Len(t, list.Resources, 2)
+	names := map[string]string{}
+	for _, r := range list.Resources {
+		names[r.Name] = r.URI
+	}
+	require.Equal(t, defaultMCPBackendResourceURIPrefix+testmcp.DummyResource.URI,
+		names[defaultMCPBackendResourcePrefix+testmcp.DummyResource.Name])
+	require.Equal(t, defaultMCPBackendResourceURIPrefix+testmcp.UIRendererResource.URI,
+		names[defaultMCPBackendResourcePrefix+testmcp.UIRendererResource.Name])
 	requireMCPSpan(t, m.collector.TakeSpan(), "ListResources", map[string]string{
 		"mcp.method.name": "resources/list",
 	})
@@ -577,10 +674,17 @@ func testResourceSubscribe(t *testing.T, m *mcpEnv) {
 	s := m.newSession(t)
 	list, err := s.session.ListResources(t.Context(), &mcp.ListResourcesParams{})
 	require.NoError(t, err)
-	require.Len(t, list.Resources, 1)
-	require.Equal(t, defaultMCPBackendResourcePrefix+testmcp.DummyResource.Name, list.Resources[0].Name)
-	require.Equal(t, defaultMCPBackendResourceURIPrefix+testmcp.DummyResource.URI, list.Resources[0].URI)
-	require.Equal(t, testmcp.DummyResource.Description, list.Resources[0].Description)
+	require.Len(t, list.Resources, 2)
+	// Find DummyResource by name — order is not guaranteed.
+	var dummyResourceURI string
+	for _, r := range list.Resources {
+		if r.Name == defaultMCPBackendResourcePrefix+testmcp.DummyResource.Name {
+			require.Equal(t, defaultMCPBackendResourceURIPrefix+testmcp.DummyResource.URI, r.URI)
+			require.Equal(t, testmcp.DummyResource.Description, r.Description)
+			dummyResourceURI = r.URI
+		}
+	}
+	require.NotEmpty(t, dummyResourceURI, "DummyResource not found in list")
 	requireMCPSpan(t, m.collector.TakeSpan(), "ListResources", map[string]string{
 		"mcp.method.name": "resources/list",
 	})
@@ -588,12 +692,12 @@ func testResourceSubscribe(t *testing.T, m *mcpEnv) {
 	// It is important to be able to use the resource URI returned by the List method *as-is*, because this is what real MCP
 	// clients will do.
 	err = s.session.Subscribe(t.Context(), &mcp.SubscribeParams{
-		URI: list.Resources[0].URI,
+		URI: dummyResourceURI,
 	})
 	require.NoError(t, err)
 	requireMCPSpan(t, m.collector.TakeSpan(), "Subscribe", map[string]string{
 		"mcp.method.name":  "resources/subscribe",
-		"mcp.resource.uri": list.Resources[0].URI,
+		"mcp.resource.uri": dummyResourceURI,
 	})
 
 	// Update the resource.
@@ -623,12 +727,12 @@ func testResourceSubscribe(t *testing.T, m *mcpEnv) {
 	require.Equal(t, req.Params.URI, defaultMCPBackendResourceURIPrefix+testmcp.DummyResource.URI)
 
 	err = s.session.Unsubscribe(t.Context(), &mcp.UnsubscribeParams{
-		URI: list.Resources[0].URI,
+		URI: dummyResourceURI,
 	})
 	require.NoError(t, err)
 	requireMCPSpan(t, m.collector.TakeSpan(), "Unsubscribe", map[string]string{
 		"mcp.method.name":  "resources/unsubscribe",
-		"mcp.resource.uri": list.Resources[0].URI,
+		"mcp.resource.uri": dummyResourceURI,
 	})
 	// Wait for the unsubscribe notification.
 	requireEventuallyNotificationCountMessages(t, s, m, "unsubscribe: 1")
@@ -655,7 +759,7 @@ func testResourceListChangeNotifications(t *testing.T, m *mcpEnv) {
 	s := m.newSession(t)
 	list, err := s.session.ListResources(t.Context(), &mcp.ListResourcesParams{})
 	require.NoError(t, err)
-	require.Len(t, list.Resources, 1)
+	require.Len(t, list.Resources, 2)
 	requireMCPSpan(t, m.collector.TakeSpan(), "ListResources", map[string]string{
 		"mcp.method.name": "resources/list",
 	})
@@ -694,7 +798,7 @@ func testResourceListChangeNotifications(t *testing.T, m *mcpEnv) {
 	// Verify the resource was added.
 	list, err = s.session.ListResources(t.Context(), &mcp.ListResourcesParams{})
 	require.NoError(t, err)
-	require.Len(t, list.Resources, 2)
+	require.Len(t, list.Resources, 3)
 	requireMCPSpan(t, m.collector.TakeSpan(), "ListResources", map[string]string{
 		"mcp.method.name": "resources/list",
 	})

--- a/tests/internal/testmcp/resources.go
+++ b/tests/internal/testmcp/resources.go
@@ -24,6 +24,14 @@ var (
 		URI:      "file:///another-dummy.txt",
 	}
 
+	// UIRendererResource is a ui:// resource used to test _meta.ui.resourceUri round-trip
+	// in multiplexing mode (gateway must namespace bare ui:// URIs returned by tool results).
+	UIRendererResource = &mcp.Resource{
+		Name:     "ui-renderer",
+		MIMEType: "text/html",
+		URI:      "ui://prefab/tool/renderer.html",
+	}
+
 	DummyResourceTemplate = &mcp.ResourceTemplate{
 		Name:        "dummy-template",
 		Description: "A dummy resource template for testing",
@@ -38,19 +46,16 @@ func DummyResourceHandler() mcp.ResourceHandler {
 		switch req.Params.URI {
 		case DummyResource.URI:
 			return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{
-				{
-					URI:  req.Params.URI,
-					Blob: []byte("dummy"),
-				},
+				{URI: req.Params.URI, Blob: []byte("dummy")},
 			}}, nil
 		case AnotherDummyResource.URI:
 			return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{
-				{
-					URI:  req.Params.URI,
-					Blob: []byte("another-dummy"),
-				},
+				{URI: req.Params.URI, Blob: []byte("another-dummy")},
 			}}, nil
-
+		case UIRendererResource.URI:
+			return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{
+				{URI: req.Params.URI, MIMEType: "text/html", Blob: []byte("<html>renderer</html>")},
+			}}, nil
 		}
 
 		return nil, mcp.ResourceNotFoundError(req.Params.URI)

--- a/tests/internal/testmcp/server.go
+++ b/tests/internal/testmcp/server.go
@@ -128,6 +128,7 @@ func NewServer(opts *Options) (*http.Server, *mcp.Server) {
 
 	s.AddPrompt(CodeReviewPrompt, codReviewPromptHandler)
 	s.AddResource(DummyResource, DummyResourceHandler())
+	s.AddResource(UIRendererResource, DummyResourceHandler())
 	s.AddResourceTemplate(DummyResourceTemplate, DummyResourceHandler())
 	mcp.AddTool(s, ToolEcho.Tool, ToolEcho.Handler)
 	mcp.AddTool(s, ToolSum.Tool, ToolSum.Handler)
@@ -145,6 +146,9 @@ func NewServer(opts *Options) (*http.Server, *mcp.Server) {
 	mcp.AddTool(s, addOrDeleteResourceTool.Tool, addOrDeleteResourceTool.Handler)
 	notificationsCounts := newToolNotificationCounts(handlerCounts)
 	mcp.AddTool(s, notificationsCounts.Tool, notificationsCounts.Handler)
+	mcp.AddTool(s, ToolUIResource.Tool, ToolUIResource.Handler)
+	mcp.AddTool(s, ToolResourceLink.Tool, ToolResourceLink.Handler)
+	mcp.AddTool(s, ToolEmbeddedResource.Tool, ToolEmbeddedResource.Handler)
 
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		// Check for API key in query param if configured.

--- a/tests/internal/testmcp/tools.go
+++ b/tests/internal/testmcp/tools.go
@@ -426,6 +426,55 @@ var ToolCreateMessage = TestTool[struct{}, any]{
 	},
 }
 
+// ToolUIResource returns a tools/call result carrying _meta.ui.resourceUri — the exact
+// scenario from envoyproxy/ai-gateway#2228. The gateway must rewrite the bare ui:// URI
+// to <backend>+ui:// so the agent can round-trip it via resources/read.
+var ToolUIResource = TestTool[struct{}, any]{
+	Tool: &mcp.Tool{
+		Name:        "ui_resource",
+		Description: "Return a tool result with _meta.ui.resourceUri",
+		InputSchema: &jsonschema.Schema{Type: "object", Properties: map[string]*jsonschema.Schema{}},
+	},
+	Handler: func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Meta:    mcp.Meta{"ui": map[string]any{"resourceUri": UIRendererResource.URI}},
+			Content: []mcp.Content{&mcp.TextContent{Text: "rendered"}},
+		}, nil, nil
+	},
+}
+
+// ToolResourceLink returns a tools/call result carrying a ResourceLink — covers the
+// Content[] surface of the same #2228 fix.
+var ToolResourceLink = TestTool[struct{}, any]{
+	Tool: &mcp.Tool{
+		Name:        "resource_link",
+		Description: "Return a tool result with a ResourceLink in Content",
+		InputSchema: &jsonschema.Schema{Type: "object", Properties: map[string]*jsonschema.Schema{}},
+	},
+	Handler: func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.ResourceLink{URI: UIRendererResource.URI, Name: UIRendererResource.Name}},
+		}, nil, nil
+	},
+}
+
+// ToolEmbeddedResource returns a tools/call result carrying an EmbeddedResource — covers the
+// third Content[] surface of the same #2228 fix.
+var ToolEmbeddedResource = TestTool[struct{}, any]{
+	Tool: &mcp.Tool{
+		Name:        "embedded_resource",
+		Description: "Return a tool result with an EmbeddedResource in Content",
+		InputSchema: &jsonschema.Schema{Type: "object", Properties: map[string]*jsonschema.Schema{}},
+	},
+	Handler: func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{URI: UIRendererResource.URI, MIMEType: UIRendererResource.MIMEType},
+			}},
+		}, nil, nil
+	},
+}
+
 type notificationCounts struct {
 	RootsListChanged,
 	Subscribe,


### PR DESCRIPTION
**Description**
In MCP multiplexing mode, `tools/call` results carrying `_meta.ui.resourceUri` (or `ResourceLink`/`EmbeddedResource` URIs in `Content[]`) passed through the gateway bare. The agent then called `resources/read` with the unnamespaced URI, `upstreamResourceURI` found no `+` separator, and the gateway returned HTTP 400.

The fix extends `maybeResponseModify` to handle `tools/call` in addition to the existing `resources/read` case. It adds two helpers — `rewriteMetaResourceURIs` (walks a declarative path table, includes an idempotency guard) and `rewriteToolResultURIs` (covers `_meta`, `ResourceLink`, and `EmbeddedResource` surfaces) — and applies the same rewrite to tool descriptors in `mergeToolsList`. The inverse path (`upstreamResourceURI` on the `resources/read` request) already worked correctly and required no change.

Unit tests cover all three rewrite surfaces, the idempotency guard, nil/wrong-type no-op cases, and a regression guard for `resources/read`. Three new data-plane round-trip tests prove the 400 is gone end-to-end for each surface.

Fixes #2228

> This PR was developed with AI assistance (Claude Code).