### PR TITLE
fix: add tokenize tracer

### DIFF
--- a/internal/tracing/openinference/openai/tokenize.go
+++ b/internal/tracing/openinference/openai/tokenize.go
@@ -85,9 +85,9 @@ func (r *TokenizeRecorder) RecordResponse(span trace.Span, resp *tokenize.Respon
 func buildTokenizeRequestAttributes(req *tokenize.RequestUnion, body string, config *openinference.TraceConfig) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
-	// Set span kind to LLM since tokenization is an LLM operation
+	// Set span kind to token counter since tokenization is a token counting operation
 	attrs = append(attrs,
-		attribute.String(openinference.SpanKind, openinference.SpanKindLLM),
+		attribute.String(openinference.SpanKind, openinference.SpanKindTokenCounter),
 		attribute.String(openinference.LLMSystem, openinference.LLMSystemOpenAI),
 	)
 

--- a/internal/tracing/openinference/openai/tokenize_test.go
+++ b/internal/tracing/openinference/openai/tokenize_test.go
@@ -145,7 +145,7 @@ func TestTokenizeRecorder_RecordRequest(t *testing.T) {
 				HideOutputs: false,
 			},
 			expectedAttrs: map[string]interface{}{
-				openinference.SpanKind:            openinference.SpanKindLLM,
+				openinference.SpanKind:            openinference.SpanKindTokenCounter,
 				openinference.LLMSystem:           openinference.LLMSystemOpenAI,
 				openinference.LLMModelName:        "gpt-4",
 				openinference.InputValue:          `{"model":"gpt-4","messages":[...]}`,
@@ -175,7 +175,7 @@ func TestTokenizeRecorder_RecordRequest(t *testing.T) {
 				HideOutputs: false,
 			},
 			expectedAttrs: map[string]interface{}{
-				openinference.SpanKind:        openinference.SpanKindLLM,
+				openinference.SpanKind:        openinference.SpanKindTokenCounter,
 				openinference.LLMSystem:       openinference.LLMSystemOpenAI,
 				openinference.LLMModelName:    "gpt-3.5-turbo",
 				openinference.InputValue:      `{"model":"gpt-3.5-turbo","prompt":"Complete this"}`,
@@ -207,7 +207,7 @@ func TestTokenizeRecorder_RecordRequest(t *testing.T) {
 				HideOutputs: false,
 			},
 			expectedAttrs: map[string]interface{}{
-				openinference.SpanKind:     openinference.SpanKindLLM,
+				openinference.SpanKind:     openinference.SpanKindTokenCounter,
 				openinference.LLMSystem:    openinference.LLMSystemOpenAI,
 				openinference.LLMModelName: "gpt-4",
 				"tokenize.request_type":    "chat",

--- a/internal/tracing/openinference/openinference.go
+++ b/internal/tracing/openinference/openinference.go
@@ -22,6 +22,9 @@ const (
 
 	// SpanKindEmbedding indicates an Embedding operation.
 	SpanKindEmbedding = "EMBEDDING"
+
+	// SpanKindTokenCounter indicates a token counting operation (e.g., tokenize, count_tokens).
+	SpanKindTokenCounter = "TOKEN_COUNTER"
 )
 
 // LLM Operation constants.

--- a/internal/tracing/openinference/openinference.go
+++ b/internal/tracing/openinference/openinference.go
@@ -23,7 +23,7 @@ const (
 	// SpanKindEmbedding indicates an Embedding operation.
 	SpanKindEmbedding = "EMBEDDING"
 
-	// SpanKindTokenCounter indicates a token counting operation.
+	// SpanKindTokenCounter indicates a token counting operation (e.g., tokenize, count_tokens).
 	SpanKindTokenCounter = "TOKEN_COUNTER"
 )
 

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -15,6 +15,7 @@ import (
 
 	cohereschema "github.com/envoyproxy/ai-gateway/internal/apischema/cohere"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai/tokenize"
 	"github.com/envoyproxy/ai-gateway/internal/tracing/tracingapi"
 )
 
@@ -40,6 +41,7 @@ var (
 	_ tracingapi.TranscriptionTracer   = (*transcriptionTracer)(nil)
 	_ tracingapi.TranslationTracer     = (*translationTracer)(nil)
 	_ tracingapi.RerankTracer          = (*rerankTracer)(nil)
+	_ tracingapi.TokenizeTracer        = (*tokenizeTracer)(nil)
 )
 
 type (
@@ -52,6 +54,7 @@ type (
 	transcriptionTracer   = requestTracerImpl[openai.TranscriptionRequest, openai.TranscriptionResponse, openai.TranscriptionStreamEvent]
 	translationTracer     = requestTracerImpl[openai.TranslationRequest, openai.TranslationResponse, struct{}]
 	rerankTracer          = requestTracerImpl[cohereschema.RerankV2Request, cohereschema.RerankV2Response, struct{}]
+	tokenizeTracer        = requestTracerImpl[tokenize.RequestUnion, tokenize.Response, struct{}]
 )
 
 func newRequestTracer[ReqT any, RespT any, RespChunkT any](

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -16,6 +16,7 @@ import (
 	anthropicschema "github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"
 	cohereschema "github.com/envoyproxy/ai-gateway/internal/apischema/cohere"
 	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai/tokenize"
 	"github.com/envoyproxy/ai-gateway/internal/tracing/tracingapi"
 )
 
@@ -43,6 +44,7 @@ var (
 	_ tracingapi.RerankTracer               = (*rerankTracer)(nil)
 	_ tracingapi.ResponsesInputTokensTracer = (*responsesInputTokensTracer)(nil)
 	_ tracingapi.CountTokensTracer          = (*countTokensTracer)(nil)
+	_ tracingapi.TokenizeTracer             = (*tokenizeTracer)(nil)
 )
 
 type (
@@ -57,6 +59,7 @@ type (
 	rerankTracer               = requestTracerImpl[cohereschema.RerankV2Request, cohereschema.RerankV2Response, struct{}]
 	responsesInputTokensTracer = requestTracerImpl[openai.ResponseRequest, openai.ResponsesInputTokensResponse, struct{}]
 	countTokensTracer          = requestTracerImpl[anthropicschema.CountTokensRequest, anthropicschema.CountTokensResponse, struct{}]
+	tokenizeTracer             = requestTracerImpl[tokenize.RequestUnion, tokenize.Response, struct{}]
 )
 
 func newRequestTracer[ReqT any, RespT any, RespChunkT any](


### PR DESCRIPTION
**Description**
@aabchoo identified that we missed the tracer for `/tokenize` endpooint in:  https://github.com/envoyproxy/ai-gateway/pull/2078#discussion_r3633528910, this is just to add the tracer separatly.