### PR TITLE
feat: honour HTTP trace context for MCP requests

### DIFF
--- a/internal/tracing/mcp.go
+++ b/internal/tracing/mcp.go
@@ -93,7 +93,8 @@ func (m mcpTracer) StartSpanAndInjectMeta(ctx context.Context, req *jsonrpc.Requ
 		}
 	}
 
-	// Extract trace context from incoming meta.
+	// Extract trace context: headers first, then _meta on top. Extract returns the context it was
+	// given when a carrier holds none, so either source alone works.
 	mutableMeta := param.GetMeta()
 	if mutableMeta == nil {
 		mutableMeta = make(map[string]any)
@@ -101,7 +102,8 @@ func (m mcpTracer) StartSpanAndInjectMeta(ctx context.Context, req *jsonrpc.Requ
 	mc := metaMapCarrier{
 		m: mutableMeta,
 	}
-	parentCtx := m.propagator.Extract(ctx, mc)
+	parentCtx := m.propagator.Extract(ctx, propagation.HeaderCarrier(headers))
+	parentCtx = m.propagator.Extract(parentCtx, mc)
 
 	// Start the span with options appropriate for the semantic convention.
 	// Convert method name to span name following mcp-go SDK patterns

--- a/internal/tracing/mcp_test.go
+++ b/internal/tracing/mcp_test.go
@@ -102,6 +102,80 @@ func TestTracer_StartSpanAndInjectMeta_MetaAndHeaderFallback(t *testing.T) {
 	}
 }
 
+func TestTracer_StartSpanAndInjectMeta_ParentTraceContext(t *testing.T) {
+	const (
+		headerTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+		headerSpanID  = "00f067aa0ba902b7"
+		metaTraceID   = "0af7651916cd43dd8448eb211c80319c"
+		metaSpanID    = "b7ad6b7169203331"
+	)
+	traceparent := func(traceID, spanID string) string {
+		return "00-" + traceID + "-" + spanID + "-01"
+	}
+	meta := func(traceID, spanID string) map[string]any {
+		return map[string]any{"traceparent": traceparent(traceID, spanID)}
+	}
+
+	cases := []struct {
+		name            string
+		headers         http.Header
+		meta            map[string]any
+		expectedTraceID string
+		expectedSpanID  string
+	}{
+		{
+			name:            "header only becomes the parent",
+			headers:         http.Header{"Traceparent": []string{traceparent(headerTraceID, headerSpanID)}},
+			expectedTraceID: headerTraceID,
+			expectedSpanID:  headerSpanID,
+		},
+		{
+			name:            "meta only becomes the parent",
+			meta:            meta(metaTraceID, metaSpanID),
+			expectedTraceID: metaTraceID,
+			expectedSpanID:  metaSpanID,
+		},
+		{
+			name:            "meta wins when both are present",
+			headers:         http.Header{"Traceparent": []string{traceparent(headerTraceID, headerSpanID)}},
+			meta:            meta(metaTraceID, metaSpanID),
+			expectedTraceID: metaTraceID,
+			expectedSpanID:  metaSpanID,
+		},
+		{
+			name:    "invalid header traceparent is ignored",
+			headers: http.Header{"Traceparent": []string{"not-a-traceparent"}},
+		},
+		{
+			name: "no trace context anywhere starts a root span",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			tp := trace.NewTracerProvider(trace.WithSyncer(exporter))
+			tracer := newMCPTracer(tp.Tracer("test"), autoprop.NewTextMapPropagator(), nil)
+
+			reqID, _ := jsonrpc.MakeID("id")
+			span := tracer.StartSpanAndInjectMeta(t.Context(),
+				&jsonrpc.Request{ID: reqID, Method: "initialize"},
+				&mcp.InitializeParams{Meta: tc.meta}, tc.headers)
+			require.NotNil(t, span)
+			span.EndSpan()
+
+			spans := exporter.GetSpans()
+			require.Len(t, spans, 1)
+			if tc.expectedTraceID == "" {
+				require.False(t, spans[0].Parent.IsValid(), "span must be a trace root")
+				return
+			}
+			require.Equal(t, tc.expectedTraceID, spans[0].SpanContext.TraceID().String())
+			require.Equal(t, tc.expectedSpanID, spans[0].Parent.SpanID().String())
+		})
+	}
+}
+
 func Test_getMCPAttributes(t *testing.T) {
 	cases := []struct {
 		p        mcp.Params

--- a/internal/tracing/tracingapi/mcp.go
+++ b/internal/tracing/tracingapi/mcp.go
@@ -18,11 +18,14 @@ type MCPTracer interface {
 	// StartSpanAndInjectMeta starts a span and injects trace context into
 	// the _meta mutation.
 	//
+	// The parent trace context is taken from the HTTP headers first, then the JSON-RPC _meta on
+	// top, so _meta wins when a client propagates in both. Either source alone works.
+	//
 	// Parameters:
 	//   - ctx: might include a parent span context.
 	//   - req: Incoming MCP request message.
 	//   - param: Incoming MCP parameter used to extract parent trace context.
-	//   - headers: Request HTTP request headers.
+	//   - headers: Request HTTP request headers, also used to extract parent trace context.
 	//
 	// Returns nil unless the span is sampled.
 	StartSpanAndInjectMeta(ctx context.Context, req *jsonrpc.Request, param mcp.Params, headers http.Header) MCPSpan


### PR DESCRIPTION
**Description**

Makes the MCP proxy honour trace context that a client sets on the HTTP request, not just in the JSON-RPC `_meta` field.

MCP's own propagation lives in `_meta`, and that was the only place `StartSpanAndInjectMeta` looked (`internal/tracing/mcp.go`):

```go
mc := metaMapCarrier{m: mutableMeta}
parentCtx := m.propagator.Extract(ctx, mc)
```

Clients that propagate at the HTTP layer — setting `traceparent` on the POST, which is what an OTel-instrumented HTTP client does by default — get their trace broken at the gateway. The MCP span starts a fresh trace instead of continuing the caller's, so the client's span and the gateway's span end up in two unrelated traces.

`StartSpanAndInjectMeta` already receives the request headers, and already reads them for custom attribute mapping, so this just extracts from them before extracting from `_meta`:

```go
parentCtx := m.propagator.Extract(ctx, propagation.HeaderCarrier(headers))
parentCtx = m.propagator.Extract(parentCtx, mc)
```

`_meta` still wins when a client propagates in both, since `Extract` returns the context it was given when a carrier holds no trace context. Using the configured propagator rather than parsing `traceparent` directly means this also works for deployments that set `OTEL_PROPAGATORS` to B3 or Jaeger.

**Example**

```shell
curl $GATEWAY_URL/mcp \
  -H 'traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' \
  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{...}}'
```

Before, the MCP span is a trace root. After, it continues trace `4bf92f35…` with parent span `00f067aa0ba902b7`, so the client's span and every backend hop appear in one trace.

**Related Issues/PRs (if applicable)**

None.

**Special notes for reviewers (if applicable)**

Two behaviour changes. Both are standard OTel propagation semantics:

- Sampling is now inherited from the caller. With the default `ParentBased` sampler, a client sending `traceparent` with flags `-00` suppresses the gateway's MCP span, where before the gateway made its own root sampling decision.
- The configured propagator is composite:  tracecontext + baggage by default, so a `baggage` HTTP header is now extracted and then re-injected into the `_meta` forwarded to backends. Previously only `_meta`-supplied baggage was sent. Operators who don't want client baggage reaching upstream MCP servers can strip the header at the edge.
