### PR TITLE
feat: add topologySpreadConstraints and PodDisruptionBudget to helm chart

### DIFF
--- a/manifests/charts/ai-gateway-helm/templates/deployment.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/deployment.yaml
@@ -173,3 +173,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/manifests/charts/ai-gateway-helm/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+{{- if .Values.controller.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ai-gateway-helm.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ai-gateway-helm.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.controller.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.controller.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ai-gateway-helm.controller.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -241,6 +241,26 @@ controller:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Topology spread constraints for the controller pods.
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  # Example:
+  # topologySpreadConstraints:
+  #   - maxSkew: 1
+  #     topologyKey: topology.kubernetes.io/zone
+  #     whenUnsatisfiable: ScheduleAnyway
+  #     labelSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: ai-gateway-helm
+  topologySpreadConstraints: []
+
+  # PodDisruptionBudget for the controller pods, protecting them from voluntary
+  # disruptions such as node drains. Only meaningful when replicaCount > 1.
+  # If maxUnavailable is set, it takes precedence over minAvailable.
+  # See: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
 
   # maxRecvMsgSize is the maximum message size in bytes that the gRPC extension server can receive
   # from xDS (envoy-gateway).


### PR DESCRIPTION
**Description**

This commit adds two availability-related knobs to the controller Deployment in the ai-gateway-helm chart:

- `controller.topologySpreadConstraints`: passed through verbatim to the pod spec, allowing controller replicas to be spread evenly across zones or nodes. Defaults to an empty list, so rendered output is unchanged for existing users.
- `controller.podDisruptionBudget`: an optional PodDisruptionBudget protecting the controller from voluntary disruptions such as node drains. Disabled by default; supports `minAvailable` (default 1) or `maxUnavailable`, with `maxUnavailable` taking precedence when both are set so users can switch without nulling the default.

Without a PDB, a node drain can evict all controller replicas at once; leader election protects consistency but not availability, and while no replica is running the mutating webhook is unavailable. Topology spread constraints complement the existing `nodeSelector`/`affinity`/`tolerations` passthroughs with `maxSkew`-based zone spreading, which pod anti-affinity cannot express.

Verified with `make helm-test`, plus `helm template` renders with both features enabled, with `maxUnavailable` set, and with default values (no diff in default output).

**Related Issues/PRs (if applicable)**

n/a

**Special notes for reviewers (if applicable)**

Both features only affect the controller Deployment; data-plane (Envoy proxy) scheduling remains configurable via Envoy Gateway's `EnvoyProxy` resource.

🤖 Generated with Claude Code [1], session at [2]

1: https://claude.com/claude-code
2: https://claude.ai/code/session_012tknKnthzw4n8QEkL1f1xX