### PR TITLE
feat: add --logFormat=json for structured logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,10 @@ helm-test: helm-package  ## Test the helm chart with a dummy version.
 	@$(GO_TOOL) helm template ${HELM_CHART_PATH} --set global.imagePullSecrets[0].name=testsecret | grep -q "imagePullSecrets:"
 	@$(GO_TOOL) helm template ${HELM_CHART_PATH} --set global.imagePullSecrets[0].name=testsecret | grep -q "name: testsecret"
 	@$(GO_TOOL) helm template ${HELM_CHART_PATH} --set global.imagePullSecrets[0].name=testsecret | grep -q -- "extProcImagePullSecrets=testsecret"
+	@$(GO_TOOL) helm template ${HELM_CHART_PATH} | grep -q -- "-logFormat=text"
+	@$(GO_TOOL) helm template ${HELM_CHART_PATH} | grep -q -- "extProcLogFormat=text"
+	@$(GO_TOOL) helm template ${HELM_CHART_PATH} --set controller.logFormat=json --set extProc.logFormat=json | grep -q -- "-logFormat=json"
+	@$(GO_TOOL) helm template ${HELM_CHART_PATH} --set controller.logFormat=json --set extProc.logFormat=json | grep -q -- "extProcLogFormat=json"
 
 # This pushes the helm chart to the OCI registry, requiring the access to the registry endpoint.
 .PHONY: helm-push

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -40,6 +40,8 @@ import (
 type flags struct {
 	envoyGatewayNamespace          string
 	extProcLogLevel                string
+	extProcLogFormat               string
+	logFormat                      string
 	extProcEnableRedaction         bool
 	extProcImage                   string
 	extProcImagePullPolicy         corev1.PullPolicy
@@ -119,6 +121,11 @@ func parseAndValidateFlags(args []string) (*flags, error) {
 		"info",
 		"The log level for the external processor. One of 'debug', 'info', 'warn', or 'error'.",
 	)
+	extProcLogFormatPtr := fs.String(
+		"extProcLogFormat",
+		internalapi.LogFormatText,
+		"The log output format for the external processor. One of 'text' or 'json'.",
+	)
 	extProcEnableRedactionPtr := fs.Bool(
 		"extProcEnableRedaction",
 		false,
@@ -143,6 +150,11 @@ func parseAndValidateFlags(args []string) (*flags, error) {
 		"logLevel",
 		"info",
 		"The log level for the controller manager. One of 'debug', 'info', 'warn', or 'error'.",
+	)
+	logFormatPtr := fs.String(
+		"logFormat",
+		internalapi.LogFormatText,
+		"The log output format for the controller manager. One of 'text' or 'json'.",
 	)
 	extensionServerPortPtr := fs.String(
 		"port",
@@ -266,6 +278,13 @@ func parseAndValidateFlags(args []string) (*flags, error) {
 		return nil, err
 	}
 
+	if err := internalapi.ValidateLogFormat(*logFormatPtr); err != nil {
+		return nil, err
+	}
+	if err := internalapi.ValidateLogFormat(*extProcLogFormatPtr); err != nil {
+		return nil, fmt.Errorf("external processor: %w", err)
+	}
+
 	extProcPullPolicy, err := parsePullPolicy(*extProcImagePullPolicyPtr)
 	if err != nil {
 		return nil, err
@@ -336,6 +355,8 @@ func parseAndValidateFlags(args []string) (*flags, error) {
 	return &flags{
 		envoyGatewayNamespace:                  *envoyGatewayNamespace,
 		extProcLogLevel:                        *extProcLogLevelPtr,
+		extProcLogFormat:                       *extProcLogFormatPtr,
+		logFormat:                              *logFormatPtr,
 		extProcEnableRedaction:                 *extProcEnableRedactionPtr,
 		extProcImage:                           *extProcImagePtr,
 		extProcImagePullPolicy:                 extProcPullPolicy,
@@ -369,6 +390,24 @@ func parseAndValidateFlags(args []string) (*flags, error) {
 	}, nil
 }
 
+// newZapOpts builds the controller-runtime logger options for the requested log output format.
+//
+// zap.UseFlagOptions assigns the whole Options struct, so it has to stay first: an encoder chosen
+// before it would be silently discarded and the logger would fall back to console output.
+func newZapOpts(logFormat string, level zapcore.LevelEnabler) []zap.Opts {
+	opts := []zap.Opts{zap.UseFlagOptions(&zap.Options{Development: true, Level: level})}
+	if logFormat == internalapi.LogFormatJSON {
+		// Development defaults the encoder to console; override it so structured log pipelines get JSON.
+		// zap.JSONEncoder builds the encoder eagerly, which skips the RFC3339 time encoder that
+		// controller-runtime would otherwise apply, so pass it explicitly to keep timestamps in the
+		// same format the console encoder prints instead of zap's production epoch float.
+		opts = append(opts, zap.JSONEncoder(func(ec *zapcore.EncoderConfig) {
+			ec.EncodeTime = zapcore.RFC3339TimeEncoder
+		}))
+	}
+	return opts
+}
+
 func main() {
 	setupLog := ctrl.Log.WithName("setup")
 
@@ -378,7 +417,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true, Level: parsedFlags.logLevel})))
+	ctrl.SetLogger(zap.New(newZapOpts(parsedFlags.logFormat, parsedFlags.logLevel)...))
 	k8sConfig := ctrl.GetConfigOrDie()
 
 	lis, err := net.Listen("tcp", parsedFlags.extensionServerPort)
@@ -455,6 +494,7 @@ func main() {
 		ExtProcImage:                           parsedFlags.extProcImage,
 		ExtProcImagePullPolicy:                 parsedFlags.extProcImagePullPolicy,
 		ExtProcLogLevel:                        parsedFlags.extProcLogLevel,
+		ExtProcLogFormat:                       parsedFlags.extProcLogFormat,
 		ExtProcEnableRedaction:                 parsedFlags.extProcEnableRedaction,
 		EnableLeaderElection:                   parsedFlags.enableLeaderElection,
 		UDSPath:                                extProcUDSPath,

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -6,17 +6,24 @@
 package main
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/json"
 )
 
 func Test_parseAndValidateFlags(t *testing.T) {
@@ -24,6 +31,8 @@ func Test_parseAndValidateFlags(t *testing.T) {
 		f, err := parseAndValidateFlags([]string{})
 		require.Equal(t, "envoy-gateway-system", f.envoyGatewayNamespace)
 		require.Equal(t, "info", f.extProcLogLevel)
+		require.Equal(t, "text", f.extProcLogFormat)
+		require.Equal(t, "text", f.logFormat)
 		require.False(t, f.extProcEnableRedaction)
 		require.Equal(t, "docker.io/envoyproxy/ai-gateway-extproc:latest", f.extProcImage)
 		require.Equal(t, corev1.PullIfNotPresent, f.extProcImagePullPolicy)
@@ -51,6 +60,8 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				args := []string{
 					tc.dash + "envoyGatewayNamespace=eg-system",
 					tc.dash + "extProcLogLevel=debug",
+					tc.dash + "extProcLogFormat=json",
+					tc.dash + "logFormat=json",
 					tc.dash + "extProcEnableRedaction=true",
 					tc.dash + "extProcImage=example.com/extproc:latest",
 					tc.dash + "extProcImagePullPolicy=Always",
@@ -74,6 +85,8 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				f, err := parseAndValidateFlags(args)
 				require.Equal(t, "eg-system", f.envoyGatewayNamespace)
 				require.Equal(t, "debug", f.extProcLogLevel)
+				require.Equal(t, "json", f.extProcLogFormat)
+				require.Equal(t, "json", f.logFormat)
 				require.True(t, f.extProcEnableRedaction)
 				require.Equal(t, "example.com/extproc:latest", f.extProcImage)
 				require.Equal(t, corev1.PullAlways, f.extProcImagePullPolicy)
@@ -163,6 +176,16 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				expErr: "invalid endpoint prefixes",
 			},
 			{
+				name:   "invalid log format",
+				flags:  []string{"--logFormat=yaml"},
+				expErr: `invalid log format: "yaml", must be "text" or "json"`,
+			},
+			{
+				name:   "invalid extproc log format",
+				flags:  []string{"--extProcLogFormat=yaml"},
+				expErr: `external processor: invalid log format: "yaml", must be "text" or "json"`,
+			},
+			{
 				name:   "invalid mcp session encryption iterations",
 				flags:  []string{"--mcpSessionEncryptionIterations=invalid"},
 				expErr: `invalid value "invalid" for flag -mcpSessionEncryptionIterations: parse error`,
@@ -187,6 +210,45 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				_, err := parseAndValidateFlags(tc.flags)
 				require.ErrorContains(t, err, tc.expErr)
 			})
+		}
+	})
+}
+
+func Test_newZapOpts(t *testing.T) {
+	logTo := func(t *testing.T, logFormat string) string {
+		t.Helper()
+		var buf bytes.Buffer
+		opts := append(newZapOpts(logFormat, zapcore.InfoLevel), zap.WriteTo(&buf))
+		zap.New(opts...).Info("starting controller", "address", ":1063")
+		return buf.String()
+	}
+
+	t.Run("json emits parseable records", func(t *testing.T) {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(logTo(t, internalapi.LogFormatJSON)), &record))
+		require.Equal(t, "starting controller", record["msg"])
+		require.Equal(t, ":1063", record["address"])
+		require.Equal(t, "info", record["level"])
+	})
+
+	t.Run("json timestamps stay RFC3339", func(t *testing.T) {
+		// zap.JSONEncoder builds the encoder eagerly, which drops controller-runtime's default time
+		// encoder unless it is passed explicitly. Without that the ts field is an epoch float, which
+		// disagrees with what the console format prints.
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(logTo(t, internalapi.LogFormatJSON)), &record))
+		ts, ok := record["ts"].(string)
+		require.True(t, ok, "ts must be a string, got %T", record["ts"])
+		_, err := time.Parse(time.RFC3339, ts)
+		require.NoError(t, err)
+	})
+
+	t.Run("text stays console and is the fallback", func(t *testing.T) {
+		for _, format := range []string{internalapi.LogFormatText, ""} {
+			out := logTo(t, format)
+			require.Contains(t, out, "starting controller")
+			var record map[string]any
+			require.Error(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &record), "console output must not be JSON")
 		}
 	})
 }

--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -43,6 +43,7 @@ type extProcFlags struct {
 	configBundlePath                       string        // path to the sharded configuration bundle directory.
 	extProcAddr                            string        // gRPC address for the external processor.
 	logLevel                               slog.Level    // log level for the external processor.
+	logFormat                              string        // log output format for the external processor, "text" or "json".
 	enableRedaction                        bool          // enable redaction of sensitive information in debug logs.
 	adminPort                              int           // HTTP port for the admin server (metrics and health).
 	requestHeaderAttributes                *string       // comma-separated key-value pairs for mapping HTTP request headers to otel attributes shared across metrics, spans, and access logs.
@@ -61,6 +62,16 @@ type extProcFlags struct {
 	maxRecvMsgSize int
 	// endpointPrefixes is the comma-separated key-value pairs for endpoint prefixes.
 	endpointPrefixes string
+}
+
+// newLogHandler returns the slog handler for the requested output format. Anything other than
+// json gets the text handler, which is what the external processor has always emitted.
+func newLogHandler(w io.Writer, level slog.Level, format string) slog.Handler {
+	opts := &slog.HandlerOptions{Level: level}
+	if format == internalapi.LogFormatJSON {
+		return slog.NewJSONHandler(w, opts)
+	}
+	return slog.NewTextHandler(w, opts)
 }
 
 func setOptionalString(dst **string) func(string) error {
@@ -98,6 +109,11 @@ func parseAndValidateFlags(args []string) (extProcFlags, error) {
 		"logLevel",
 		"info",
 		"log level for the external processor. One of 'debug', 'info', 'warn', or 'error'.",
+	)
+	fs.StringVar(&flags.logFormat,
+		"logFormat",
+		internalapi.LogFormatText,
+		"log output format for the external processor. One of 'text' or 'json'.",
 	)
 	fs.BoolVar(&flags.enableRedaction, "enableRedaction", false,
 		"Enable redaction of sensitive information in debug logs.")
@@ -155,6 +171,9 @@ func parseAndValidateFlags(args []string) (extProcFlags, error) {
 	if err := flags.logLevel.UnmarshalText([]byte(*logLevelPtr)); err != nil {
 		errs = append(errs, fmt.Errorf("failed to unmarshal log level: %w", err))
 	}
+	if err := internalapi.ValidateLogFormat(flags.logFormat); err != nil {
+		errs = append(errs, err)
+	}
 	if flags.requestHeaderAttributes != nil && *flags.requestHeaderAttributes != "" {
 		if _, err := internalapi.ParseRequestHeaderAttributeMapping(*flags.requestHeaderAttributes); err != nil {
 			errs = append(errs, fmt.Errorf("failed to parse request header mapping: %w", err))
@@ -205,7 +224,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 		return fmt.Errorf("failed to parse and validate extProcFlags: %w", err)
 	}
 
-	l := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: flags.logLevel}))
+	l := slog.New(newLogHandler(stderr, flags.logLevel, flags.logFormat))
 
 	l.Info("starting external processor",
 		slog.String("version", version.Parse()),

--- a/cmd/extproc/mainlib/main_test.go
+++ b/cmd/extproc/mainlib/main_test.go
@@ -7,6 +7,7 @@ package mainlib
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -18,7 +19,42 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/json"
 )
+
+func Test_newLogHandler(t *testing.T) {
+	t.Run("json emits parseable records", func(t *testing.T) {
+		var buf bytes.Buffer
+		slog.New(newLogHandler(&buf, slog.LevelInfo, internalapi.LogFormatJSON)).
+			Info("starting external processor", slog.String("address", ":1063"))
+
+		var record map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &record))
+		require.Equal(t, "starting external processor", record["msg"])
+		require.Equal(t, ":1063", record["address"])
+		require.Equal(t, "INFO", record["level"])
+	})
+
+	t.Run("text is unchanged and is the fallback", func(t *testing.T) {
+		for _, format := range []string{internalapi.LogFormatText, ""} {
+			var buf bytes.Buffer
+			slog.New(newLogHandler(&buf, slog.LevelInfo, format)).
+				Info("starting external processor", slog.String("address", ":1063"))
+
+			require.Contains(t, buf.String(), `msg="starting external processor" address=:1063`)
+			var record map[string]any
+			require.Error(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &record), "text output must not be JSON")
+		}
+	})
+
+	t.Run("level is honored", func(t *testing.T) {
+		var buf bytes.Buffer
+		slog.New(newLogHandler(&buf, slog.LevelWarn, internalapi.LogFormatJSON)).Info("filtered out")
+		require.Empty(t, buf.String())
+	})
+}
 
 func Test_parseAndValidateFlags(t *testing.T) {
 	t.Run("ok extProcFlags", func(t *testing.T) {
@@ -30,6 +66,7 @@ func Test_parseAndValidateFlags(t *testing.T) {
 			addr             string
 			rootPrefix       string
 			logLevel         slog.Level
+			logFormat        string
 			enableRedaction  bool
 		}{
 			{
@@ -39,6 +76,17 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				addr:            ":1063",
 				rootPrefix:      "/",
 				logLevel:        slog.LevelInfo,
+				logFormat:       "text",
+				enableRedaction: false,
+			},
+			{
+				name:            "log format json",
+				args:            []string{"-configPath", "/path/to/config.yaml", "-logFormat", "json"},
+				configPath:      "/path/to/config.yaml",
+				addr:            ":1063",
+				rootPrefix:      "/",
+				logLevel:        slog.LevelInfo,
+				logFormat:       "json",
 				enableRedaction: false,
 			},
 			{
@@ -175,6 +223,12 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				require.Equal(t, tc.configBundlePath, flags.configBundlePath)
 				require.Equal(t, tc.addr, flags.extProcAddr)
 				require.Equal(t, tc.logLevel, flags.logLevel)
+				// Cases that do not care about the format expect the default.
+				wantLogFormat := tc.logFormat
+				if wantLogFormat == "" {
+					wantLogFormat = "text"
+				}
+				require.Equal(t, wantLogFormat, flags.logFormat)
 				require.Equal(t, tc.enableRedaction, flags.enableRedaction)
 				require.Equal(t, tc.rootPrefix, flags.rootPrefix)
 			})
@@ -191,6 +245,11 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				name:          "invalid log level",
 				args:          []string{"-logLevel", "invalid"},
 				expectedError: "either configPath or configBundlePath must be provided\nfailed to unmarshal log level: slog: level string \"invalid\": unknown name",
+			},
+			{
+				name:          "invalid log format",
+				args:          []string{"-configPath", "/path/to/config.yaml", "-logFormat", "yaml"},
+				expectedError: `invalid log format: "yaml", must be "text" or "json"`,
 			},
 			{
 				name:          "invalid endpoint prefixes - unknown key",

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -65,6 +65,9 @@ var Scheme = runtime.NewScheme()
 type Options struct {
 	// ExtProcLogLevel is the log level for the external processor, e.g., debug, info, warn, or error.
 	ExtProcLogLevel string
+	// ExtProcLogFormat is the log output format for the external processor, "text" or "json".
+	// Empty means the extproc default, which is text.
+	ExtProcLogFormat string
 	// ExtProcEnableRedaction enables redaction of sensitive information in debug logs for the external processor.
 	ExtProcEnableRedaction bool
 	// ExtProcImage is the image for the external processor set on Deployment.

--- a/internal/controller/extproc_builder.go
+++ b/internal/controller/extproc_builder.go
@@ -58,6 +58,7 @@ func newExtProcBuilder(options *Options, extProcAsSideCar bool, logger logr.Logg
 		image:                                  options.ExtProcImage,
 		imagePullPolicy:                        options.ExtProcImagePullPolicy,
 		logLevel:                               options.ExtProcLogLevel,
+		logFormat:                              options.ExtProcLogFormat,
 		enableRedaction:                        options.ExtProcEnableRedaction,
 		udsPath:                                options.UDSPath,
 		requestHeaderAttributes:                options.RequestHeaderAttributes,
@@ -83,6 +84,7 @@ type extProcBuilder struct {
 	image           string
 	imagePullPolicy corev1.PullPolicy
 	logLevel        string
+	logFormat       string
 	enableRedaction bool
 	udsPath         string
 
@@ -203,9 +205,12 @@ func (b *extProcBuilder) buildExtProcContainer(input extProcContainerInput) core
 // extProcConfigDigest contains the config inputs that affect extproc injection.
 // It intentionally avoids hashing the full Kubernetes Container API object.
 type extProcConfigDigest struct {
-	Image                                  string
-	ImagePullPolicy                        corev1.PullPolicy
-	LogLevel                               string
+	Image           string
+	ImagePullPolicy corev1.PullPolicy
+	LogLevel        string
+	// LogFormat is omitted when it is the default, so deployments that never asked for JSON keep
+	// the same hash as before this field existed and are not rolled on upgrade.
+	LogFormat                              string `json:",omitempty"`
 	EnableRedaction                        bool
 	UDSPath                                string
 	RequestHeaderAttributes                *string
@@ -232,6 +237,7 @@ func (b *extProcBuilder) extProcContainerHash(input extProcContainerInput) strin
 		Image:                                  b.extProcImage(input),
 		ImagePullPolicy:                        b.imagePullPolicy,
 		LogLevel:                               b.logLevel,
+		LogFormat:                              b.nonDefaultLogFormat(),
 		EnableRedaction:                        b.enableRedaction,
 		UDSPath:                                b.udsPath,
 		RequestHeaderAttributes:                b.requestHeaderAttributes,
@@ -267,6 +273,16 @@ func (b *extProcBuilder) extProcImage(input extProcContainerInput) string {
 	return b.resolveExtProcImage(extProcSpecFromInput(input))
 }
 
+// nonDefaultLogFormat returns the configured log format only when it differs from the extproc
+// default. The extproc already emits text without being told to, so passing it explicitly would
+// change the container args and hash of every existing deployment for no behavioral difference.
+func (b *extProcBuilder) nonDefaultLogFormat() string {
+	if b.logFormat == internalapi.LogFormatText {
+		return ""
+	}
+	return b.logFormat
+}
+
 // buildExtProcBaseArgs builds the command line arguments for the extproc
 // container excluding the secret-presence-driven -configPath / -configBundlePath
 // flags. The mutating webhook prepends those based on which filter-config
@@ -278,6 +294,9 @@ func (b *extProcBuilder) buildExtProcBaseArgs(needMCP bool) []string {
 		"-adminPort", fmt.Sprintf("%d", extProcAdminPort),
 		"-rootPrefix", b.rootPrefix,
 		"-maxRecvMsgSize", fmt.Sprintf("%d", b.maxRecvMsgSize),
+	}
+	if f := b.nonDefaultLogFormat(); f != "" {
+		args = append(args, "-logFormat", f)
 	}
 	if needMCP {
 		args = append(args,

--- a/internal/controller/extproc_builder_test.go
+++ b/internal/controller/extproc_builder_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 )
 
 // newTestBuilder returns an extProcBuilder with the standard test defaults. It is
@@ -78,7 +79,7 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 	input := extProcContainerInput{}
 	baseHash := base.extProcContainerHash(input)
 	require.NotEmpty(t, baseHash)
-	require.Equal(t, 19, reflect.TypeOf(extProcBuilder{}).NumField(),
+	require.Equal(t, 20, reflect.TypeOf(extProcBuilder{}).NumField(),
 		"update drift coverage when extProcBuilder fields change")
 
 	// Helper: mutate a copy of the builder, recompute, expect a different hash.
@@ -133,6 +134,11 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 	assertDrifts("logLevel", func() *extProcBuilder {
 		b := newTestBuilder()
 		b.logLevel = "debug"
+		return b
+	}())
+	assertDrifts("logFormat", func() *extProcBuilder {
+		b := newTestBuilder()
+		b.logFormat = internalapi.LogFormatJSON
 		return b
 	}())
 	assertDrifts("requestHeaderAttributes", func() *extProcBuilder {
@@ -244,6 +250,31 @@ func TestExtProcContainerHash_ExcludesConfigRoutingArgs(t *testing.T) {
 	}
 	require.Equal(t, baseHash, b.extProcContainerHash(input),
 		"secret-presence-driven config routing must not affect the workload template hash")
+}
+
+// TestBuildExtProcBaseArgs_LogFormat asserts that -logFormat reaches the extproc container only
+// when it differs from the extproc default, so existing deployments keep the args they already have.
+func TestBuildExtProcBaseArgs_LogFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		logFormat string
+	}{
+		{name: "unset", logFormat: ""},
+		{name: "explicit default", logFormat: internalapi.LogFormatText},
+	} {
+		t.Run("not passed when "+tc.name, func(t *testing.T) {
+			b := newTestBuilder()
+			b.logFormat = tc.logFormat
+			require.NotContains(t, b.buildExtProcBaseArgs(false), "-logFormat")
+		})
+	}
+
+	t.Run("passed when json", func(t *testing.T) {
+		b := newTestBuilder()
+		b.logFormat = internalapi.LogFormatJSON
+		args := b.buildExtProcBaseArgs(false)
+		require.Equal(t, []string{"-logFormat", internalapi.LogFormatJSON}, args[len(args)-2:])
+	})
 }
 
 // TestNewExtProcBuilder_MalformedInput covers the defensive parse-error log

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -70,6 +70,22 @@ var MCPInternalHeadersToMetadata = map[string]string{
 }
 
 const (
+	// LogFormatText selects human-readable log output. This is the default for every binary.
+	LogFormatText = "text"
+	// LogFormatJSON selects JSON log output, for log pipelines that parse structured records.
+	LogFormatJSON = "json"
+)
+
+// ValidateLogFormat checks that format is one of the supported log output formats. Callers that
+// validate another binary's format wrap the error to say whose it is.
+func ValidateLogFormat(format string) error {
+	if format != LogFormatText && format != LogFormatJSON {
+		return fmt.Errorf("invalid log format: %q, must be %q or %q", format, LogFormatText, LogFormatJSON)
+	}
+	return nil
+}
+
+const (
 	// EndpointPickerHeaderKey is the header key used to specify the target backend endpoint.
 	// This is the default header name in the reference implementation:
 	// https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/2b5b337b45c3289e5f9367b2c19deef021722fcd/pkg/epp/server/runserver.go#L63

--- a/manifests/charts/ai-gateway-helm/templates/deployment.yaml
+++ b/manifests/charts/ai-gateway-helm/templates/deployment.yaml
@@ -50,9 +50,11 @@ spec:
             {{- end }}
           args:
             - -logLevel={{ .Values.controller.logLevel }}
+            - -logFormat={{ .Values.controller.logFormat }}
             - --extProcImage={{ .Values.extProc.image.repository }}:{{ .Values.extProc.image.tag | default .Chart.AppVersion }}
             - --extProcImagePullPolicy={{ .Values.extProc.imagePullPolicy }}
             - --extProcLogLevel={{ .Values.extProc.logLevel }}
+            - --extProcLogFormat={{ .Values.extProc.logFormat }}
             - --envoyGatewayNamespace={{ .Values.envoyGateway.namespace }}
             {{- if .Values.extProc.enableRedaction }}
             - --extProcEnableRedaction=true

--- a/manifests/charts/ai-gateway-helm/values.yaml
+++ b/manifests/charts/ai-gateway-helm/values.yaml
@@ -45,6 +45,9 @@ extProc:
   imagePullSecrets: []
   # One of "info", "debug", "trace", "warn", "error", "fatal", "panic".
   logLevel: info
+  # Log output format. One of "text" or "json". Set to "json" when logs are ingested by a pipeline
+  # that parses structured records, such as Cloud Logging, Loki, Datadog or ELK.
+  logFormat: text
   # Enable redaction of sensitive information in debug logs (only takes effect when logLevel is "debug").
   enableRedaction: false
 
@@ -67,6 +70,9 @@ extProc:
 
 controller:
   logLevel: info
+  # Log output format. One of "text" or "json". Set to "json" when logs are ingested by a pipeline
+  # that parses structured records, such as Cloud Logging, Loki, Datadog or ELK.
+  logFormat: text
   nameOverride: ""
   fullnameOverride: "ai-gateway-controller"
 


### PR DESCRIPTION
**Description**

Adds `--logFormat=json` to the controller and the external processor, so their logs can be parsed by a structured log pipeline.

Today neither binary can emit JSON. The controller logs through zap in development console format (`cmd/controller/main.go:417`) and the extproc through slog's text handler (`cmd/extproc/mainlib/main.go:208`):

```
time=2026-08-05T09:23:47.743+05:30 level=INFO msg="starting external processor" version=dev address=:1063 configPath=/nonexistent.yaml configBundlePath=""
```

Anything ingesting that — Cloud Logging, Loki, Datadog, ELK — stores it as an opaque string, so `version`, `address` and `configPath` are not queryable fields.

**Example**

Same extproc startup line with the flag set:

```shell
aigw-extproc -configPath /etc/aigw/config.yaml -logFormat json
```

```json
{"time":"2026-08-05T09:23:48.593648+05:30","level":"INFO","msg":"starting external processor","version":"dev","address":":1063","configPath":"/nonexistent.yaml","configBundlePath":""}
```

And the controller, console vs json for the same event (error string truncated here):

```
2026-08-05T09:23:34+05:30	ERROR	controller-runtime.client.config	unable to get kubeconfig	{"error": "invalid configuration: no configuration has been provided…"}
```

```json
{"level":"error","ts":1785901994.999012,"logger":"controller-runtime.client.config","msg":"unable to get kubeconfig","error":"invalid configuration: no configuration has been provided…","stacktrace":"sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie\n\t…"}
```

Three flags:

- `--logFormat` on the controller, which swaps the zap encoder
- `--logFormat` on the extproc, which swaps the slog handler
- `--extProcLogFormat` on the controller, which is passed through to the extproc containers it injects — without it the extproc pods, which produce most of the log volume, would stay on text in a Kubernetes install

`text` is the default for all three and output is unchanged unless json is asked for.

**Related Issues/PRs (if applicable)**

None.

**Special notes for reviewers (if applicable)**

None.