### PR TITLE
feat: allow excluding models from /v1/models

### DIFF
--- a/api/v1alpha1/ai_gateway_route.go
+++ b/api/v1alpha1/ai_gateway_route.go
@@ -306,6 +306,16 @@ type AIGatewayRouteRule struct {
 	// +optional
 	// +kubebuilder:validation:Format=date-time
 	ModelsCreatedAt *metav1.Time `json:"modelsCreatedAt,omitempty"`
+
+	// ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the
+	// OpenAI-compatible "/models" endpoint. Requests still match this rule and apply its
+	// configured transformations, including model name overrides.
+	//
+	// This is useful for internal or backwards-compatible aliases, as well as duplicate model
+	// definitions with different schemas.
+	//
+	// +optional
+	ExcludeFromModelsEndpoint bool `json:"excludeFromModelsEndpoint,omitempty"`
 }
 
 // AIGatewayRouteRuleBackendRef is a reference to a backend with a weight.

--- a/api/v1beta1/ai_gateway_route.go
+++ b/api/v1beta1/ai_gateway_route.go
@@ -306,6 +306,16 @@ type AIGatewayRouteRule struct {
 	// +optional
 	// +kubebuilder:validation:Format=date-time
 	ModelsCreatedAt *metav1.Time `json:"modelsCreatedAt,omitempty"`
+
+	// ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the
+	// OpenAI-compatible "/models" endpoint. Requests still match this rule and apply its
+	// configured transformations, including model name overrides.
+	//
+	// This is useful for internal or backwards-compatible aliases, as well as duplicate model
+	// definitions with different schemas.
+	//
+	// +optional
+	ExcludeFromModelsEndpoint bool `json:"excludeFromModelsEndpoint,omitempty"`
 }
 
 // AIGatewayRouteRuleBackendRef is a reference to a backend with a weight.

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -391,6 +391,10 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 		injectedQuotaCosts := make(map[string]struct{})
 		for ruleIndex := range spec.Rules {
 			rule := &spec.Rules[ruleIndex]
+			if rule.ExcludeFromModelsEndpoint {
+				continue
+			}
+
 			for _, m := range rule.Matches {
 				for _, h := range m.Headers {
 					// If explicitly set to something that is not an exact match, skip.
@@ -421,6 +425,11 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 					}
 				}
 			}
+		}
+		// Second pass: backends are collected for every rule, including rules excluded from
+		// /v1/models — those rules still route traffic and need their backends in the config.
+		for ruleIndex := range spec.Rules {
+			rule := &spec.Rules[ruleIndex]
 			for backendRefIndex := range rule.BackendRefs {
 				backendRef := &rule.BackendRefs[backendRefIndex]
 				b := filterapi.Backend{}

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -418,6 +418,10 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 		injectedQuotaCosts := make(map[string]struct{})
 		for ruleIndex := range spec.Rules {
 			rule := &spec.Rules[ruleIndex]
+			if rule.ExcludeFromModelsEndpoint {
+				continue
+			}
+
 			for _, m := range rule.Matches {
 				for _, h := range m.Headers {
 					// If explicitly set to something that is not an exact match, skip.
@@ -448,6 +452,11 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 					}
 				}
 			}
+		}
+		// Second pass: backends are collected for every rule, including rules excluded from
+		// /v1/models — those rules still route traffic and need their backends in the config.
+		for ruleIndex := range spec.Rules {
+			rule := &spec.Rules[ruleIndex]
 			for backendRefIndex := range rule.BackendRefs {
 				backendRef := &rule.BackendRefs[backendRefIndex]
 				b := filterapi.Backend{}

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -429,6 +429,23 @@ func TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels(t *t
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "hidden-alias-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Hostnames: []gwapiv1.Hostname{"api.example.com"},
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs:               []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}},
+						ExcludeFromModelsEndpoint: true,
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "hidden-alias"},
+							}},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, b := range []*aigv1b1.AIServiceBackend{
 		{
@@ -472,6 +489,14 @@ func TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels(t *t
 		gotHostModels = append(gotHostModels, m.Name)
 	}
 	require.ElementsMatch(t, []string{"scoped-model", "unscoped-model"}, gotHostModels)
+
+	// The hidden alias must keep its backend config so requests can still be routed.
+	hiddenAliasBackendName := internalapi.PerRouteRuleRefBackendName(gwNamespace, "apple", "hidden-alias-route", 0, 0)
+	backendNames := make([]string, 0, len(fc.Backends))
+	for _, backend := range fc.Backends {
+		backendNames = append(backendNames, backend.Name)
+	}
+	require.Contains(t, backendNames, hiddenAliasBackendName)
 }
 
 // TestGatewayController_reconcileFilterConfigSecret_AllUnscopedRoutesLeaveUnscopedModelsEmpty

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -547,6 +547,23 @@ func TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels(t *t
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "hidden-alias-route", Namespace: gwNamespace},
+			Spec: aigv1b1.AIGatewayRouteSpec{
+				Hostnames: []gwapiv1.Hostname{"api.example.com"},
+				Rules: []aigv1b1.AIGatewayRouteRule{
+					{
+						BackendRefs:               []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}},
+						ExcludeFromModelsEndpoint: true,
+						Matches: []aigv1b1.AIGatewayRouteRuleMatch{
+							{Headers: []gwapiv1.HTTPHeaderMatch{
+								{Name: internalapi.ModelNameHeaderKeyDefault, Value: "hidden-alias"},
+							}},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, b := range []*aigv1b1.AIServiceBackend{
 		{
@@ -590,6 +607,14 @@ func TestGatewayController_reconcileFilterConfigSecret_HostnameScopedModels(t *t
 		gotHostModels = append(gotHostModels, m.Name)
 	}
 	require.ElementsMatch(t, []string{"scoped-model", "unscoped-model"}, gotHostModels)
+
+	// The hidden alias must keep its backend config so requests can still be routed.
+	hiddenAliasBackendName := internalapi.PerRouteRuleRefBackendName(gwNamespace, "apple", "hidden-alias-route", 0, 0)
+	backendNames := make([]string, 0, len(fc.Backends))
+	for _, backend := range fc.Backends {
+		backendNames = append(backendNames, backend.Name)
+	}
+	require.Contains(t, backendNames, hiddenAliasBackendName)
 }
 
 // TestGatewayController_reconcileFilterConfigSecret_AllUnscopedRoutesLeaveUnscopedModelsEmpty

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aigatewayroutes.yaml
@@ -666,6 +666,15 @@ spec:
                             && self.kind == ''InferencePool'')'
                       maxItems: 128
                       type: array
+                    excludeFromModelsEndpoint:
+                      description: |-
+                        ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the
+                        OpenAI-compatible "/models" endpoint. Requests still match this rule and apply its
+                        configured transformations, including model name overrides.
+
+                        This is useful for internal or backwards-compatible aliases, as well as duplicate model
+                        definitions with different schemas.
+                      type: boolean
                     matches:
                       description: |-
                         Matches is the list of AIGatewayRouteMatch that this rule will match the traffic to.
@@ -1595,6 +1604,15 @@ spec:
                             && self.kind == ''InferencePool'')'
                       maxItems: 128
                       type: array
+                    excludeFromModelsEndpoint:
+                      description: |-
+                        ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the
+                        OpenAI-compatible "/models" endpoint. Requests still match this rule and apply its
+                        configured transformations, including model name overrides.
+
+                        This is useful for internal or backwards-compatible aliases, as well as duplicate model
+                        definitions with different schemas.
+                      type: boolean
                     matches:
                       description: |-
                         Matches is the list of AIGatewayRouteMatch that this rule will match the traffic to.

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -669,6 +669,11 @@ AIGatewayRouteRule is a rule that defines the routing behavior of the AIGatewayR
   type="[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)"
   required="false"
   description="ModelsCreatedAt represents the creation timestamp of the running models serving by the backends,<br />which will be exported as the field of `Created` in openai-compatible API `/models`.<br />It follows the format of RFC 3339, for example `2024-05-21T10:00:00Z`.<br />This is used only when this rule contains `x-ai-eg-model` in its header matching<br />where the header value will be recognized as a `model` in `/models` endpoint.<br />All the matched models will share the same creation time.<br />Default to the creation timestamp of the AIGatewayRoute if not set."
+/><ApiField
+  name="excludeFromModelsEndpoint"
+  type="boolean"
+  required="false"
+  description="ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the<br />OpenAI-compatible `/models` endpoint. Requests still match this rule and apply its<br />configured transformations, including model name overrides.<br />This is useful for internal or backwards-compatible aliases, as well as duplicate model<br />definitions with different schemas."
 />
 
 
@@ -3097,6 +3102,11 @@ AIGatewayRouteRule is a rule that defines the routing behavior of the AIGatewayR
   type="[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)"
   required="false"
   description="ModelsCreatedAt represents the creation timestamp of the running models serving by the backends,<br />which will be exported as the field of `Created` in openai-compatible API `/models`.<br />It follows the format of RFC 3339, for example `2024-05-21T10:00:00Z`.<br />This is used only when this rule contains `x-ai-eg-model` in its header matching<br />where the header value will be recognized as a `model` in `/models` endpoint.<br />All the matched models will share the same creation time.<br />Default to the creation timestamp of the AIGatewayRoute if not set."
+/><ApiField
+  name="excludeFromModelsEndpoint"
+  type="boolean"
+  required="false"
+  description="ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the<br />OpenAI-compatible `/models` endpoint. Requests still match this rule and apply its<br />configured transformations, including model name overrides.<br />This is useful for internal or backwards-compatible aliases, as well as duplicate model<br />definitions with different schemas."
 />
 
 

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -672,6 +672,11 @@ AIGatewayRouteRule is a rule that defines the routing behavior of the AIGatewayR
   type="[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)"
   required="false"
   description="ModelsCreatedAt represents the creation timestamp of the running models serving by the backends,<br />which will be exported as the field of `Created` in openai-compatible API `/models`.<br />It follows the format of RFC 3339, for example `2024-05-21T10:00:00Z`.<br />This is used only when this rule contains `x-ai-eg-model` in its header matching<br />where the header value will be recognized as a `model` in `/models` endpoint.<br />All the matched models will share the same creation time.<br />Default to the creation timestamp of the AIGatewayRoute if not set."
+/><ApiField
+  name="excludeFromModelsEndpoint"
+  type="boolean"
+  required="false"
+  description="ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the<br />OpenAI-compatible `/models` endpoint. Requests still match this rule and apply its<br />configured transformations, including model name overrides.<br />This is useful for internal or backwards-compatible aliases, as well as duplicate model<br />definitions with different schemas."
 />
 
 
@@ -3195,6 +3200,11 @@ AIGatewayRouteRule is a rule that defines the routing behavior of the AIGatewayR
   type="[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)"
   required="false"
   description="ModelsCreatedAt represents the creation timestamp of the running models serving by the backends,<br />which will be exported as the field of `Created` in openai-compatible API `/models`.<br />It follows the format of RFC 3339, for example `2024-05-21T10:00:00Z`.<br />This is used only when this rule contains `x-ai-eg-model` in its header matching<br />where the header value will be recognized as a `model` in `/models` endpoint.<br />All the matched models will share the same creation time.<br />Default to the creation timestamp of the AIGatewayRoute if not set."
+/><ApiField
+  name="excludeFromModelsEndpoint"
+  type="boolean"
+  required="false"
+  description="ExcludeFromModelsEndpoint prevents models matched by this rule from being returned by the<br />OpenAI-compatible `/models` endpoint. Requests still match this rule and apply its<br />configured transformations, including model name overrides.<br />This is useful for internal or backwards-compatible aliases, as well as duplicate model<br />definitions with different schemas."
 />
 
 


### PR DESCRIPTION
**Description**

Adds `excludeFromModelsEndpoint` to `AIGatewayRoute` rules.

Models matched by a rule with this option remain routeable and support `modelNameOverride`, but are excluded from the OpenAI-compatible `/v1/models` response. This supports backwards-compatible aliases and aliases only intended for selected clients.

**Related Issues/PRs (if applicable)**

Fixes #2445

**Special notes for reviewers (if applicable)**

Tested manually.

⚒️ with ❤️ by @siemens