### PR TITLE
feat: implement `/cohere/v2/embed` endpoint

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -323,6 +323,8 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 		imageGenerationMetricsFactory, tracing.ImageGenerationTracer(), endpointspec.ImageGenerationEndpointSpec{}))
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Cohere, "/v2/rerank"), extproc.NewFactory(
 		rerankMetricsFactory, tracing.RerankTracer(), endpointspec.RerankEndpointSpec{}))
+	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Cohere, "/v2/embed"), extproc.NewFactory(
+		embeddingsMetricsFactory, tracing.EmbedTracer(), endpointspec.EmbedEndpointSpec{}))
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.OpenAI, "/v1/models"), extproc.NewModelsProcessor)
 	server.Register(path.Join(flags.rootPrefix, endpointPrefixes.Anthropic, "/v1/messages"), extproc.NewFactory(
 		messagesMetricsFactory, tracing.MessageTracer(), endpointspec.MessagesEndpointSpec{}))

--- a/examples/basic/cohere.yaml
+++ b/examples/basic/cohere.yaml
@@ -21,6 +21,13 @@ spec:
               value: rerank-english-v3.0
       backendRefs:
         - name: envoy-ai-gateway-basic-cohere
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: embed-v4.0
+      backendRefs:
+        - name: envoy-ai-gateway-basic-cohere
 ---
 apiVersion: aigateway.envoyproxy.io/v1beta1
 kind: AIServiceBackend

--- a/internal/apischema/cohere/embed_v2.go
+++ b/internal/apischema/cohere/embed_v2.go
@@ -51,21 +51,21 @@ const (
 type EmbedV2EmbeddingType string
 
 const (
-	EmbedV2EmbeddingTypeFloat EmbedV2EmbeddingType = "float"
-	EmbedV2EmbeddingTypeInt8 EmbedV2EmbeddingType = "int8"
-	EmbedV2EmbeddingTypeUint8 EmbedV2EmbeddingType = "uint8"
-	EmbedV2EmbeddingTypeBinary EmbedV2EmbeddingType = "binary"
+	EmbedV2EmbeddingTypeFloat   EmbedV2EmbeddingType = "float"
+	EmbedV2EmbeddingTypeInt8    EmbedV2EmbeddingType = "int8"
+	EmbedV2EmbeddingTypeUint8   EmbedV2EmbeddingType = "uint8"
+	EmbedV2EmbeddingTypeBinary  EmbedV2EmbeddingType = "binary"
 	EmbedV2EmbeddingTypeUbinary EmbedV2EmbeddingType = "ubinary"
-	EmbedV2EmbeddingTypeBase64 EmbedV2EmbeddingType = "base64"
+	EmbedV2EmbeddingTypeBase64  EmbedV2EmbeddingType = "base64"
 )
 
 // EmbedV2Truncate specifies how the API will handle inputs longer than the maximum token length.
 type EmbedV2Truncate string
 
 const (
-	EmbedV2TruncateNone EmbedV2Truncate = "NONE"
+	EmbedV2TruncateNone  EmbedV2Truncate = "NONE"
 	EmbedV2TruncateStart EmbedV2Truncate = "START"
-	EmbedV2TruncateEnd EmbedV2Truncate = "END"
+	EmbedV2TruncateEnd   EmbedV2Truncate = "END"
 )
 
 // EmbedV2Inputs represents an array of mixed text/image input entries.
@@ -75,8 +75,8 @@ type EmbedV2Inputs struct {
 
 // EmbedV2InputContent represents a single content item in a mixed input entry.
 type EmbedV2InputContent struct {
-	Type string `json:"type"`
-	Text *string `json:"text,omitempty"`
+	Type     string           `json:"type"`
+	Text     *string          `json:"text,omitempty"`
 	ImageURL *EmbedV2ImageURL `json:"image_url,omitempty"`
 }
 
@@ -112,10 +112,10 @@ type EmbedV2Embeddings struct {
 
 // EmbedV2ImageMeta contains metadata about an input image.
 type EmbedV2ImageMeta struct {
-	Width *int `json:"width,omitempty"`
-	Height *int `json:"height,omitempty"`
-	Format *string `json:"format,omitempty"`
-	BitDepth *int `json:"bit_depth,omitempty"`
+	Width    *int    `json:"width,omitempty"`
+	Height   *int    `json:"height,omitempty"`
+	Format   *string `json:"format,omitempty"`
+	BitDepth *int    `json:"bit_depth,omitempty"`
 }
 
 // EmbedV2Meta contains metadata returned by the API.

--- a/internal/apischema/cohere/embed_v2.go
+++ b/internal/apischema/cohere/embed_v2.go
@@ -1,0 +1,176 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// Package cohere contains Cohere API schema definitions.
+package cohere
+
+// EmbedV2Request represents the request body for Cohere Embed API v2.
+// Docs: https://docs.cohere.com/reference/embed
+type EmbedV2Request struct {
+	// Model identifier to use, e.g. "embed-v4.0".
+	Model string `json:"model"`
+	// InputType specifies the type of input passed to the model. Required for embedding models v3 and higher.
+	InputType EmbedV2InputType `json:"input_type"`
+	// Texts is a list of strings to embed.
+	Texts []string `json:"texts,omitempty"`
+	// Images is a list of image data URIs to embed.
+	Images []string `json:"images,omitempty"`
+	// Inputs is a list of mixed text/image content entries to embed.
+	Inputs []EmbedV2Inputs `json:"inputs,omitempty"`
+	// EmbeddingTypes specifies the desired output format(s).
+	EmbeddingTypes []EmbedV2EmbeddingType `json:"embedding_types,omitempty"`
+	// MaxTokens is the maximum number of tokens to embed per input.
+	MaxTokens *int `json:"max_tokens,omitempty"`
+	// OutputDimension is the number of dimensions of the output embedding.
+	OutputDimension *int `json:"output_dimension,omitempty"`
+	// Truncate specifies how the API will handle inputs longer than the maximum token length.
+	Truncate *EmbedV2Truncate `json:"truncate,omitempty"`
+	// Priority controls request processing order.
+	Priority *int `json:"priority,omitempty"`
+}
+
+// EmbedV2InputType specifies the type of input passed to the embed endpoint.
+type EmbedV2InputType string
+
+const (
+	// EmbedV2InputTypeSearchDocument is used for embeddings stored in a vector database for search use-cases.
+	EmbedV2InputTypeSearchDocument EmbedV2InputType = "search_document"
+	// EmbedV2InputTypeSearchQuery is used for embeddings of search queries run against a vector database.
+	EmbedV2InputTypeSearchQuery EmbedV2InputType = "search_query"
+	// EmbedV2InputTypeClassification is used for embeddings passed through a text classifier.
+	EmbedV2InputTypeClassification EmbedV2InputType = "classification"
+	// EmbedV2InputTypeClustering is used for embeddings run through a clustering algorithm.
+	EmbedV2InputTypeClustering EmbedV2InputType = "clustering"
+	// EmbedV2InputTypeImage is used for embeddings of images.
+	EmbedV2InputTypeImage EmbedV2InputType = "image"
+)
+
+// EmbedV2EmbeddingType specifies the desired output format(s) of the embed endpoint.
+type EmbedV2EmbeddingType string
+
+const (
+	EmbedV2EmbeddingTypeFloat EmbedV2EmbeddingType = "float"
+	EmbedV2EmbeddingTypeInt8 EmbedV2EmbeddingType = "int8"
+	EmbedV2EmbeddingTypeUint8 EmbedV2EmbeddingType = "uint8"
+	EmbedV2EmbeddingTypeBinary EmbedV2EmbeddingType = "binary"
+	EmbedV2EmbeddingTypeUbinary EmbedV2EmbeddingType = "ubinary"
+	EmbedV2EmbeddingTypeBase64 EmbedV2EmbeddingType = "base64"
+)
+
+// EmbedV2Truncate specifies how the API will handle inputs longer than the maximum token length.
+type EmbedV2Truncate string
+
+const (
+	EmbedV2TruncateNone EmbedV2Truncate = "NONE"
+	EmbedV2TruncateStart EmbedV2Truncate = "START"
+	EmbedV2TruncateEnd EmbedV2Truncate = "END"
+)
+
+// EmbedV2Inputs represents an array of mixed text/image input entries.
+type EmbedV2Inputs struct {
+	Content []EmbedV2InputContent `json:"content"`
+}
+
+// EmbedV2InputContent represents a single content item in a mixed input entry.
+type EmbedV2InputContent struct {
+	Type string `json:"type"`
+	Text *string `json:"text,omitempty"`
+	ImageURL *EmbedV2ImageURL `json:"image_url,omitempty"`
+}
+
+// EmbedV2ImageURL represents a base64-encoded image data.
+type EmbedV2ImageURL struct {
+	URL string `json:"url"`
+}
+
+// EmbedV2Response represents the response from Cohere Embed API v2.
+// Docs: https://docs.cohere.com/reference/embed
+type EmbedV2Response struct {
+	// Unique request ID.
+	ID *string `json:"id,omitempty"`
+	// Embeddings holds the resulting embedding vectors, keyed by the embedding type.
+	Embeddings *EmbedV2Embeddings `json:"embeddings,omitempty"`
+	// Texts is the list of input texts that were embedded.
+	Texts []string `json:"texts,omitempty"`
+	// Images is the list of input images that were embedded.
+	Images []EmbedV2ImageMeta `json:"images,omitempty"`
+	// Additional metadata including API version and billing.
+	Meta *EmbedV2Meta `json:"meta,omitempty"`
+}
+
+// EmbedV2Embeddings holds the resulting embedding vectors, keyed by the embedding type.
+type EmbedV2Embeddings struct {
+	Float   [][]float32 `json:"float,omitempty"`
+	Int8    [][]int8    `json:"int8,omitempty"`
+	Uint8   [][]uint8   `json:"uint8,omitempty"`
+	Binary  [][]byte    `json:"binary,omitempty"`
+	Ubinary [][]byte    `json:"ubinary,omitempty"`
+	Base64  []string    `json:"base64,omitempty"`
+}
+
+// EmbedV2ImageMeta contains metadata about an input image.
+type EmbedV2ImageMeta struct {
+	Width *int `json:"width,omitempty"`
+	Height *int `json:"height,omitempty"`
+	Format *string `json:"format,omitempty"`
+	BitDepth *int `json:"bit_depth,omitempty"`
+}
+
+// EmbedV2Meta contains metadata returned by the API.
+type EmbedV2Meta struct {
+	// APIVersion contains the version information for the API that processed the request.
+	APIVersion *EmbedV2APIVersion `json:"api_version,omitempty"`
+	// BilledUnits reports the billed resource usage for this request.
+	BilledUnits *EmbedV2BilledUnits `json:"billed_units,omitempty"`
+	// Tokens provides the token usage breakdown for the request/response.
+	Tokens *EmbedV2Tokens `json:"tokens,omitempty"`
+	// CachedTokens is the number of prompt tokens that hit the inference cache.
+	CachedTokens *float64 `json:"cached_tokens,omitempty"`
+	// Warnings contains any non-fatal warnings generated while processing the request.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// EmbedV2APIVersion describes the API version details in the response meta.
+type EmbedV2APIVersion struct {
+	// Version is the API version string (e.g., "2").
+	Version string `json:"version"`
+	// IsDeprecated indicates whether this API version is deprecated (nullable).
+	IsDeprecated *bool `json:"is_deprecated,omitempty"`
+	// IsExperimental indicates whether this API version is experimental (nullable).
+	IsExperimental *bool `json:"is_experimental,omitempty"`
+}
+
+// EmbedV2BilledUnits contains usage metrics related to the request.
+type EmbedV2BilledUnits struct {
+	// Images is the number of billed images (nullable).
+	Images *float64 `json:"images,omitempty"`
+	// InputTokens is the number of billed input tokens (nullable).
+	InputTokens *float64 `json:"input_tokens,omitempty"`
+	// ImageTokens is the number of billed image tokens (nullable).
+	ImageTokens *float64 `json:"image_tokens,omitempty"`
+	// OutputTokens is the number of billed output tokens (nullable).
+	OutputTokens *float64 `json:"output_tokens,omitempty"`
+	// SearchUnits is the number of billed search units (nullable).
+	SearchUnits *float64 `json:"search_units,omitempty"`
+	// Classifications is the number of billed classification units (nullable).
+	Classifications *float64 `json:"classifications,omitempty"`
+}
+
+// EmbedV2Tokens captures token accounting for the request.
+// Docs: https://docs.cohere.com/reference/embed#response.body.meta.tokens
+type EmbedV2Tokens struct {
+	// InputTokens is the number of tokens used as input to the model (nullable).
+	InputTokens *float64 `json:"input_tokens,omitempty"`
+	// OutputTokens is the number of tokens produced by the model (nullable).
+	OutputTokens *float64 `json:"output_tokens,omitempty"`
+}
+
+// EmbedV2Error describes a Cohere v2 error.
+type EmbedV2Error struct {
+	// ID is a unique identifier for the error (nullable).
+	ID *string `json:"id,omitempty"`
+	// Message is a human-readable description of the error (nullable).
+	Message *string `json:"message,omitempty"`
+}

--- a/internal/apischema/cohere/embed_v2.go
+++ b/internal/apischema/cohere/embed_v2.go
@@ -102,7 +102,7 @@ type EmbedV2Response struct {
 
 // EmbedV2Embeddings holds the resulting embedding vectors, keyed by the embedding type.
 type EmbedV2Embeddings struct {
-	Float   [][]float32 `json:"float,omitempty"`
+	Float   [][]float64 `json:"float,omitempty"`
 	Int8    [][]int8    `json:"int8,omitempty"`
 	Uint8   [][]uint8   `json:"uint8,omitempty"`
 	Binary  [][]byte    `json:"binary,omitempty"`

--- a/internal/endpointspec/endpointspec.go
+++ b/internal/endpointspec/endpointspec.go
@@ -108,6 +108,8 @@ type (
 	MessagesEndpointSpec struct{}
 	// RerankEndpointSpec implements EndpointSpec for /v2/rerank.
 	RerankEndpointSpec struct{}
+	// EmbedEndpointSpec implements EndpointSpec for /v2/embed.
+	EmbedEndpointSpec struct{}
 	// SpeechEndpointSpec implements EndpointSpec for /v1/audio/speech.
 	SpeechEndpointSpec struct{}
 	// TranscriptionEndpointSpec implements EndpointSpec for /v1/audio/transcriptions.
@@ -419,6 +421,39 @@ func (RerankEndpointSpec) GetTranslator(schema filterapi.VersionedAPISchema, mod
 
 // RedactSensitiveInfoFromRequest implements [EndpointSpec.RedactSensitiveInfoFromRequest].
 func (RerankEndpointSpec) RedactSensitiveInfoFromRequest(req *cohereschema.RerankV2Request) (redactedReq *cohereschema.RerankV2Request, err error) {
+	// Placeholder if redaction is required in future
+	return req, nil
+}
+
+// ParseBody implements [EndpointSpec.ParseBody].
+func (EmbedEndpointSpec) ParseBody(
+	body []byte,
+	_ bool,
+) (internalapi.OriginalModel, *cohereschema.EmbedV2Request, bool, []byte, error) {
+	var req cohereschema.EmbedV2Request
+	if err := json.Unmarshal(body, &req); err != nil {
+		return "", nil, false, nil, fmt.Errorf("%w: failed to parse JSON for /v2/embed: %w", internalapi.ErrMalformedRequest, err)
+	}
+	return req.Model, &req, false, nil, nil
+}
+
+// ParseMultipartBody implements [Spec.ParseMultipartBody].
+func (EmbedEndpointSpec) ParseMultipartBody([]byte, string, bool) (internalapi.OriginalModel, *cohereschema.EmbedV2Request, bool, []byte, error) {
+	return "", nil, false, nil, errMultipartNotSupported
+}
+
+// GetTranslator implements [EndpointSpec.GetTranslator].
+func (EmbedEndpointSpec) GetTranslator(schema filterapi.VersionedAPISchema, modelNameOverride string) (translator.CohereEmbedTranslator, error) {
+	switch schema.Name {
+	case filterapi.APISchemaCohere:
+		return translator.NewEmbedCohereToCohereTranslator(schema.Version, modelNameOverride), nil
+	default:
+		return nil, fmt.Errorf("unsupported API schema: backend=%s", schema)
+	}
+}
+
+// RedactSensitiveInfoFromRequest implements [EndpointSpec.RedactSensitiveInfoFromRequest].
+func (EmbedEndpointSpec) RedactSensitiveInfoFromRequest(req *cohereschema.EmbedV2Request) (redactedReq *cohereschema.EmbedV2Request, err error) {
 	// Placeholder if redaction is required in future
 	return req, nil
 }

--- a/internal/endpointspec/endpointspec_test.go
+++ b/internal/endpointspec/endpointspec_test.go
@@ -312,6 +312,37 @@ func TestRerankEndpointSpec_GetTranslator(t *testing.T) {
 	require.ErrorContains(t, err, "unsupported API schema")
 }
 
+func TestEmbedEndpointSpec_ParseBody(t *testing.T) {
+	spec := EmbedEndpointSpec{}
+	t.Run("invalid json", func(t *testing.T) {
+		_, _, _, _, err := spec.ParseBody([]byte("{"), false)
+		require.ErrorContains(t, err, "malformed request")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		req := cohereschema.EmbedV2Request{Model: "embed-v4.0", InputType: cohereschema.EmbedV2InputTypeClassification, Texts: []string{"hello", "goodbye"}}
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		model, parsed, stream, mutated, err := spec.ParseBody(body, false)
+		require.NoError(t, err)
+		require.Equal(t, "embed-v4.0", model)
+		require.False(t, stream)
+		require.NotNil(t, parsed)
+		require.Nil(t, mutated)
+	})
+}
+
+func TestEmbedEndpointSpec_GetTranslator(t *testing.T) {
+	spec := EmbedEndpointSpec{}
+
+	_, err := spec.GetTranslator(filterapi.VersionedAPISchema{Name: filterapi.APISchemaCohere}, "override")
+	require.NoError(t, err)
+
+	_, err = spec.GetTranslator(filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}, "override")
+	require.ErrorContains(t, err, "unsupported API schema")
+}
+
 func TestResponsesEndpointSpec_ParseBody(t *testing.T) {
 	spec := ResponsesEndpointSpec{}
 	t.Run("invalid json", func(t *testing.T) {

--- a/internal/tracing/openinference/cohere/embed.go
+++ b/internal/tracing/openinference/cohere/embed.go
@@ -1,0 +1,148 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// Package cohere provides OpenInference semantic conventions hooks for
+// Cohere instrumentation used by the ExtProc router filter.
+package cohere
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	cohereschema "github.com/envoyproxy/ai-gateway/internal/apischema/cohere"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/openinference"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/tracingapi"
+)
+
+// EmbedRecorder implements recorders for Cohere Embed spans.
+type EmbedRecorder struct {
+	tracingapi.NoopChunkRecorder[struct{}]
+	traceConfig *openinference.TraceConfig
+}
+
+// NewEmbedRecorderFromEnv creates an tracingapi.EmbedRecorder from environment variables
+// using the OpenInference configuration specification.
+func NewEmbedRecorderFromEnv() tracingapi.EmbedRecorder {
+	return NewEmbedRecorder(nil)
+}
+
+// NewEmbedRecorder creates a tracingapi.EmbedRecorder with the given config using
+// the OpenInference configuration specification.
+//
+// Parameters:
+//   - config: configuration for redaction. Defaults to NewTraceConfigFromEnv().
+func NewEmbedRecorder(config *openinference.TraceConfig) tracingapi.EmbedRecorder {
+	if config == nil {
+		config = openinference.NewTraceConfigFromEnv()
+	}
+	return &EmbedRecorder{traceConfig: config}
+}
+
+// startOptsEmbed sets trace.SpanKindInternal as that's the span kind used in OpenInference.
+var startOptsEmbed = []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}
+
+// StartParams implements the same method as defined in tracingapi.EmbedRecorder.
+func (r *EmbedRecorder) StartParams(*cohereschema.EmbedV2Request, []byte) (spanName string, opts []trace.SpanStartOption) {
+	return "Embed", startOptsEmbed
+}
+
+// RecordRequest implements the same method as defined in tracingapi.EmbedRecorder.
+func (r *EmbedRecorder) RecordRequest(span trace.Span, req *cohereschema.EmbedV2Request, body []byte) {
+	span.SetAttributes(buildEmbedRequestAttributes(req, body, r.traceConfig)...)
+}
+
+// RecordResponseOnError implements the same method as defined in tracingapi.EmbedRecorder.
+func (r *EmbedRecorder) RecordResponseOnError(span trace.Span, statusCode int, body []byte) {
+	openinference.RecordResponseError(span, statusCode, string(body))
+}
+
+// RecordResponse implements the same method as defined in tracingapi.EmbedRecorder.
+func (r *EmbedRecorder) RecordResponse(span trace.Span, resp *cohereschema.EmbedV2Response) {
+	// Build response attributes (excluding output.value) similar to embeddings.
+	attrs := buildEmbedResponseAttributes(resp, r.traceConfig)
+
+	// Add output.value respecting HideOutputs.
+	bodyString := openinference.RedactedValue
+	if !r.traceConfig.HideOutputs {
+		if marshaled, err := json.Marshal(resp); err == nil {
+			bodyString = string(marshaled)
+		}
+	}
+	attrs = append(attrs, attribute.String(openinference.OutputValue, bodyString))
+
+	span.SetAttributes(attrs...)
+	span.SetStatus(codes.Ok, "")
+}
+
+// buildEmbedRequestAttributes builds OpenInference attributes from the embed request.
+func buildEmbedRequestAttributes(req *cohereschema.EmbedV2Request, body []byte, config *openinference.TraceConfig) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String(openinference.LLMSystem, openinference.LLMSystemCohere),
+		attribute.String(openinference.SpanKind, openinference.SpanKindEmbedding),
+	}
+
+	if req.Model != "" {
+		attrs = append(attrs, attribute.String(openinference.EmbeddingModelName, req.Model))
+	}
+
+	if !config.HideInputs {
+		attrs = append(attrs, attribute.String(openinference.InputValue, openinference.RedactedValue))
+	} else {
+		attrs = append(attrs,
+			attribute.String(openinference.InputValue, string(body)),
+			attribute.String(openinference.InputMimeType, openinference.MimeTypeJSON),
+		)
+	}
+
+	// Record embedding text attributes for string inputs only, consistent with OpenAI embeddings.
+	if !config.HideInputs && !config.HideEmbeddingsText {
+		for i, text := range req.Texts {
+			attrs = append(attrs, attribute.String(openinference.EmbeddingTextAttribute(i), text))
+		}
+	}
+
+	return attrs
+}
+
+// buildEmbedResponseAttributes builds OpenInference attributes from the embed response.
+func buildEmbedResponseAttributes(resp *cohereschema.EmbedV2Response, config *openinference.TraceConfig) []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+
+	// Include output MIME type only when outputs are not hidden.
+	if !config.HideOutputs {
+		attrs = append(attrs, attribute.String(openinference.OutputMimeType, openinference.MimeTypeJSON))
+
+		// Record embedding vectors as float arrays.
+		// TODO: Consider supporting other embedding types (int8, uint8, binary, etc.)
+		if !config.HideEmbeddingsVectors && resp.Embeddings != nil {
+			for i, vec := range resp.Embeddings.Float {
+				if len(vec) > 0 {
+					attrs = append(attrs, attribute.Float64Slice(openinference.EmbeddingVectorAttribute(i), vec))
+				}
+			}
+		}
+	}
+
+	// Token counts (metadata) are included even when outputs are hidden.
+	if resp.Meta != nil && resp.Meta.Tokens != nil {
+		if resp.Meta.Tokens.InputTokens != nil {
+			attrs = append(attrs, attribute.Int(openinference.LLMTokenCountPrompt, int(*resp.Meta.Tokens.InputTokens)))
+		}
+		var total int
+		if resp.Meta.Tokens.InputTokens != nil {
+			total += int(*resp.Meta.Tokens.InputTokens)
+		}
+		if resp.Meta.Tokens.OutputTokens != nil {
+			total += int(*resp.Meta.Tokens.OutputTokens)
+		}
+		if total > 0 {
+			attrs = append(attrs, attribute.Int(openinference.LLMTokenCountTotal, total))
+		}
+	}
+
+	return attrs
+}

--- a/internal/tracing/openinference/cohere/embed.go
+++ b/internal/tracing/openinference/cohere/embed.go
@@ -89,7 +89,7 @@ func buildEmbedRequestAttributes(req *cohereschema.EmbedV2Request, body []byte, 
 		attrs = append(attrs, attribute.String(openinference.EmbeddingModelName, req.Model))
 	}
 
-	if !config.HideInputs {
+	if config.HideInputs {
 		attrs = append(attrs, attribute.String(openinference.InputValue, openinference.RedactedValue))
 	} else {
 		attrs = append(attrs,

--- a/internal/tracing/openinference/cohere/embed_test.go
+++ b/internal/tracing/openinference/cohere/embed_test.go
@@ -58,8 +58,8 @@ func TestEmbedRecorder_RecordRequest(t *testing.T) {
 		attribute.String(openinference.EmbeddingModelName, "embed-v4.0"),
 		attribute.String(openinference.InputValue, string(reqBody)),
 		attribute.String(openinference.InputMimeType, openinference.MimeTypeJSON),
-		attribute.String(openinference.EmbeddingInputText(0), "hello"),
-		attribute.String(openinference.EmbeddingInputText(1), "goodbye"),
+		attribute.String(openinference.EmbeddingTextAttribute(0), "hello"),
+		attribute.String(openinference.EmbeddingTextAttribute(1), "goodbye"),
 	}
 	openinference.RequireAttributesEqual(t, expected, actualSpan.Attributes)
 }
@@ -91,7 +91,7 @@ func TestEmbedRecorder_RecordRequest_HideInputs(t *testing.T) {
 
 func TestEmbedRecorder_RecordResponse(t *testing.T) {
 	resp := &cohereschema.EmbedV2Response{
-		Embeddings: [][]float32{{0.1, 0.2, 0.3, 0.4}},
+		Embeddings: [][]float64{{0.1, 0.2, 0.3, 0.4}},
 		Meta: &cohereschema.EmbedV2Meta{
 			Tokens: &cohereschema.EmbedV2Tokens{
 				InputTokens:  fptr(25),
@@ -120,7 +120,7 @@ func TestEmbedRecorder_RecordResponse(t *testing.T) {
 
 func TestEmbedRecorder_RecordResponse_HideOutputs(t *testing.T) {
 	resp := &cohereschema.EmbedV2Response{
-		Embeddings: [][]float32{{0.1, 0.2, 0.3, 0.4}},
+		Embeddings: [][]float64{{0.1, 0.2, 0.3, 0.4}},
 		Meta: &cohereschema.EmbedV2Meta{
 			Tokens: &cohereschema.EmbedV2Tokens{
 				InputTokens:  fptr(25),
@@ -202,9 +202,4 @@ func TestEmbedRecorder_RecordResponseOnError(t *testing.T) {
 			}
 		})
 	}
-}
-
-func fptr(v int) *float64 {
-	f := float64(v)
-	return &f
 }

--- a/internal/tracing/openinference/cohere/embed_test.go
+++ b/internal/tracing/openinference/cohere/embed_test.go
@@ -22,12 +22,12 @@ import (
 
 func TestEmbedRecorder_StartParams(t *testing.T) {
 	req := &cohereschema.EmbedV2Request{
-		Model:       "embed-v4.0",
-		InputType:   cohereschema.EmbedV2InputTypeClassification,
-		Texts:       []string{"hello", "goodbye"},
+		Model:     "embed-v4.0",
+		InputType: cohereschema.EmbedV2InputTypeClassification,
+		Texts:     []string{"hello", "goodbye"},
 	}
 	reqBody, _ := json.Marshal(req)
-	
+
 	recorder := NewEmbedRecorderFromEnv()
 
 	spanName, opts := recorder.StartParams(req, reqBody)
@@ -39,9 +39,9 @@ func TestEmbedRecorder_StartParams(t *testing.T) {
 
 func TestEmbedRecorder_RecordRequest(t *testing.T) {
 	req := &cohereschema.EmbedV2Request{
-		Model:       "embed-v4.0",
-		InputType:   cohereschema.EmbedV2InputTypeClassification,
-		Texts:       []string{"hello", "goodbye"},
+		Model:     "embed-v4.0",
+		InputType: cohereschema.EmbedV2InputTypeClassification,
+		Texts:     []string{"hello", "goodbye"},
 	}
 	reqBody, _ := json.Marshal(req)
 
@@ -66,9 +66,9 @@ func TestEmbedRecorder_RecordRequest(t *testing.T) {
 
 func TestEmbedRecorder_RecordRequest_HideInputs(t *testing.T) {
 	req := &cohereschema.EmbedV2Request{
-		Model:       "embed-v4.0",
-		InputType:   cohereschema.EmbedV2InputTypeClassification,
-		Texts:       []string{"hello", "goodbye"},
+		Model:     "embed-v4.0",
+		InputType: cohereschema.EmbedV2InputTypeClassification,
+		Texts:     []string{"hello", "goodbye"},
 	}
 	reqBody, _ := json.Marshal(req)
 

--- a/internal/tracing/openinference/cohere/embed_test.go
+++ b/internal/tracing/openinference/cohere/embed_test.go
@@ -91,7 +91,9 @@ func TestEmbedRecorder_RecordRequest_HideInputs(t *testing.T) {
 
 func TestEmbedRecorder_RecordResponse(t *testing.T) {
 	resp := &cohereschema.EmbedV2Response{
-		Embeddings: [][]float64{{0.1, 0.2, 0.3, 0.4}},
+		Embeddings: &cohereschema.EmbedV2Embeddings{
+			Float: [][]float64{{0.1, 0.2, 0.3, 0.4}},
+		},
 		Meta: &cohereschema.EmbedV2Meta{
 			Tokens: &cohereschema.EmbedV2Tokens{
 				InputTokens:  fptr(25),
@@ -110,7 +112,7 @@ func TestEmbedRecorder_RecordResponse(t *testing.T) {
 	respJSON, _ := json.Marshal(resp)
 	expected := []attribute.KeyValue{
 		attribute.String(openinference.OutputMimeType, openinference.MimeTypeJSON),
-		attribute.Float64(openinference.EmbeddingVectorAttribute(0), []float64{0.1, 0.2, 0.3, 0.4}),
+		attribute.Float64Slice(openinference.EmbeddingVectorAttribute(0), []float64{0.1, 0.2, 0.3, 0.4}),
 		attribute.Int(openinference.LLMTokenCountPrompt, 25),
 		attribute.Int(openinference.LLMTokenCountTotal, 25),
 		attribute.String(openinference.OutputValue, string(respJSON)),
@@ -120,7 +122,9 @@ func TestEmbedRecorder_RecordResponse(t *testing.T) {
 
 func TestEmbedRecorder_RecordResponse_HideOutputs(t *testing.T) {
 	resp := &cohereschema.EmbedV2Response{
-		Embeddings: [][]float64{{0.1, 0.2, 0.3, 0.4}},
+		Embeddings: &cohereschema.EmbedV2Embeddings{
+			Float: [][]float64{{0.1, 0.2, 0.3, 0.4}},
+		},
 		Meta: &cohereschema.EmbedV2Meta{
 			Tokens: &cohereschema.EmbedV2Tokens{
 				InputTokens:  fptr(25),

--- a/internal/tracing/openinference/cohere/embed_test.go
+++ b/internal/tracing/openinference/cohere/embed_test.go
@@ -1,0 +1,210 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package cohere
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	cohereschema "github.com/envoyproxy/ai-gateway/internal/apischema/cohere"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+	"github.com/envoyproxy/ai-gateway/internal/testing/testotel"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/openinference"
+)
+
+func TestEmbedRecorder_StartParams(t *testing.T) {
+	req := &cohereschema.EmbedV2Request{
+		Model:       "embed-v4.0",
+		InputType:   cohereschema.EmbedV2InputTypeClassification,
+		Texts:       []string{"hello", "goodbye"},
+	}
+	reqBody, _ := json.Marshal(req)
+	
+	recorder := NewEmbedRecorderFromEnv()
+
+	spanName, opts := recorder.StartParams(req, reqBody)
+	actualSpan := testotel.RecordNewSpan(t, spanName, opts...)
+
+	require.Equal(t, "Embed", actualSpan.Name)
+	require.Equal(t, oteltrace.SpanKindInternal, actualSpan.SpanKind)
+}
+
+func TestEmbedRecorder_RecordRequest(t *testing.T) {
+	req := &cohereschema.EmbedV2Request{
+		Model:       "embed-v4.0",
+		InputType:   cohereschema.EmbedV2InputTypeClassification,
+		Texts:       []string{"hello", "goodbye"},
+	}
+	reqBody, _ := json.Marshal(req)
+
+	recorder := NewEmbedRecorder(&openinference.TraceConfig{})
+
+	actualSpan := testotel.RecordWithSpan(t, func(span oteltrace.Span) bool {
+		recorder.RecordRequest(span, req, reqBody)
+		return false
+	})
+
+	expected := []attribute.KeyValue{
+		attribute.String(openinference.LLMSystem, openinference.LLMSystemCohere),
+		attribute.String(openinference.SpanKind, openinference.SpanKindEmbedding),
+		attribute.String(openinference.EmbeddingModelName, "embed-v4.0"),
+		attribute.String(openinference.InputValue, string(reqBody)),
+		attribute.String(openinference.InputMimeType, openinference.MimeTypeJSON),
+		attribute.String(openinference.EmbeddingInputText(0), "hello"),
+		attribute.String(openinference.EmbeddingInputText(1), "goodbye"),
+	}
+	openinference.RequireAttributesEqual(t, expected, actualSpan.Attributes)
+}
+
+func TestEmbedRecorder_RecordRequest_HideInputs(t *testing.T) {
+	req := &cohereschema.EmbedV2Request{
+		Model:       "embed-v4.0",
+		InputType:   cohereschema.EmbedV2InputTypeClassification,
+		Texts:       []string{"hello", "goodbye"},
+	}
+	reqBody, _ := json.Marshal(req)
+
+	recorder := NewEmbedRecorder(&openinference.TraceConfig{HideInputs: true})
+
+	actualSpan := testotel.RecordWithSpan(t, func(span oteltrace.Span) bool {
+		recorder.RecordRequest(span, req, reqBody)
+		return false
+	})
+
+	expected := []attribute.KeyValue{
+		attribute.String(openinference.LLMSystem, openinference.LLMSystemCohere),
+		attribute.String(openinference.SpanKind, openinference.SpanKindEmbedding),
+		attribute.String(openinference.EmbeddingModelName, "embed-v4.0"),
+		attribute.String(openinference.InputValue, openinference.RedactedValue),
+		// No InputMimeType and no text content attributes when inputs are hidden
+	}
+	openinference.RequireAttributesEqual(t, expected, actualSpan.Attributes)
+}
+
+func TestEmbedRecorder_RecordResponse(t *testing.T) {
+	resp := &cohereschema.EmbedV2Response{
+		Embeddings: [][]float32{{0.1, 0.2, 0.3, 0.4}},
+		Meta: &cohereschema.EmbedV2Meta{
+			Tokens: &cohereschema.EmbedV2Tokens{
+				InputTokens:  fptr(25),
+				OutputTokens: fptr(0),
+			},
+		},
+	}
+
+	recorder := NewEmbedRecorder(&openinference.TraceConfig{})
+
+	actualSpan := testotel.RecordWithSpan(t, func(span oteltrace.Span) bool {
+		recorder.RecordResponse(span, resp)
+		return false
+	})
+
+	respJSON, _ := json.Marshal(resp)
+	expected := []attribute.KeyValue{
+		attribute.String(openinference.OutputMimeType, openinference.MimeTypeJSON),
+		attribute.Float64(openinference.EmbeddingVectorAttribute(0), []float64{0.1, 0.2, 0.3, 0.4}),
+		attribute.Int(openinference.LLMTokenCountPrompt, 25),
+		attribute.Int(openinference.LLMTokenCountTotal, 25),
+		attribute.String(openinference.OutputValue, string(respJSON)),
+	}
+	openinference.RequireAttributesEqual(t, expected, actualSpan.Attributes)
+}
+
+func TestEmbedRecorder_RecordResponse_HideOutputs(t *testing.T) {
+	resp := &cohereschema.EmbedV2Response{
+		Embeddings: [][]float32{{0.1, 0.2, 0.3, 0.4}},
+		Meta: &cohereschema.EmbedV2Meta{
+			Tokens: &cohereschema.EmbedV2Tokens{
+				InputTokens:  fptr(25),
+				OutputTokens: fptr(0),
+			},
+		},
+	}
+
+	recorder := NewEmbedRecorder(&openinference.TraceConfig{HideOutputs: true})
+
+	actualSpan := testotel.RecordWithSpan(t, func(span oteltrace.Span) bool {
+		recorder.RecordResponse(span, resp)
+		return false
+	})
+
+	expected := []attribute.KeyValue{
+		// No OutputMimeType and no per-document scores when outputs are hidden
+		attribute.Int(openinference.LLMTokenCountPrompt, 25),
+		attribute.Int(openinference.LLMTokenCountTotal, 25),
+		attribute.String(openinference.OutputValue, openinference.RedactedValue),
+	}
+	openinference.RequireAttributesEqual(t, expected, actualSpan.Attributes)
+	require.Equal(t, trace.Status{Code: codes.Ok, Description: ""}, actualSpan.Status)
+}
+
+func TestEmbedRecorder_RecordResponseOnError(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		errorBody      []byte
+		expectedStatus trace.Status
+		expectedEvents int
+	}{
+		{
+			name:       "404 not found error",
+			statusCode: 404,
+			errorBody:  []byte(`{"error":{"message":"Not found"}}`),
+			expectedStatus: trace.Status{
+				Code:        codes.Error,
+				Description: "Error code: 404 - {\"error\":{\"message\":\"Not found\"}}",
+			},
+			expectedEvents: 1,
+		},
+		{
+			name:       "500 internal server error",
+			statusCode: 500,
+			errorBody:  []byte(`{"error":{"message":"Internal server error"}}`),
+			expectedStatus: trace.Status{
+				Code:        codes.Error,
+				Description: "Error code: 500 - {\"error\":{\"message\":\"Internal server error\"}}",
+			},
+			expectedEvents: 1,
+		},
+		{
+			name:       "400 bad request",
+			statusCode: 400,
+			errorBody:  []byte(`{"error":{"message":"Invalid input"}}`),
+			expectedStatus: trace.Status{
+				Code:        codes.Error,
+				Description: "Error code: 400 - {\"error\":{\"message\":\"Invalid input\"}}",
+			},
+			expectedEvents: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := NewEmbedRecorderFromEnv()
+
+			actualSpan := testotel.RecordWithSpan(t, func(span oteltrace.Span) bool {
+				recorder.RecordResponseOnError(span, tt.statusCode, tt.errorBody)
+				return false
+			})
+
+			require.Equal(t, tt.expectedStatus, actualSpan.Status)
+			require.Len(t, actualSpan.Events, tt.expectedEvents)
+			if tt.expectedEvents > 0 {
+				require.Equal(t, "exception", actualSpan.Events[0].Name)
+			}
+		})
+	}
+}
+
+func fptr(v int) *float64 {
+	f := float64(v)
+	return &f
+}

--- a/internal/tracing/span.go
+++ b/internal/tracing/span.go
@@ -56,6 +56,7 @@ type (
 	transcriptionSpan        = span[openai.TranscriptionResponse, openai.TranscriptionStreamEvent]
 	translationSpan          = span[openai.TranslationResponse, struct{}]
 	rerankSpan               = span[cohereschema.RerankV2Response, struct{}]
+	embedSpan                = span[cohereschema.EmbedV2Response, struct{}]
 	messageSpan              = span[anthropicschema.MessagesResponse, anthropicschema.MessagesStreamChunk]
 	tokenizeSpan             = span[tokenize.Response, struct{}]
 	responsesInputTokensSpan = span[openai.ResponsesInputTokensResponse, struct{}]

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -40,6 +40,7 @@ var (
 	_ tracingapi.TranscriptionTracer        = (*transcriptionTracer)(nil)
 	_ tracingapi.TranslationTracer          = (*translationTracer)(nil)
 	_ tracingapi.RerankTracer               = (*rerankTracer)(nil)
+	_ tracingapi.EmbedTracer                = (*embedTracer)(nil)
 	_ tracingapi.ResponsesInputTokensTracer = (*responsesInputTokensTracer)(nil)
 )
 
@@ -53,6 +54,7 @@ type (
 	transcriptionTracer        = requestTracerImpl[openai.TranscriptionRequest, openai.TranscriptionResponse, openai.TranscriptionStreamEvent]
 	translationTracer          = requestTracerImpl[openai.TranslationRequest, openai.TranslationResponse, struct{}]
 	rerankTracer               = requestTracerImpl[cohereschema.RerankV2Request, cohereschema.RerankV2Response, struct{}]
+	embedTracer                = requestTracerImpl[cohereschema.EmbedV2Request, cohereschema.EmbedV2Response, struct{}]
 	responsesInputTokensTracer = requestTracerImpl[openai.ResponseRequest, openai.ResponsesInputTokensResponse, struct{}]
 )
 
@@ -214,6 +216,18 @@ func newRerankTracer(tracer trace.Tracer, propagator propagation.TextMapPropagat
 		headerAttributes,
 		func(span trace.Span, recorder tracingapi.RerankRecorder) tracingapi.RerankSpan {
 			return &rerankSpan{span: span, recorder: recorder}
+		},
+	)
+}
+
+func newEmbedTracer(tracer trace.Tracer, propagator propagation.TextMapPropagator, recorder tracingapi.EmbedRecorder, headerAttributes map[string]string) tracingapi.EmbedTracer {
+	return newRequestTracer(
+		tracer,
+		propagator,
+		recorder,
+		headerAttributes,
+		func(span trace.Span, recorder tracingapi.EmbedRecorder) tracingapi.EmbedSpan {
+			return &embedSpan{span: span, recorder: recorder}
 		},
 	)
 }

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -37,6 +37,7 @@ type tracingImpl struct {
 	transcriptionTracer        tracingapi.TranscriptionTracer
 	translationTracer          tracingapi.TranslationTracer
 	rerankTracer               tracingapi.RerankTracer
+	embedTracer                tracingapi.EmbedTracer
 	messageTracer              tracingapi.MessageTracer
 	tokenizeTracer             tracingapi.TokenizeTracer
 	responsesInputTokensTracer tracingapi.ResponsesInputTokensTracer
@@ -88,6 +89,11 @@ func (t *tracingImpl) TranslationTracer() tracingapi.TranslationTracer {
 // RerankTracer implements the same method as documented on tracingapi.Tracing.
 func (t *tracingImpl) RerankTracer() tracingapi.RerankTracer {
 	return t.rerankTracer
+}
+
+// EmbedTracer implements the same method as documented on tracingapi.Tracing.
+func (t *tracingImpl) EmbedTracer() tracingapi.EmbedTracer {
+	return t.embedTracer
 }
 
 // MCPTracer implements the same method as documented on tracingapi.Tracing.
@@ -232,6 +238,7 @@ func NewTracingFromEnv(ctx context.Context, stdout io.Writer, headerAttributeMap
 	transcriptionRecorder := openai.NewTranscriptionRecorderFromEnv()
 	translationRecorder := openai.NewTranslationRecorderFromEnv()
 	rerankRecorder := cohere.NewRerankRecorderFromEnv()
+	embedRecorder := cohere.NewEmbedRecorderFromEnv()
 	messageRecorder := anthropic.NewMessageRecorderFromEnv()
 	tokenizeRecorder := openai.NewTokenizeRecorderFromEnv()
 	responsesInputTokensRecorder := openai.NewResponsesInputTokensRecorderFromEnv()
@@ -289,6 +296,12 @@ func NewTracingFromEnv(ctx context.Context, stdout io.Writer, headerAttributeMap
 			tracer,
 			propagator,
 			rerankRecorder,
+			headerAttrs,
+		),
+		embedTracer: newEmbedTracer(
+			tracer,
+			propagator,
+			embedRecorder,
 			headerAttrs,
 		),
 		messageTracer: newMessageTracer(

--- a/internal/tracing/tracingapi/api.go
+++ b/internal/tracing/tracingapi/api.go
@@ -259,6 +259,7 @@ func (NoopTracing) RerankTracer() RerankTracer {
 func (NoopTracing) EmbedTracer() EmbedTracer {
 	return NoopEmbedTracer{}
 }
+
 func (NoopTracing) MessageTracer() MessageTracer {
 	return NoopMessageTracer{}
 }

--- a/internal/tracing/tracingapi/api.go
+++ b/internal/tracing/tracingapi/api.go
@@ -41,6 +41,8 @@ type (
 		TranslationTracer() TranslationTracer
 		// RerankTracer creates spans for rerank requests.
 		RerankTracer() RerankTracer
+		// EmbedTracer creates spans for Cohere embed requests on /v2/embed endpoint.
+		EmbedTracer() EmbedTracer
 		// MessageTracer creates spans for Anthropic messages requests.
 		MessageTracer() MessageTracer
 		// TokenizeTracer creates spans for tokenize requests.
@@ -89,6 +91,8 @@ type (
 	TranslationTracer = RequestTracer[openai.TranslationRequest, openai.TranslationResponse, struct{}]
 	// RerankTracer creates spans for rerank requests.
 	RerankTracer = RequestTracer[cohere.RerankV2Request, cohere.RerankV2Response, struct{}]
+	// EmbedTracer creates spans for Cohere embed requests.
+	EmbedTracer = RequestTracer[cohere.EmbedV2Request, cohere.EmbedV2Response, struct{}]
 	// MessageTracer creates spans for Anthropic messages requests.
 	MessageTracer = RequestTracer[anthropicschema.MessagesRequest, anthropicschema.MessagesResponse, anthropicschema.MessagesStreamChunk]
 	// TokenizeTracer creates spans for tokenize requests.
@@ -128,6 +132,8 @@ type (
 	TranslationSpan = Span[openai.TranslationResponse, struct{}]
 	// RerankSpan represents a rerank request span.
 	RerankSpan = Span[cohere.RerankV2Response, struct{}]
+	// EmbedSpan represents a Cohere embed request span.
+	EmbedSpan = Span[cohere.EmbedV2Response, struct{}]
 	// MessageSpan represents an Anthropic messages request span.
 	MessageSpan = Span[anthropicschema.MessagesResponse, anthropicschema.MessagesStreamChunk]
 	// TokenizeSpan represents a tokenize request span. The chunk type is unused and therefore set to struct{}.
@@ -181,6 +187,8 @@ type (
 	TranslationRecorder = SpanRecorder[openai.TranslationRequest, openai.TranslationResponse, struct{}]
 	// RerankRecorder records attributes to a span according to a semantic convention.
 	RerankRecorder = SpanRecorder[cohere.RerankV2Request, cohere.RerankV2Response, struct{}]
+	// EmbedRecorder records attributes to a span according to a semantic convention.
+	EmbedRecorder = SpanRecorder[cohere.EmbedV2Request, cohere.EmbedV2Response, struct{}]
 	// MessageRecorder records attributes to a span according to a semantic convention.
 	MessageRecorder = SpanRecorder[anthropicschema.MessagesRequest, anthropicschema.MessagesResponse, anthropicschema.MessagesStreamChunk]
 	// TokenizeRecorder records attributes to a span according to a semantic convention.
@@ -247,6 +255,10 @@ func (NoopTracing) RerankTracer() RerankTracer {
 	return NoopRerankTracer{}
 }
 
+// EmbedTracer implements Tracing.EmbedTracer.
+func (NoopTracing) EmbedTracer() EmbedTracer {
+	return NoopEmbedTracer{}
+}
 func (NoopTracing) MessageTracer() MessageTracer {
 	return NoopMessageTracer{}
 }
@@ -287,6 +299,8 @@ type (
 	NoopTranslationTracer = NoopTracer[openai.TranslationRequest, openai.TranslationResponse, struct{}]
 	// NoopRerankTracer implements RerankTracer.
 	NoopRerankTracer = NoopTracer[cohere.RerankV2Request, cohere.RerankV2Response, struct{}]
+	// NoopEmbedTracer implements EmbedTracer.
+	NoopEmbedTracer = NoopTracer[cohere.EmbedV2Request, cohere.EmbedV2Response, struct{}]
 	// NoopMessageTracer implements MessageTracer.
 	NoopMessageTracer = NoopTracer[anthropicschema.MessagesRequest, anthropicschema.MessagesResponse, anthropicschema.MessagesStreamChunk]
 	// NoopTokenizeTracer implements TokenizeTracer.

--- a/internal/translator/cohere_embed_v2.go
+++ b/internal/translator/cohere_embed_v2.go
@@ -1,0 +1,135 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/sjson"
+
+	cohereschema "github.com/envoyproxy/ai-gateway/internal/apischema/cohere"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+	"github.com/envoyproxy/ai-gateway/internal/tracing/tracingapi"
+)
+
+// NewEmbedCohereToCohereTranslator implements [Factory] for Cohere Embed v2 translation.
+func NewEmbedCohereToCohereTranslator(apiVersion string, modelNameOverride internalapi.ModelNameOverride) CohereEmbedTranslator {
+	return &cohereToCohereTranslatorV2Embed{modelNameOverride: modelNameOverride, path: path.Join("/", apiVersion, "embed")} // e.g., /v2/embed
+}
+
+// cohereToCohereTranslatorV2Embed is a passthrough translator for Cohere Embed API v2.
+// May apply model overrides but otherwise preserves the Cohere format:
+// https://docs.cohere.com/reference/embed
+type cohereToCohereTranslatorV2Embed struct {
+	modelNameOverride internalapi.ModelNameOverride
+	// requestModel stores the effective model for this request (override or provided)
+	requestModel internalapi.RequestModel
+	// The path of the embed endpoint to be used for the request. It is prefixed with the API path prefix.
+	path string
+}
+
+// RequestBody implements [CohereEmbedTranslator.RequestBody].
+func (t *cohereToCohereTranslatorV2Embed) RequestBody(original []byte, req *cohereschema.EmbedV2Request, onRetry bool) (
+	newHeaders []internalapi.Header, newBody []byte, err error,
+) {
+	// Store the request model to use as fallback for response model
+	t.requestModel = req.Model
+	if t.modelNameOverride != "" {
+		// Override the model if configured.
+		newBody, err = sjson.SetBytesOptions(original, "model", t.modelNameOverride, sjsonOptions)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
+		}
+		// Make everything coherent.
+		t.requestModel = t.modelNameOverride
+	}
+
+	// Always set the path header to the embed endpoint so that the request is routed correctly.
+	if onRetry && len(newBody) == 0 {
+		newBody = original
+	}
+
+	newHeaders = []internalapi.Header{{pathHeaderName, t.path}}
+	if len(newBody) > 0 {
+		newHeaders = append(newHeaders, internalapi.Header{contentLengthHeaderName, strconv.Itoa(len(newBody))})
+	}
+	return
+}
+
+// ResponseHeaders implements [CohereEmbedTranslator.ResponseHeaders].
+func (t *cohereToCohereTranslatorV2Embed) ResponseHeaders(map[string]string) (newHeaders []internalapi.Header, err error) {
+	return nil, nil
+}
+
+// ResponseBody implements [CohereEmbedTranslator.ResponseBody].
+// For embed, token usage is provided via meta.tokens.input_tokens when available.
+func (t *cohereToCohereTranslatorV2Embed) ResponseBody(_ map[string]string, body io.Reader, _ bool, span tracingapi.EmbedSpan) (
+	newHeaders []internalapi.Header, newBody []byte, tokenUsage metrics.TokenUsage, responseModel internalapi.ResponseModel, err error,
+) {
+	var resp cohereschema.EmbedV2Response
+	if err := json.NewDecoder(body).Decode(&resp); err != nil {
+		return nil, nil, tokenUsage, t.requestModel, fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+
+	// Record the response in the span if successful.
+	if span != nil {
+		span.RecordResponse(&resp)
+	}
+
+	// Token accounting: embed only has input tokens; output tokens do not apply.
+	if resp.Meta != nil && resp.Meta.Tokens != nil {
+		var totalTokens uint32
+		if resp.Meta.Tokens.InputTokens != nil {
+			// Cohere uses float; round down to uint32 like embeddings.
+			input := uint32(*resp.Meta.Tokens.InputTokens) //nolint:gosec
+			tokenUsage.SetInputTokens(input)
+			totalTokens += input
+		}
+		if resp.Meta.Tokens.OutputTokens != nil {
+			output := uint32(*resp.Meta.Tokens.OutputTokens) //nolint:gosec
+			tokenUsage.SetOutputTokens(output)
+			totalTokens += output
+		}
+		tokenUsage.SetTotalTokens(totalTokens)
+	}
+
+	// Cohere embed responses do not echo model; report the effective request model if known.
+	responseModel = t.requestModel
+	return
+}
+
+// ResponseError implements [CohereEmbedTranslator.ResponseError].
+// If connection fails or a non-JSON error is returned, wrap it into a JSON error body.
+func (t *cohereToCohereTranslatorV2Embed) ResponseError(respHeaders map[string]string, body io.Reader) (
+	newHeaders []internalapi.Header, newBody []byte, err error,
+) {
+	if v, ok := respHeaders[contentTypeHeaderName]; ok && !strings.Contains(v, jsonContentType) {
+		buf, err := io.ReadAll(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read error body: %w", err)
+		}
+		message := string(buf)
+		// Wrap as a minimal Cohere v2 error JSON for consistency.
+		cohereErr := cohereschema.EmbedV2Error{
+			Message: &message,
+		}
+		newBody, err = json.Marshal(cohereErr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal error body: %w", err)
+		}
+		newHeaders = append(newHeaders,
+			internalapi.Header{contentTypeHeaderName, jsonContentType},
+			internalapi.Header{contentLengthHeaderName, strconv.Itoa(len(newBody))},
+		)
+	}
+	return
+}

--- a/internal/translator/cohere_embed_v2_test.go
+++ b/internal/translator/cohere_embed_v2_test.go
@@ -134,7 +134,7 @@ func TestCohereToCohereTranslatorV2Embed_ResponseBody(t *testing.T) {
 		{
 			name: "valid_response_input_only",
 			responseBody: `{
-"embeddings": [{"float": [[0.1, 0.2, 0.3, 0.4]]}],
+"embeddings": {"float": [[0.1, 0.2, 0.3, 0.4]]},
 "id": "em-123",
 "meta": {"tokens": {"input_tokens": 25}}
 }`,
@@ -145,7 +145,7 @@ func TestCohereToCohereTranslatorV2Embed_ResponseBody(t *testing.T) {
 		{
 			name: "valid_response_with_output_tokens",
 			responseBody: `{
-"embeddings": [{"float": [[0.1, 0.2, 0.3, 0.4]]}],
+"embeddings": {"float": [[0.1, 0.2, 0.3, 0.4]]},
 "id": "em-123",
 "meta": {"tokens": {"input_tokens": 25, "output_tokens": 0}}
 }`,
@@ -245,7 +245,7 @@ func TestCohereToCohereTranslatorV2Embed_ResponseBody_RecordsResponseInSpan(t *t
 	tr := NewEmbedCohereToCohereTranslator("v2", "")
 	tr.(*cohereToCohereTranslatorV2Embed).requestModel = "embed-v4.0"
 
-	body := `{"embeddings":[[0.1, 0.2, 0.3]],"id":"em-456"}`
+	body := `{"embeddings":{"float":[[0.1, 0.2, 0.3]]},"id":"em-456"}`
 	_, _, _, _, err := tr.ResponseBody(
 		map[string]string{contentTypeHeaderName: jsonContentType},
 		strings.NewReader(body),

--- a/internal/translator/cohere_embed_v2_test.go
+++ b/internal/translator/cohere_embed_v2_test.go
@@ -6,7 +6,6 @@
 package translator
 
 import (
-	"errors"
 	"strings"
 	"testing"
 

--- a/internal/translator/cohere_embed_v2_test.go
+++ b/internal/translator/cohere_embed_v2_test.go
@@ -1,0 +1,258 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/sjson"
+
+	cohereschema "github.com/envoyproxy/ai-gateway/internal/apischema/cohere"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+)
+
+func TestCohereToCohereTranslatorV2Embed_RequestBody(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		modelNameOverride string
+		onRetry           bool
+		expPath           string
+		expBodyContains   string
+	}{
+		{
+			name:            "valid_body",
+			expPath:         "/v2/embed",
+			expBodyContains: "",
+		},
+		{
+			name:              "model_name_override",
+			modelNameOverride: "embed-v4.0",
+			expPath:           "/v2/embed",
+			expBodyContains:   `"model":"embed-v4.0"`,
+		},
+		{
+			name:    "on_retry_no_change",
+			onRetry: true,
+			expPath: "/v2/embed",
+		},
+		{
+			name:              "model_name_override_with_retry",
+			modelNameOverride: "embed-v4.0",
+			onRetry:           true,
+			expPath:           "/v2/embed",
+			expBodyContains:   `"model":"embed-v4.0"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			translator := NewEmbedCohereToCohereTranslator("v2", tc.modelNameOverride)
+			originalBody := `{"model":"embed-v4.0","input_type":"classification","texts":["text1","text2"]}`
+			var req cohereschema.EmbedV2Request
+			require.NoError(t, json.Unmarshal([]byte(originalBody), &req))
+
+			headerMutation, bodyMutation, err := translator.RequestBody([]byte(originalBody), &req, tc.onRetry)
+			require.NoError(t, err)
+			require.NotNil(t, headerMutation)
+			require.GreaterOrEqual(t, len(headerMutation), 1)
+			require.Equal(t, pathHeaderName, headerMutation[0].Key())
+			require.Equal(t, tc.expPath, headerMutation[0].Value())
+
+			switch {
+			case tc.expBodyContains != "":
+				require.NotNil(t, bodyMutation)
+				require.Contains(t, string(bodyMutation), tc.expBodyContains)
+				// Verify content-length header is set.
+				require.Len(t, headerMutation, 2)
+				require.Equal(t, contentLengthHeaderName, headerMutation[1].Key())
+			case bodyMutation != nil:
+				// If there's a body mutation (like on retry), content-length header should be set.
+				require.Len(t, headerMutation, 2)
+				require.Equal(t, contentLengthHeaderName, headerMutation[1].Key())
+			default:
+				// No body mutation, only path header.
+				require.Len(t, headerMutation, 1)
+			}
+		})
+	}
+}
+
+func TestCohereToCohereTranslatorV2Embed_RequestBody_InvalidJSONCreatesBodyWithOverride(t *testing.T) {
+	translator := NewEmbedCohereToCohereTranslator("v2", "override-model")
+	// Provide invalid JSON; sjson with Optimistic mode can still produce a body with the override.
+	originalBody := []byte("not-json")
+	var req cohereschema.EmbedV2Request
+	headerMutation, bodyMutation, err := translator.RequestBody(originalBody, &req, false)
+	require.NoError(t, err)
+	require.NotNil(t, headerMutation)
+	require.NotNil(t, bodyMutation)
+	// Body should contain the override model
+	require.Contains(t, string(bodyMutation), `"model":"override-model"`)
+	// Verify content-length header is set alongside :path
+	require.GreaterOrEqual(t, len(headerMutation), 2)
+	require.Equal(t, pathHeaderName, headerMutation[0].Key())
+	require.Equal(t, "/v2/embed", headerMutation[0].Value())
+	require.Equal(t, contentLengthHeaderName, headerMutation[1].Key())
+}
+
+func TestCohereToCohereTranslatorV2Embed_RequestBody_SetModelNameError(t *testing.T) {
+	orig := sjsonOptions
+	sjsonOptions = &sjson.Options{Optimistic: false, ReplaceInPlace: false}
+	t.Cleanup(func() { sjsonOptions = orig })
+
+	translator := NewEmbedCohereToCohereTranslator("v2", "override-model")
+	// Use an array root to make setting an object key fail with Optimistic=false.
+	originalBody := []byte("[]")
+	var req cohereschema.EmbedV2Request
+
+	headerMutation, bodyMutation, err := translator.RequestBody(originalBody, &req, false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to set model name")
+	require.Nil(t, headerMutation)
+	require.Nil(t, bodyMutation)
+}
+
+func TestCohereToCohereTranslatorV2Embed_ResponseHeaders(t *testing.T) {
+	translator := NewEmbedCohereToCohereTranslator("v2", "")
+	headerMutation, err := translator.ResponseHeaders(map[string]string{})
+	require.NoError(t, err)
+	require.Nil(t, headerMutation)
+}
+
+func TestCohereToCohereTranslatorV2Embed_ResponseBody(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		responseBody   string
+		expectedInput  int32
+		expectedOutput int32
+		expectedTotal  int32
+		expError       bool
+	}{
+		{
+			name: "valid_response_input_only",
+			responseBody: `{
+"embeddings": [{"float": [[0.1, 0.2, 0.3, 0.4]]}],
+"id": "em-123",
+"meta": {"tokens": {"input_tokens": 25}}
+}`,
+			expectedInput:  25,
+			expectedOutput: -1,
+			expectedTotal:  25,
+		},
+		{
+			name: "valid_response_with_output_tokens",
+			responseBody: `{
+"embeddings": [{"float": [[0.1, 0.2, 0.3, 0.4]]}],
+"id": "em-123",
+"meta": {"tokens": {"input_tokens": 25, "output_tokens": 0}}
+}`,
+			expectedInput:  25,
+			expectedOutput: 0,
+			expectedTotal:  25,
+		},
+		{
+			name:         "invalid_json",
+			responseBody: `invalid json`,
+			expError:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			translator := NewEmbedCohereToCohereTranslator("v2", "")
+			translator.(*cohereToCohereTranslatorV2Embed).requestModel = "embed-v4.0"
+			headerMutation, bodyMutation, tokenUsage, responseModel, err := translator.ResponseBody(
+				map[string]string{contentTypeHeaderName: jsonContentType},
+				strings.NewReader(tc.responseBody),
+				true,
+				nil,
+			)
+
+			if tc.expError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			expected := tokenUsageFrom(tc.expectedInput, -1, -1, tc.expectedOutput, tc.expectedTotal, -1)
+			require.Equal(t, expected, tokenUsage)
+			require.Equal(t, "embed-v4.0", responseModel)
+			require.Nil(t, headerMutation)
+			require.Nil(t, bodyMutation)
+		})
+	}
+}
+
+func TestCohereToCohereTranslatorV2Embed_ResponseError(t *testing.T) {
+	translator := NewEmbedCohereToCohereTranslator("v2", "")
+
+	t.Run("non_json_error", func(t *testing.T) {
+		respHeaders := map[string]string{
+			statusHeaderName:      "503",
+			contentTypeHeaderName: "text/plain",
+		}
+		errorBody := "Service Unavailable"
+
+		headerMutation, bodyMutation, err := translator.ResponseError(respHeaders, strings.NewReader(errorBody))
+		require.NoError(t, err)
+		require.NotNil(t, headerMutation)
+		require.NotNil(t, bodyMutation)
+
+		var cohereErr cohereschema.EmbedV2Error
+		require.NoError(t, json.Unmarshal(bodyMutation, &cohereErr))
+		require.NotNil(t, cohereErr.Message)
+		require.Equal(t, errorBody, *cohereErr.Message)
+	})
+
+	t.Run("json_error_passthrough", func(t *testing.T) {
+		respHeaders := map[string]string{
+			statusHeaderName:      "400",
+			contentTypeHeaderName: jsonContentType,
+		}
+		errorBody := `{"error": {"message": "Invalid request"}}`
+
+		headerMutation, bodyMutation, err := translator.ResponseError(respHeaders, strings.NewReader(errorBody))
+		require.NoError(t, err)
+		require.Nil(t, headerMutation)
+		require.Nil(t, bodyMutation)
+	})
+
+	t.Run("read_error", func(t *testing.T) {
+		respHeaders := map[string]string{
+			statusHeaderName:      "500",
+			contentTypeHeaderName: "text/plain",
+		}
+		headerMutation, bodyMutation, err := translator.ResponseError(respHeaders, alwaysErrReader{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to read error body")
+		require.Nil(t, headerMutation)
+		require.Nil(t, bodyMutation)
+	})
+}
+
+type mockEmbedSpanTranslator struct{ recordCalled bool }
+
+func (m *mockEmbedSpanTranslator) EndSpan()                   {}
+func (m *mockEmbedSpanTranslator) EndSpanOnError(int, []byte) {}
+func (m *mockEmbedSpanTranslator) RecordResponse(_ *cohereschema.EmbedV2Response) {
+	m.recordCalled = true
+}
+func (m *mockEmbedSpanTranslator) RecordResponseChunk(*struct{}) {}
+
+func TestCohereToCohereTranslatorV2Embed_ResponseBody_RecordsResponseInSpan(t *testing.T) {
+	mspan := &mockEmbedSpanTranslator{}
+	tr := NewEmbedCohereToCohereTranslator("v2", "")
+	tr.(*cohereToCohereTranslatorV2Embed).requestModel = "embed-v4.0"
+
+	body := `{"embeddings":[[0.1, 0.2, 0.3]],"id":"em-456"}`
+	_, _, _, _, err := tr.ResponseBody(
+		map[string]string{contentTypeHeaderName: jsonContentType},
+		strings.NewReader(body),
+		true,
+		mspan,
+	)
+	require.NoError(t, err)
+	require.True(t, mspan.recordCalled)
+}

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -121,6 +121,8 @@ type (
 	OpenAICompletionTranslator = Translator[openai.CompletionRequest, tracingapi.CompletionSpan]
 	// CohereRerankTranslator translates the Cohere's /v2/rerank endpoint.
 	CohereRerankTranslator = Translator[cohereschema.RerankV2Request, tracingapi.RerankSpan]
+	// CohereEmbedTranslator translates the Cohere's /v2/embed endpoint.
+	CohereEmbedTranslator = Translator[cohereschema.EmbedV2Request, tracingapi.EmbedSpan]
 	// AnthropicMessagesTranslator translates the Anthropic's /messages endpoint.
 	AnthropicMessagesTranslator = Translator[anthropicschema.MessagesRequest, tracingapi.MessageSpan]
 	// OpenAIImageGenerationTranslator translates the OpenAI's /images/generations endpoint.

--- a/site/docs/capabilities/observability/metrics.md
+++ b/site/docs/capabilities/observability/metrics.md
@@ -24,6 +24,7 @@ Metrics are collected for the following LLM endpoints:
 - **`/v1/completions`** - Legacy text completions (streaming and non-streaming)
 - **`/v1/embeddings`** - Text embeddings
 - **`/cohere/v2/rerank`** - Rerank
+- **`/cohere/v2/embed`** - Cohere embeddings
 - **`/anthropic/v1/messages`** - Anthropic messages (streaming and non-streaming)
 
 For example, the Envoy AI Gateway collects metrics such as:
@@ -38,7 +39,7 @@ Each metric comes with some default attributes such as:
 - `gen_ai.operation.name`
   - `chat`: For `/v1/chat/completions` endpoint.
   - `completion`: For `/v1/completions` endpoint.
-  - `embedding`: For `/v1/embeddings` endpoint.
+  - `embedding`: For `/v1/embeddings` and `/cohere/v2/embed` endpoint.
   - `rerank`: For `/cohere/v2/rerank` endpoint.
   - `image_generation`: For `/v1/images/generations` endpoint.
   - `messages`: For `/anthropic/v1/messages` endpoint.


### PR DESCRIPTION
**Description**

Current support of Cohere provider is limited to rerank endpoint `/cohere/v2/rerank`. This PR complements it by adding the Cohere native Embed V2 endpoint `/cohere/v2/embed` [1].

**Related Issues/PRs (if applicable)**

No relevant PRs submitted so far.

**Special notes for reviewers (if applicable)**

This PR closely follows the OpenAI `/v1/embeddings` endpoints, but as the API spec and feature range of the two providers are slightly different, some features (mostly the nonstandard output dtypes including ubinary) are left as todo.

1: https://docs.cohere.com/reference/embed