### PR TITLE
fix(translator): preserve Anthropic web search tools

### DIFF
--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1227,6 +1227,7 @@ const (
 	ToolTypeImageGeneration     ToolType = "image_generation"
 	ToolTypeEnterpriseWebSearch ToolType = "enterprise_search"
 	ToolTypeGoogleSearch        ToolType = "google_search"
+	ToolTypeAnthropicWebSearch  ToolType = "web_search_20260209"
 )
 
 // GCPGoogleSearchConfig contains GCP-specific configuration for Google Search grounding.
@@ -1245,6 +1246,7 @@ type GCPTimeRangeFilter struct {
 
 type Tool struct {
 	Type         ToolType               `json:"type"`
+	Name         string                 `json:"name,omitempty"`
 	Function     *FunctionDefinition    `json:"function,omitempty"`
 	GoogleSearch *GCPGoogleSearchConfig `json:"google_search,omitempty"` //nolint:tagliatelle
 }

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -1227,6 +1227,24 @@ func TestChatCompletionRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "Anthropic web search tool",
+			jsonStr: `{
+				"model": "claude-sonnet-4-6",
+				"messages": [{"role": "user", "content": "Search for the weather"}],
+				"tools": [{"type": "web_search_20260209", "name": "web_search"}]
+			}`,
+			expected: &ChatCompletionRequest{
+				Model: "claude-sonnet-4-6",
+				Messages: []ChatCompletionMessageParamUnion{{
+					OfUser: &ChatCompletionUserMessageParam{
+						Role:    ChatMessageRoleUser,
+						Content: StringOrUserRoleContentUnion{Value: "Search for the weather"},
+					},
+				}},
+				Tools: []Tool{{Type: ToolTypeAnthropicWebSearch, Name: "web_search"}},
+			},
+		},
+		{
 			name: "enterprise search tool",
 			jsonStr: `{
 				"model": "gemini-1.5-pro",

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -168,8 +168,18 @@ func translateOpenAItoAnthropicTools(openAITools []openai.Tool, openAIToolChoice
 	if len(openAITools) > 0 {
 		anthropicTools := make([]anthropic.ToolUnionParam, 0, len(openAITools))
 		for _, openAITool := range openAITools {
+			if openAITool.Type == openai.ToolTypeAnthropicWebSearch {
+				anthropicTools = append(anthropicTools, anthropic.ToolUnionParam{
+					OfWebSearchTool20260209: &anthropic.WebSearchTool20260209Param{
+						Name: constant.WebSearch(openAITool.Name),
+						Type: constant.WebSearch20260209(openAITool.Type),
+					},
+				})
+				continue
+			}
+
 			if openAITool.Type != openai.ToolTypeFunction || openAITool.Function == nil {
-				// Anthropic only supports 'function' tools, so we skip others.
+				// Anthropic only supports function tools and its built-in web search tool.
 				continue
 			}
 			toolParam := anthropic.ToolParam{
@@ -193,9 +203,9 @@ func translateOpenAItoAnthropicTools(openAITools []openai.Tool, openAIToolChoice
 			}
 
 			anthropicTools = append(anthropicTools, anthropic.ToolUnionParam{OfTool: &toolParam})
-			if len(anthropicTools) > 0 {
-				tools = anthropicTools
-			}
+		}
+		if len(anthropicTools) > 0 {
+			tools = anthropicTools
 		}
 
 		// 2. Handle the tool_choice parameter.

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -169,6 +169,16 @@ func translateOpenAItoAnthropicTools(openAITools []openai.Tool, openAIToolChoice
 	if len(openAITools) > 0 {
 		anthropicTools := make([]anthropic.ToolUnionParam, 0, len(openAITools))
 		for _, openAITool := range openAITools {
+			if openAITool.Type == openai.ToolTypeAnthropicWebSearch {
+				anthropicTools = append(anthropicTools, anthropic.ToolUnionParam{
+					OfWebSearchTool20260209: &anthropic.WebSearchTool20260209Param{
+						Name: constant.WebSearch(openAITool.Name),
+						Type: constant.WebSearch20260209(openAITool.Type),
+					},
+				})
+				continue
+			}
+
 			if openAITool.Type != openai.ToolTypeFunction {
 				err = fmt.Errorf("%w: unsupported tool type: %s", internalapi.ErrInvalidRequestBody, openAITool.Type)
 				return
@@ -198,9 +208,9 @@ func translateOpenAItoAnthropicTools(openAITools []openai.Tool, openAIToolChoice
 			}
 
 			anthropicTools = append(anthropicTools, anthropic.ToolUnionParam{OfTool: &toolParam})
-			if len(anthropicTools) > 0 {
-				tools = anthropicTools
-			}
+		}
+		if len(anthropicTools) > 0 {
+			tools = anthropicTools
 		}
 
 		// 2. Handle the tool_choice parameter.

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -292,6 +292,21 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "maps Anthropic web search tool",
+			openAIReq: &openai.ChatCompletionRequest{
+				Tools: []openai.Tool{{
+					Type: openai.ToolTypeAnthropicWebSearch,
+					Name: "web_search",
+				}},
+			},
+			expectedTools: []anthropic.ToolUnionParam{{
+				OfWebSearchTool20260209: &anthropic.WebSearchTool20260209Param{
+					Name: constant.WebSearch("web_search"),
+					Type: constant.WebSearch20260209("web_search_20260209"),
+				},
+			}},
+		},
+		{
 			name: "tool definition without type field",
 			openAIReq: &openai.ChatCompletionRequest{
 				Tools: []openai.Tool{
@@ -463,11 +478,11 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 					require.Equal(t, tt.expectedTools[0].GetName(), tools[0].GetName())
 					require.Equal(t, tt.expectedTools[0].GetType(), tools[0].GetType())
 					require.Equal(t, tt.expectedTools[0].GetDescription(), tools[0].GetDescription())
-					if tt.expectedTools[0].GetInputSchema().Properties != nil {
-						require.Equal(t, tt.expectedTools[0].GetInputSchema().Properties, tools[0].GetInputSchema().Properties)
+					if inputSchema := tt.expectedTools[0].GetInputSchema(); inputSchema != nil && inputSchema.Properties != nil {
+						require.Equal(t, inputSchema.Properties, tools[0].GetInputSchema().Properties)
 					}
-					if tt.expectedTools[0].GetInputSchema().ExtraFields != nil {
-						require.Equal(t, tt.expectedTools[0].GetInputSchema().ExtraFields, tools[0].GetInputSchema().ExtraFields)
+					if inputSchema := tt.expectedTools[0].GetInputSchema(); inputSchema != nil && inputSchema.ExtraFields != nil {
+						require.Equal(t, inputSchema.ExtraFields, tools[0].GetInputSchema().ExtraFields)
 					}
 				}
 			}

--- a/internal/translator/anthropic_helper_test.go
+++ b/internal/translator/anthropic_helper_test.go
@@ -277,6 +277,21 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "maps Anthropic web search tool",
+			openAIReq: &openai.ChatCompletionRequest{
+				Tools: []openai.Tool{{
+					Type: openai.ToolTypeAnthropicWebSearch,
+					Name: "web_search",
+				}},
+			},
+			expectedTools: []anthropic.ToolUnionParam{{
+				OfWebSearchTool20260209: &anthropic.WebSearchTool20260209Param{
+					Name: constant.WebSearch("web_search"),
+					Type: constant.WebSearch20260209("web_search_20260209"),
+				},
+			}},
+		},
+		{
 			name: "tool definition without type field",
 			openAIReq: &openai.ChatCompletionRequest{
 				Tools: []openai.Tool{
@@ -448,11 +463,11 @@ func TestTranslateOpenAItoAnthropicTools(t *testing.T) {
 					require.Equal(t, tt.expectedTools[0].GetName(), tools[0].GetName())
 					require.Equal(t, tt.expectedTools[0].GetType(), tools[0].GetType())
 					require.Equal(t, tt.expectedTools[0].GetDescription(), tools[0].GetDescription())
-					if tt.expectedTools[0].GetInputSchema().Properties != nil {
-						require.Equal(t, tt.expectedTools[0].GetInputSchema().Properties, tools[0].GetInputSchema().Properties)
+					if inputSchema := tt.expectedTools[0].GetInputSchema(); inputSchema != nil && inputSchema.Properties != nil {
+						require.Equal(t, inputSchema.Properties, tools[0].GetInputSchema().Properties)
 					}
-					if tt.expectedTools[0].GetInputSchema().ExtraFields != nil {
-						require.Equal(t, tt.expectedTools[0].GetInputSchema().ExtraFields, tools[0].GetInputSchema().ExtraFields)
+					if inputSchema := tt.expectedTools[0].GetInputSchema(); inputSchema != nil && inputSchema.ExtraFields != nil {
+						require.Equal(t, inputSchema.ExtraFields, tools[0].GetInputSchema().ExtraFields)
 					}
 				}
 			}


### PR DESCRIPTION
**Description**
Preserve Anthropic's `web_search_20260209` tool when an OpenAI-compatible chat-completions request is routed to an Anthropic backend. The translator now retains the tool name and maps it to Anthropic's built-in web search parameter instead of silently dropping it.

Fixes #2124

**Testing**
- go test ./internal/apischema/openai ./internal/translator ./internal/extproc -count=1