### PR TITLE
fix: cache token double counting at message_start

### DIFF
--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -971,13 +971,6 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 		if input, ok := usage.InputTokens(); ok {
 			p.tokenUsage.SetInputTokens(input)
 		}
-		if cached, ok := usage.CachedInputTokens(); ok {
-			p.tokenUsage.SetCachedInputTokens(cached)
-		}
-		if cacheCreation, ok := usage.CacheCreationInputTokens(); ok {
-			p.tokenUsage.SetCacheCreationInputTokens(cacheCreation)
-		}
-
 		// reset the toolIndex for each message
 		p.toolIndex = -1
 		return nil, nil

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -1157,3 +1157,35 @@ func TestBuildAnthropicParamsWithReasoningEffort(t *testing.T) {
 		require.Equal(t, anthropic.OutputConfigEffort(""), params.OutputConfig.Effort)
 	})
 }
+
+// TestAnthropicStreamParser_CacheTokensNotSetFromMessageStart verifies that cache tokens are not
+// written during message_start processing. Before the fix, message_start called SetCachedInputTokens
+// and SetCacheCreationInputTokens; if message_delta then called AddCachedInputTokens with the same
+// values, both would be counted, doubling the result.
+func TestAnthropicStreamParser_CacheTokensNotSetFromMessageStart(t *testing.T) {
+	p := newAnthropicStreamParser("claude-3-5-sonnet")
+
+	// Simulate message_start with cache tokens.
+	messageStart := []byte(`{"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"cache_read_input_tokens":5,"cache_creation_input_tokens":2,"output_tokens":0}}}`)
+	_, err := p.handleAnthropicStreamEvent([]byte("message_start"), messageStart)
+	require.NoError(t, err)
+
+	// Cache tokens must NOT be set after message_start; only input tokens are set.
+	_, cachedSet := p.tokenUsage.CachedInputTokens()
+	require.False(t, cachedSet, "cache_read tokens must not be set from message_start")
+	_, cacheCreationSet := p.tokenUsage.CacheCreationInputTokens()
+	require.False(t, cacheCreationSet, "cache_creation tokens must not be set from message_start")
+
+	// Simulate message_delta carrying the authoritative cache and output counts.
+	messageDelta := []byte(`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":8,"cache_read_input_tokens":5,"cache_creation_input_tokens":2}}`)
+	_, err = p.handleAnthropicStreamEvent([]byte("message_delta"), messageDelta)
+	require.NoError(t, err)
+
+	cachedTokens, cachedSet := p.tokenUsage.CachedInputTokens()
+	require.True(t, cachedSet)
+	require.Equal(t, uint32(5), cachedTokens, "cache_read tokens must not be double-counted")
+
+	cacheCreationTokens, cacheCreationSet := p.tokenUsage.CacheCreationInputTokens()
+	require.True(t, cacheCreationSet)
+	require.Equal(t, uint32(2), cacheCreationTokens, "cache_creation tokens must not be double-counted")
+}


### PR DESCRIPTION
**Description**
The Anthropic streaming protocol reports cache tokens (cache_read_input_tokens, cache_creation_input_tokens) in two events:
  - message_start — contains the initial usage snapshot
  - message_delta — contains the final/authoritative totals

Previously, the **message_start** handler set both input tokens and cache tokens from the initial event. The **message_delta** handler then accumulated cache tokens on top, resulting in double counting — cache tokens were applied once from message_start and again from message_delta.

This fix removes the cache token writes from the message_start handler, deferring all cache token accounting to message_delta where the authoritative values are available. Input tokens are still initialized from message_start as before.


** Detailed Example **
**message_start**
`time=2026-06-16T18:37:53.012Z level=DEBUG msg="response body processing"  is_upstream_filter=false request="response_body:{body:\"event: message_start\\ndata: {\\\"type\\\":\\\"message_start\\\",\\\"message\\\":{\\\"model\\\":\\\"claude-sonnet-4-20250514\\\",\\\"id\\\":\\\"<request_id>\\\",\\\"type\\\":\\\"message\\\",\\\"role\\\":\\\"assistant\\\",\\\"content\\\":[],\\\"stop_reason\\\":null,\\\"stop_sequence\\\":null,\\\"stop_details\\\":null,\\\"usage\\\":{\\\"input_tokens\\\":317,\\\"cache_creation_input_tokens\\\":4425,\\\"cache_read_input_tokens\\\":0,\\\"cache_creation\\\":{\\\"ephemeral_5m_input_tokens\\\":4425,\\\"ephemeral_1h_input_tokens\\\":0},\\\"output_tokens\\\":1}}        }\\n\\n\"}  metadata_context:{}"`

input_tokens: 317
cache_creation_input_tokens: 4425
cache_read_input_tokens: 0
output_token: 1

**message_delta**
`time=2026-06-16T18:37:57.878Z level=DEBUG msg="response body processing" is_upstream_filter=false request="response_body:{body:\"event: message_delta\\ndata: {\\\"type\\\":\\\"message_delta\\\",\\\"delta\\\":{\\\"stop_reason\\\":\\\"end_turn\\\",\\\"stop_sequence\\\":null,\\\"stop_details\\\":null},\\\"usage\\\":{\\\"input_tokens\\\":317,\\\"cache_creation_input_tokens\\\":4425,\\\"cache_read_input_tokens\\\":0,\\\"output_tokens\\\":274}              }\\n\\n\"}  metadata_context:{}"`

input_tokens: 317
cache_creation_input_tokens: 4425 
cache_read_input_tokens: 0
output_tokens: 274

**response body processed**

`time=2026-06-16T18:37:57.884Z level=DEBUG msg="response body processed" is_upstream_filter=false response="response_body:{response:{header_mutation:{}  body_mutation:{body:\"data: {\\\"id\\\":\\\"<request_id>\\\",\\\"choices\\\":[],\\\"created\\\":1781635073,\\\"model\\\":\\\"claude-sonnet-4@20250514\\\",\\\"object\\\":\\\"chat.completion.chunk\\\",\\\"usage\\\":{\\\"prompt_tokens\\\":9167,\\\"completion_tokens\\\":274,\\\"total_tokens\\\":9441,\\\"prompt_tokens_details\\\":{\\\"cache_creation_input_tokens\\\":8850}}}\\n\\ndata: [DONE]\\n\\n\"}}}  dynamic_metadata:{fields:{key:\"io.envoy.ai_gateway\"  value:{struct_value:{fields:{key:\"ai_service_backend_name\"  value:{string_value:\"gateway/<placeholder>\"}}  fields:{key:\"backend_name\"  value:{string_value:\"gateway/<placeholder>/route/claude-sonnet-4/rule/0/ref/2\"}}  fields:{key:\"cacheCreationInputTokenUsage\"  value:{number_value:8850}}  fields:{key:\"cachedInputTokenUsage\"  value:{number_value:0}}  fields:{key:\"inputTokenUsage\"  value:{number_value:9167}}  fields:{key:\"model_name_override\"  value:{string_value:\"claude-sonnet-4@20250514\"}}  fields:{key:\"outputTokenUsage\"  value:{number_value:274}}  fields:{key:\"response_model\"  value:{string_value:\"claude-sonnet-4@20250514\"}}  fields:{key:\"route_name\"  value:{string_value:\"gateway/claude-sonnet-4\"}}  <OMITTED>}}}}}"`

prompt_tokens = 9167
completion_tokens = 274
total_tokens = 9441
prompt_detail -> cache_creation_input_tokens: 8850 <-------------------- 2x of cache_creation_input_tokens: 4425 

