### PR TITLE
docs: clarify QuotaPolicy and token-based rate limiting

### DIFF
--- a/site/docs/capabilities/traffic/quota-policy.md
+++ b/site/docs/capabilities/traffic/quota-policy.md
@@ -9,11 +9,10 @@ sidebar_position: 6
 `QuotaPolicy` enables token-based quota management for AI inference services in Envoy AI Gateway.
 When all related backend's quota are exceeded, requests are rejected with a `429 Too Many Requests` status code.
 
-:::note QuotaPolicy vs. Rate Limiting
-QuotaPolicy manages **total consumption budgets** (for example, 100,000 tokens per hour). This is
-distinct from [usage-based rate limiting](./usage-based-ratelimiting.md), which controls **request
-velocity** (for example, requests per second). Use QuotaPolicy when you need to cap cumulative token
-spend across a time window.
+:::note QuotaPolicy vs. token-based rate limiting
+Both `QuotaPolicy` and [usage-based rate limiting](./usage-based-ratelimiting.md) can cap cumulative
+token usage over a time window. The difference is the API and scope used to configure that budget,
+not whether tokens or requests are counted. See [Choosing a policy](#choosing-a-policy) for details.
 :::
 
 ## Overview
@@ -25,6 +24,30 @@ Key features of QuotaPolicy:
   computing how much a request burns down a quota.
 - **Client-selector bucket rules** — carve out per-tenant or per-header quotas using request attributes.
 - **Shadow mode** — evaluate quota rules without enforcing them, for safe rollout.
+
+## Choosing a Policy
+
+`QuotaPolicy` and usage-based rate limiting use the same rate limit infrastructure, and both reject
+requests with `429 Too Many Requests` when the applicable token budget is exhausted. Choose between
+them based on where and how you want to express the policy:
+
+| | `QuotaPolicy` | Usage-based rate limiting |
+| --- | --- | --- |
+| Configuration | One AI Gateway policy containing the token cost and quota buckets | `llmRequestCosts` on an `AIGatewayRoute`, plus an Envoy Gateway `BackendTrafficPolicy` |
+| Scope | Models served by one or more `AIServiceBackend` resources | Envoy Gateway rate limit rules and their client selectors |
+| Token accounting | One default or custom CEL cost per model | Multiple metadata keys can track and limit input, output, total, or custom token costs separately |
+| Client budgets | Default and header-selected buckets, with optional shadow mode | Envoy Gateway client selectors and rate limit rules |
+| Time windows | Exactly one second, minute, hour, or day | One second, minute, hour, day, month, or year |
+
+Use `QuotaPolicy` when the budget belongs naturally to a backend and model. For example, a platform
+team can give every tenant a separate daily budget for an expensive model, keep a shared backend
+budget as a fallback, and evaluate a new tenant rule in shadow mode. The policy stays with the
+`AIServiceBackend` even when multiple routes send traffic to it.
+
+Use usage-based rate limiting when you need lower-level Envoy Gateway controls, route-specific token
+cost metadata, separate limits for input and output tokens, or a monthly or yearly window. It is also
+the natural choice when token budgets need to be managed alongside existing Envoy Gateway rate limit
+rules.
 
 ## How It Works
 
@@ -259,6 +282,11 @@ The `duration` field selects the sliding-window size. It must be exactly one of 
 
 The window is fixed-size — arbitrary multiples such as `"30s"` or `"15m"` are **not** valid and will
 be rejected by the CRD schema. Choose the `limit` to express your budget within one of these windows.
+
+The one-day maximum is a current `QuotaPolicy` API restriction, not an inherent limitation of token
+accounting. Token-based rate limiting configured through an Envoy Gateway `BackendTrafficPolicy`
+also supports `Month` and `Year` units. Use [usage-based rate limiting](./usage-based-ratelimiting.md)
+when a token budget needs either of those longer windows.
 
 ## Service-Wide Quota
 

--- a/site/docs/capabilities/traffic/quota-policy.md
+++ b/site/docs/capabilities/traffic/quota-policy.md
@@ -9,10 +9,13 @@ sidebar_position: 6
 `QuotaPolicy` enables token-based quota management for AI inference services in Envoy AI Gateway.
 When all related backend's quota are exceeded, requests are rejected with a `429 Too Many Requests` status code.
 
-:::note QuotaPolicy vs. token-based rate limiting
-Both `QuotaPolicy` and [usage-based rate limiting](./usage-based-ratelimiting.md) can cap cumulative
-token usage over a time window. The difference is the API and scope used to configure that budget,
-not whether tokens or requests are counted. See [Choosing a policy](#choosing-a-policy) for details.
+:::note QuotaPolicy vs. usage-based rate limiting
+`QuotaPolicy` manages the platform's upstream consumption budget: how many tokens the gateway may
+spend against a provider backend and model across all routes and consumers. [Usage-based rate
+limiting](./usage-based-ratelimiting.md) manages consumer usage: how much a client may consume on a
+route. Both can count tokens and return `429 Too Many Requests`, but they answer different questions:
+whether the platform has exhausted its budget for a provider/model, or whether a client has exceeded
+its allowance. See [Choosing a policy](#choosing-a-policy) for details.
 :::
 
 ## Overview
@@ -27,27 +30,27 @@ Key features of QuotaPolicy:
 
 ## Choosing a Policy
 
-`QuotaPolicy` and usage-based rate limiting use the same rate limit infrastructure, and both reject
-requests with `429 Too Many Requests` when the applicable token budget is exhausted. Choose between
-them based on where and how you want to express the policy:
+Both policies use Envoy's rate limit protocol and Redis-backed counters, but `QuotaPolicy` is enforced
+by a dedicated AI Gateway rate limit service. Usage-based rate limiting uses Envoy Gateway's global
+rate limit service. Choose between them based on the budget's intent and scope:
 
 | | `QuotaPolicy` | Usage-based rate limiting |
 | --- | --- | --- |
 | Configuration | One AI Gateway policy containing the token cost and quota buckets | `llmRequestCosts` on an `AIGatewayRoute`, plus an Envoy Gateway `BackendTrafficPolicy` |
-| Scope | Models served by one or more `AIServiceBackend` resources | Envoy Gateway rate limit rules and their client selectors |
+| Scope | Backend- and model-scoped - the budget follows an `AIServiceBackend` across every route that sends traffic to it | Route/Gateway-scoped - budgets are keyed by client descriptors on a route |
 | Token accounting | One default or custom CEL cost per model | Multiple metadata keys can track and limit input, output, total, or custom token costs separately |
 | Client budgets | Default and header-selected buckets, with optional shadow mode | Envoy Gateway client selectors and rate limit rules |
+| Enforcement | In `Shared` mode, a request is denied only when all applicable quota buckets are exhausted; the quota is evaluated for the selected backend | A request is denied when any matched rate limit is exceeded; limits are evaluated from the route's client descriptors |
 | Time windows | Exactly one second, minute, hour, or day | One second, minute, hour, day, month, or year |
 
-Use `QuotaPolicy` when the budget belongs naturally to a backend and model. For example, a platform
-team can give every tenant a separate daily budget for an expensive model, keep a shared backend
-budget as a fallback, and evaluate a new tenant rule in shadow mode. The policy stays with the
-`AIServiceBackend` even when multiple routes send traffic to it.
+Use `QuotaPolicy` when the platform needs to protect its provider budget for a backend and model.
+For example, a platform team can give every tenant a separate daily budget for an expensive model,
+set a shared backend budget alongside those tenant budgets, and evaluate a new tenant rule in shadow
+mode. The policy stays with the `AIServiceBackend` even when multiple routes send traffic to it.
 
-Use usage-based rate limiting when you need lower-level Envoy Gateway controls, route-specific token
-cost metadata, separate limits for input and output tokens, or a monthly or yearly window. It is also
-the natural choice when token budgets need to be managed alongside existing Envoy Gateway rate limit
-rules.
+Use usage-based rate limiting when you need to define each client's allowance on a route. It is also
+the natural choice when you need lower-level Envoy Gateway controls, route-specific token cost
+metadata, separate limits for input and output tokens, or a monthly or yearly window.
 
 ## How It Works
 

--- a/site/docs/capabilities/traffic/quota-policy.md
+++ b/site/docs/capabilities/traffic/quota-policy.md
@@ -34,14 +34,14 @@ Both policies use Envoy's rate limit protocol and Redis-backed counters, but `Qu
 by a dedicated AI Gateway rate limit service. Usage-based rate limiting uses Envoy Gateway's global
 rate limit service. Choose between them based on the budget's intent and scope:
 
-| | `QuotaPolicy` | Usage-based rate limiting |
-| --- | --- | --- |
-| Configuration | One AI Gateway policy containing the token cost and quota buckets | `llmRequestCosts` on an `AIGatewayRoute`, plus an Envoy Gateway `BackendTrafficPolicy` |
-| Scope | Backend- and model-scoped - the budget follows an `AIServiceBackend` across every route that sends traffic to it | Route/Gateway-scoped - budgets are keyed by client descriptors on a route |
-| Token accounting | One default or custom CEL cost per model | Multiple metadata keys can track and limit input, output, total, or custom token costs separately |
-| Client budgets | Default and header-selected buckets, with optional shadow mode | Envoy Gateway client selectors and rate limit rules |
-| Enforcement | In `Shared` mode, a request is denied only when all applicable quota buckets are exhausted; the quota is evaluated for the selected backend | A request is denied when any matched rate limit is exceeded; limits are evaluated from the route's client descriptors |
-| Time windows | Exactly one second, minute, hour, or day | One second, minute, hour, day, month, or year |
+|                  | `QuotaPolicy`                                                                                                                               | Usage-based rate limiting                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Configuration    | One AI Gateway policy containing the token cost and quota buckets                                                                           | `llmRequestCosts` on an `AIGatewayRoute`, plus an Envoy Gateway `BackendTrafficPolicy`                                |
+| Scope            | Backend- and model-scoped - the budget follows an `AIServiceBackend` across every route that sends traffic to it                            | Route/Gateway-scoped - budgets are keyed by client descriptors on a route                                             |
+| Token accounting | One default or custom CEL cost per model                                                                                                    | Multiple metadata keys can track and limit input, output, total, or custom token costs separately                     |
+| Client budgets   | Default and header-selected buckets, with optional shadow mode                                                                              | Envoy Gateway client selectors and rate limit rules                                                                   |
+| Enforcement      | In `Shared` mode, a request is denied only when all applicable quota buckets are exhausted; the quota is evaluated for the selected backend | A request is denied when any matched rate limit is exceeded; limits are evaluated from the route's client descriptors |
+| Time windows     | Exactly one second, minute, hour, or day                                                                                                    | One second, minute, hour, day, month, or year                                                                         |
 
 Use `QuotaPolicy` when the platform needs to protect its provider budget for a backend and model.
 For example, a platform team can give every tenant a separate daily budget for an expensive model,

--- a/site/docs/capabilities/traffic/quota-policy.md
+++ b/site/docs/capabilities/traffic/quota-policy.md
@@ -62,12 +62,24 @@ metadata, separate limits for input and output tokens, or a monthly or yearly wi
 4. When all related quota buckets for that model are exceeded, subsequent matching requests receive `429 Too Many Requests`.
 
 :::tip Prerequisites
-Quota enforcement uses the same infrastructure as usage-based rate limiting:
+Quota enforcement requires two components that are not deployed by the AI Gateway Helm chart today:
 
-1. **Redis Deployment**: A Redis instance for storing quota counters. See the [redis.yaml example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/redis.yaml) for a simple deployment.
-2. **Envoy Gateway Configuration**: Envoy Gateway must be configured at installation time to enable rate limiting and point to your Redis instance. See the [Envoy Gateway Installation Guide](../../getting-started/prerequisites.md#additional-features-rate-limiting-inferencepool-etc).
+1. **Redis** stores quota counters. See the
+   [redis.yaml example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/redis.yaml)
+   for a simple deployment.
+2. **A dedicated rate limit service** evaluates the `ai-gateway-quota` domain. It must use the AI
+   Gateway controller's xDS server for configuration, with node ID `envoy-ai-gateway-ratelimit`, and
+   listen at the controller's `quotaRateLimitServiceAddr`. The
+   [quota E2E manifest](https://github.com/envoyproxy/ai-gateway/blob/main/tests/e2e/testdata/backend_quota_ratelimit.yaml)
+   provides a deployment example; Helm support is tracked in
+   [#2214](https://github.com/envoyproxy/ai-gateway/pull/2214).
 
-See [Usage-based Rate Limiting](./usage-based-ratelimiting.md) for more detail on the rate limit infrastructure that QuotaPolicy builds on.
+Envoy Gateway's rate-limit addon is a separate service used by usage-based rate limiting. It is not
+required for a QuotaPolicy-only deployment, although both services can use the same Redis instance.
+
+By default, `controller.quotaRateLimitFailureModeDeny` is `false`. If the dedicated service is absent
+or unreachable, quota checks fail open and requests continue without enforcement. Set it to `true`
+if unavailable quota enforcement should reject requests instead.
 :::
 
 ## Configuration

--- a/site/docs/capabilities/traffic/usage-based-ratelimiting.md
+++ b/site/docs/capabilities/traffic/usage-based-ratelimiting.md
@@ -9,8 +9,11 @@ import TabItem from '@theme/TabItem';
 
 This guide focuses on AI Gateway's specific capabilities for token-based rate limiting in LLM requests. For general rate limiting concepts and configurations, refer to [Envoy Gateway's Rate Limiting documentation](https://gateway.envoyproxy.io/docs/tasks/traffic/global-rate-limit/).
 
-:::info Quota Policy vs. Rate Limiting
-AI Gateway also provides [Quota Policy](./quota-policy.md) for managing **total consumption budgets** (for example, 100,000 tokens per hour). Use QuotaPolicy when you need to cap cumulative token spend, and usage-based rate limiting (this page) when you need to control **request velocity**.
+:::info Quota Policy vs. token-based rate limiting
+Both this feature and [Quota Policy](./quota-policy.md#choosing-a-policy) can cap cumulative token
+usage over a time window. Use `QuotaPolicy` for backend- and model-scoped quota buckets in a single
+AI Gateway policy. Use usage-based rate limiting when you need lower-level Envoy Gateway rules,
+route-specific token cost metadata, separate limits by token type, or monthly and yearly windows.
 :::
 
 ## Overview

--- a/site/docs/capabilities/traffic/usage-based-ratelimiting.md
+++ b/site/docs/capabilities/traffic/usage-based-ratelimiting.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 
 This guide focuses on AI Gateway's specific capabilities for token-based rate limiting in LLM requests. For general rate limiting concepts and configurations, refer to [Envoy Gateway's Rate Limiting documentation](https://gateway.envoyproxy.io/docs/tasks/traffic/global-rate-limit/).
 
-:::info Quota Policy vs. token-based rate limiting
-Both this feature and [Quota Policy](./quota-policy.md#choosing-a-policy) can cap cumulative token
-usage over a time window. Use `QuotaPolicy` for backend- and model-scoped quota buckets in a single
-AI Gateway policy. Use usage-based rate limiting when you need lower-level Envoy Gateway rules,
-route-specific token cost metadata, separate limits by token type, or monthly and yearly windows.
+:::info Quota Policy vs. usage-based rate limiting
+`QuotaPolicy` manages the platform's upstream consumption budget for a provider backend and model
+across all routes and consumers. Usage-based rate limiting (this page) manages each client's allowance
+on a route. Both can count tokens and return `429 Too Many Requests`. See [Choosing a policy](./quota-policy.md#choosing-a-policy)
+for a comparison of enforcement behavior, scope, and time windows.
 :::
 
 ## Overview


### PR DESCRIPTION
**Description**

- explain the intent split between the platform's upstream provider/model budget and each client's route allowance
- compare configuration, scope, token accounting, client budgets, enforcement semantics, and time windows
- document the dedicated AI Gateway quota rate limit service, Redis dependency, and fail-open default
- clarify the current one-day `QuotaPolicy` limit and the longer windows available through usage-based rate limiting
- keep the cross-reference in the usage-based rate limiting guide consistent

## Why

The existing comparison incorrectly described usage-based rate limiting as request velocity even though it can charge response token metadata against cumulative limits. Both features can count tokens and return 429, but they answer different operational questions and enforce matched limits differently.

The updated guide frames `QuotaPolicy` as a platform budget attached to an `AIServiceBackend`, and usage-based rate limiting as a consumer allowance attached to route traffic.

## User impact

Users can choose the policy that matches who owns the budget, where it applies, how multiple matched limits are enforced, and which time windows are required. Operators also get explicit deployment and failure-mode prerequisites for quota enforcement.

## Validation

- `git diff --check`
- `npm ci`
- `npm run build`
- repository precommit checks on Ubuntu and macOS

## AI assistance

This documentation update was prepared with OpenAI Codex assistance. The statements were checked against the `QuotaPolicy` API and implementation in this repository and the Envoy Gateway API version used by the project.

Fixes #2340