### PR TITLE
feat: add MCP resource URI to access log metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/tools v0.46.0
@@ -260,7 +261,6 @@ require (
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/internal/extensionserver/mcproute.go
+++ b/internal/extensionserver/mcproute.go
@@ -7,6 +7,8 @@ package extensionserver
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	egextension "github.com/envoyproxy/gateway/proto/extension"
@@ -99,13 +101,17 @@ func (s *Server) createBackendListener(mcpHTTPFilters []*httpconnectionmanagerv3
 	// Here we configure the header-to-metadata filter to extract those headers, populate the filter metadata, and clean
 	// the headers up from the request before sending it upstream.
 	headersToMetadata := &htomv3.Config{}
-	for h, m := range internalapi.MCPInternalHeadersToMetadata {
+	// Sorted, because ranging a map emits the rules in a different order every time. That changes the
+	// serialized listener, which bumps the xDS version and makes Envoy replace and drain this listener
+	// on every translation, even when no MCP config changed. buildHeaderToMetadataFilter sorts for the
+	// same reason.
+	for _, h := range slices.Sorted(maps.Keys(internalapi.MCPInternalHeadersToMetadata)) {
 		headersToMetadata.RequestRules = append(headersToMetadata.RequestRules,
 			&htomv3.Config_Rule{
 				Header: h,
 				OnHeaderPresent: &htomv3.Config_KeyValuePair{
 					MetadataNamespace: aigv1b1.AIGatewayFilterMetadataNamespace,
-					Key:               m,
+					Key:               internalapi.MCPInternalHeadersToMetadata[h],
 					Type:              htomv3.Config_STRING,
 				},
 				// If the header was an internal MCP header, we remove it before sending the request upstream.

--- a/internal/extensionserver/mcproute_test.go
+++ b/internal/extensionserver/mcproute_test.go
@@ -15,6 +15,7 @@ import (
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	htomv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	httpconnectionmanagerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/go-logr/logr/testr"
@@ -583,5 +584,49 @@ func TestServer_maybeGenerateResourcesForMCPGateway(t *testing.T) {
 				tt.check(t, tt.req)
 			}
 		})
+	}
+}
+
+// TestServer_createBackendListener_headerToMetadataRules pins the header_to_metadata rules the MCP
+// backend listener is built with: a stable order, and Remove set only for the internal metadata
+// headers that must not reach the upstream MCP server.
+func TestServer_createBackendListener_headerToMetadataRules(t *testing.T) {
+	s := &Server{log: testr.New(t)}
+
+	type rule struct {
+		header string
+		key    string
+		remove bool
+	}
+	rulesOf := func(t *testing.T) []rule {
+		t.Helper()
+		listener, err := s.createBackendListener(nil, nil)
+		require.NoError(t, err)
+		hcm, _, err := findHCM(listener.FilterChains[0])
+		require.NoError(t, err)
+		i, filter := findHeaderToMetadataFilter(hcm.HttpFilters)
+		require.NotEqual(t, -1, i)
+		cfg := &htomv3.Config{}
+		require.NoError(t, filter.GetTypedConfig().UnmarshalTo(cfg))
+		rules := make([]rule, 0, len(cfg.RequestRules))
+		for _, r := range cfg.RequestRules {
+			rules = append(rules, rule{r.GetHeader(), r.GetOnHeaderPresent().GetKey(), r.GetRemove()})
+		}
+		return rules
+	}
+
+	got := rulesOf(t)
+	require.Equal(t, []rule{
+		{"x-ai-eg-mcp-backend", "mcp_backend", false},
+		{"x-ai-eg-mcp-metadata-method", "mcp_method", true},
+		{"x-ai-eg-mcp-metadata-request-id", "mcp_request_id", true},
+		{"x-ai-eg-mcp-metadata-resource-uri", "mcp_resource_uri", true},
+		{"x-ai-eg-mcp-metadata-tool-name", "mcp_tool_name", true},
+	}, got)
+
+	// Ranging a map is randomized per-iteration, so an unsorted build would differ across calls. An
+	// unstable order changes the serialized listener and makes Envoy drain it on every translation.
+	for range 20 {
+		require.Equal(t, got, rulesOf(t))
 	}
 }

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -59,14 +59,22 @@ const (
 	MCPMetadataHeaderMethod = MCPMetadataHeaderPrefix + "method"
 	// MCPMetadataHeaderToolName is the special header key used to pass the MCP tool name in the filter metadata.
 	MCPMetadataHeaderToolName = MCPMetadataHeaderPrefix + "tool-name"
+	// MCPMetadataHeaderResourceURI is the special header key used to pass the MCP resource URI in the filter metadata.
+	MCPMetadataHeaderResourceURI = MCPMetadataHeaderPrefix + "resource-uri"
 )
 
 // MCPInternalHeadersToMetadata maps special MCP headers to metadata keys.
+//
+// Only headers that do not survive to the router belong here. Headers the MCP proxy sets and leaves
+// on the request - mcp-session-id, x-ai-eg-mcp-route - are already readable from an access log with
+// %REQ(...)%, on both the MCP proxy listener and the backend listener, so mapping them would only add
+// a second name for the same value.
 var MCPInternalHeadersToMetadata = map[string]string{
-	MCPBackendHeader:           "mcp_backend",
-	MCPMetadataHeaderMethod:    "mcp_method",
-	MCPMetadataHeaderRequestID: "mcp_request_id",
-	MCPMetadataHeaderToolName:  "mcp_tool_name",
+	MCPBackendHeader:             "mcp_backend",
+	MCPMetadataHeaderMethod:      "mcp_method",
+	MCPMetadataHeaderRequestID:   "mcp_request_id",
+	MCPMetadataHeaderToolName:    "mcp_tool_name",
+	MCPMetadataHeaderResourceURI: "mcp_resource_uri",
 }
 
 const (

--- a/internal/mcpproxy/handlers.go
+++ b/internal/mcpproxy/handlers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/net/http/httpguts"
 
 	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
@@ -1479,15 +1480,43 @@ func addMCPHeaders(httpReq *http.Request, msg jsonrpc.Message, params mcp.Params
 	httpReq.Header.Set(internalapi.MCPRouteHeader, routeName)
 	if mcpReq, ok := msg.(*jsonrpc.Request); ok && mcpReq != nil {
 		// MCP request headers are used to populate information in the envoy filter metadata.
-		httpReq.Header.Set(internalapi.MCPMetadataHeaderRequestID, fmt.Sprintf("%v", mcpReq.ID.Raw()))
-		httpReq.Header.Set(internalapi.MCPMetadataHeaderMethod, mcpReq.Method)
+		setMCPMetadataHeader(httpReq, internalapi.MCPMetadataHeaderRequestID, fmt.Sprintf("%v", mcpReq.ID.Raw()))
+		setMCPMetadataHeader(httpReq, internalapi.MCPMetadataHeaderMethod, mcpReq.Method)
 
 		if params != nil {
-			if p, ok := params.(*mcp.CallToolParams); ok {
-				httpReq.Header.Set(internalapi.MCPMetadataHeaderToolName, p.Name)
+			// Mirrors the span attributes set in getMCPParamsAsAttributes, so the same information is
+			// available in the access logs as well as in the traces.
+			switch p := params.(type) {
+			case *mcp.CallToolParams:
+				setMCPMetadataHeader(httpReq, internalapi.MCPMetadataHeaderToolName, p.Name)
+			case *mcp.ReadResourceParams:
+				setMCPMetadataHeader(httpReq, internalapi.MCPMetadataHeaderResourceURI, p.URI)
+			case *mcp.SubscribeParams:
+				setMCPMetadataHeader(httpReq, internalapi.MCPMetadataHeaderResourceURI, p.URI)
+			case *mcp.UnsubscribeParams:
+				setMCPMetadataHeader(httpReq, internalapi.MCPMetadataHeaderResourceURI, p.URI)
 			}
 		}
 	}
+}
+
+// maxMCPMetadataHeaderValueLen bounds a metadata header value. Resource URIs, tool names and JSON-RPC
+// IDs all come from the client unvalidated, and these headers exist only so the access log can see
+// them, so dropping an outsized value beats pushing the request over Envoy's max_request_headers_kb.
+const maxMCPMetadataHeaderValueLen = 1024
+
+// setMCPMetadataHeader sets an observability-only metadata header, skipping values that would make the
+// request unsendable. [http.Transport] rejects header values containing control characters, so a
+// resource URI or JSON-RPC ID holding one - trivially expressible as a JSON escape - would otherwise
+// fail the whole proxied request, rather than reaching the backend in the body where it is legal.
+//
+// Dropped rather than truncated or escaped: an absent log field is honest, a mangled one is not.
+func setMCPMetadataHeader(httpReq *http.Request, key, value string) {
+	// httpguts is the same check [http.Transport] applies, so this cannot drift from what it rejects.
+	if len(value) > maxMCPMetadataHeaderValueLen || !httpguts.ValidHeaderFieldValue(value) {
+		return
+	}
+	httpReq.Header.Set(key, value)
 }
 
 type (

--- a/internal/mcpproxy/handlers_test.go
+++ b/internal/mcpproxy/handlers_test.go
@@ -675,7 +675,16 @@ func TestServePOST_ToolsCallRequest(t *testing.T) {
 				require.Equal(t, tt.wantBackend, r.Header.Get(internalapi.MCPBackendHeader))
 				require.Equal(t, "tools/call", r.Header.Get(internalapi.MCPMetadataHeaderMethod))
 				require.Equal(t, tt.tool, r.Header.Get(internalapi.MCPMetadataHeaderRequestID))
-				for h := range internalapi.MCPInternalHeadersToMetadata {
+				// The headers a tools/call populates. Resource-scoped headers are asserted in the
+				// resources/read and resources/subscribe tests instead, since a tools/call leaves them unset.
+				for _, h := range []string{
+					internalapi.MCPBackendHeader,
+					internalapi.MCPRouteHeader,
+					sessionIDHeader,
+					internalapi.MCPMetadataHeaderMethod,
+					internalapi.MCPMetadataHeaderRequestID,
+					internalapi.MCPMetadataHeaderToolName,
+				} {
 					require.NotEmpty(t, r.Header.Get(h))
 				}
 
@@ -1708,6 +1717,10 @@ func TestMCPPRoxy_handleResourceReadRequest(t *testing.T) {
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "backend1", r.Header.Get(internalapi.MCPBackendHeader))
+		// The URI has already been rewritten from the client-facing composite form to the upstream one
+		// by this point, so that is what the metadata header carries. Same as mcp_tool_name, which
+		// records the tool name after the backend prefix is stripped.
+		require.Equal(t, "file://foo-resource", r.Header.Get(internalapi.MCPMetadataHeaderResourceURI))
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Contains(t, string(body), `"uri":"file://foo-resource"`)
@@ -2081,10 +2094,12 @@ func TestMCPServer_handleResourcesSubscriptionRequest(t *testing.T) {
 					var params mcp.SubscribeParams
 					require.NoError(t, json.Unmarshal(req.Params, &params))
 					require.Equal(t, "file://foo", params.URI)
+					require.Equal(t, "file://foo", r.Header.Get(internalapi.MCPMetadataHeaderResourceURI))
 				case *mcp.UnsubscribeParams:
 					var params mcp.UnsubscribeParams
 					require.NoError(t, json.Unmarshal(req.Params, &params))
 					require.Equal(t, "file://bar", params.URI)
+					require.Equal(t, "file://bar", r.Header.Get(internalapi.MCPMetadataHeaderResourceURI))
 				default:
 					t.Fatalf("unexpected params type: %T", tc.p)
 				}
@@ -2395,6 +2410,79 @@ func Test_checkToolCallError(t *testing.T) {
 				require.Equal(t, tt.backendName, toolErr.backend)
 			} else {
 				require.Nil(t, toolErr)
+			}
+		})
+	}
+}
+
+func TestAddMCPHeaders_MetadataValueGuard(t *testing.T) {
+	longURI := "file://" + strings.Repeat("a", maxMCPMetadataHeaderValueLen)
+
+	tests := []struct {
+		name    string
+		id      string
+		uri     string
+		wantID  string
+		wantURI string
+	}{
+		{
+			name:    "plain values are set",
+			id:      "req-1",
+			uri:     "file://config.yaml",
+			wantID:  "req-1",
+			wantURI: "file://config.yaml",
+		},
+		{
+			name:    "non-ascii is allowed, http.Transport accepts it",
+			id:      "req-2",
+			uri:     "file://café/résumé.txt",
+			wantID:  "req-2",
+			wantURI: "file://café/résumé.txt",
+		},
+		{
+			name:    "control characters are dropped, not forwarded",
+			id:      "req-3",
+			uri:     "file://a\nb",
+			wantID:  "req-3",
+			wantURI: "",
+		},
+		{
+			name:    "a control character in the JSON-RPC ID drops only that header",
+			id:      "req\r\n4",
+			uri:     "file://config.yaml",
+			wantID:  "",
+			wantURI: "file://config.yaml",
+		},
+		{
+			name:    "oversized values are dropped rather than truncated",
+			id:      "req-5",
+			uri:     longURI,
+			wantID:  "req-5",
+			wantURI: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "http://backend", nil)
+			require.NoError(t, err)
+			id, err := jsonrpc.MakeID(tt.id)
+			require.NoError(t, err)
+			addMCPHeaders(req,
+				&jsonrpc.Request{ID: id, Method: "resources/read"},
+				&mcp.ReadResourceParams{URI: tt.uri},
+				"route1", "backend1")
+
+			require.Equal(t, tt.wantID, req.Header.Get(internalapi.MCPMetadataHeaderRequestID))
+			require.Equal(t, tt.wantURI, req.Header.Get(internalapi.MCPMetadataHeaderResourceURI))
+			// Whatever was dropped, the request must still be sendable: the headers exist only for
+			// access logging, so they must never be what makes a proxied call fail.
+			require.NoError(t, req.Header.Write(io.Discard))
+			for _, vs := range req.Header {
+				for _, v := range vs {
+					require.NotContains(t, v, "\n")
+					require.NotContains(t, v, "\r")
+				}
 			}
 		})
 	}

--- a/tests/data-plane-mcp/envoy.yaml
+++ b/tests/data-plane-mcp/envoy.yaml
@@ -32,6 +32,7 @@ static_resources:
                           mcp.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
                           mcp.method.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
                           mcp.tool.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_tool_name)%"
+                          mcp.resource.uri: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_resource_uri)%"
                           jsonrpc.request.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_request_id)%"
                           method: "%REQ(:METHOD)%"
                           request.path: "%REQ(:PATH)%"
@@ -103,6 +104,7 @@ static_resources:
                           mcp.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
                           mcp.method.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
                           mcp.tool.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_tool_name)%"
+                          mcp.resource.uri: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_resource_uri)%"
                           jsonrpc.request.id: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_request_id)%"
                           method: "%REQ(:METHOD)%"
                           request.path: "%REQ(:PATH)%"
@@ -209,6 +211,12 @@ static_resources:
                           on_header_present:
                             metadata_namespace: io.envoy.ai_gateway
                             key: mcp_request_id
+                            type: STRING
+                          remove: true
+                        - header: x-ai-eg-mcp-metadata-resource-uri
+                          on_header_present:
+                            metadata_namespace: io.envoy.ai_gateway
+                            key: mcp_resource_uri
                             type: STRING
                           remove: true
                         - header: agent-session-id

--- a/tests/data-plane-mcp/mcp_test.go
+++ b/tests/data-plane-mcp/mcp_test.go
@@ -38,6 +38,7 @@ type accessLogLine struct {
 	MCPProviderName  any    `json:"mcp.provider.name"`
 	MCPMethodName    any    `json:"mcp.method.name"`
 	MCPToolName      any    `json:"mcp.tool.name"`
+	MCPResourceURI   any    `json:"mcp.resource.uri"`
 	JSONRPCRequestID any    `json:"jsonrpc.request.id"`
 }
 
@@ -147,6 +148,37 @@ func TestMCPAccessLogMetadata(t *testing.T) {
 				return false
 			}
 			return line.JSONRPCRequestID != nil
+		})
+	}, 15*time.Second, 500*time.Millisecond)
+}
+
+// TestMCPAccessLogResourceURI covers the one MCP metadata header the access log cannot get any other
+// way: x-ai-eg-mcp-metadata-resource-uri is consumed and removed by header_to_metadata, so %REQ(...)%
+// cannot see it.
+//
+// The logged value is the upstream URI, not the client-facing composite one the client sent, because
+// addMCPHeaders runs after the backend prefix is stripped. That matches mcp.tool.name, which
+// TestMCPAccessLogMetadata asserts is the bare tool name. The composite form stays available on the
+// span - see the mcp.resource.uri assertion in testReadResource - and is recoverable from the log by
+// pairing this with mcp.provider.name.
+func TestMCPAccessLogResourceURI(t *testing.T) {
+	env := requireNewMCPEnv(t, false, 1200*time.Second, defaultMCPPath)
+	session := env.newSession(t)
+
+	_, err := session.session.ReadResource(t.Context(), &mcp.ReadResourceParams{
+		URI: defaultMCPBackendResourceURIPrefix + testmcp.DummyResource.URI,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return accessLogHasLine(env.env.EnvoyStdout(), func(line accessLogLine) bool {
+			if line.MCPMethodName != "resources/read" {
+				return false
+			}
+			if line.MCPProviderName != defaultMCPBackend {
+				return false
+			}
+			return line.MCPResourceURI == testmcp.DummyResource.URI
 		})
 	}, 15*time.Second, 500*time.Millisecond)
 }


### PR DESCRIPTION
**Description**

Adds `mcp_resource_uri` to the filter metadata the MCP proxy exposes for access logging.

The MCP proxy sets headers on every request it sends to a backend. The `header_to_metadata` filter on the MCP backend listener turns the ones listed in `MCPInternalHeadersToMetadata` into filter metadata, strips the internal ones, and forwards the request. Access logs read them back with `%DYNAMIC_METADATA(io.envoy.ai_gateway:...)%`. Today that covers `mcp_backend`, `mcp_method`, `mcp_request_id` and `mcp_tool_name`.

A `tools/call` records which tool ran. A `resources/read` records only the method, so the log says a resource was read but not which one. Tracing does not have this gap — `getMCPParamsAsAttributes` already sets `mcp.resource.uri` for `resources/read`, `resources/subscribe` and `resources/unsubscribe` (`internal/tracing/mcp.go:143`). So the URI is there if you run tracing, and invisible if you only run access logs. `addMCPHeaders` now mirrors that switch.

Example access log format on the EnvoyProxy resource:

```yaml
mcp.method.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_method)%"
mcp.provider.name: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_backend)%"
mcp.resource.uri: "%DYNAMIC_METADATA(io.envoy.ai_gateway:mcp_resource_uri)%"
```

For a client request of:

```json
{"jsonrpc":"2.0","id":"1","method":"resources/read","params":{"uri":"backend1+file://config.yaml"}}
```

the proxy sends `x-ai-eg-mcp-metadata-resource-uri: file://config.yaml` to the backend listener, where the filter consumes and removes it. Before this change the same request logged `mcp.method.name: resources/read` and nothing identifying the resource.

**Related Issues/PRs (if applicable)**

None.

**Special notes for reviewers (if applicable)**

- Metadata header values now go through `setMCPMetadataHeader`, which skips values `http.Transport` would reject.

- `createBackendListener` now iterates `MCPInternalHeadersToMetadata` in sorted key order. Ranging the map emitted the rules in a different order on every translation, which changes the serialized listener, bumps the xDS version and makes Envoy replace and drain the MCP backend listener even when no MCP config changed.
