### PR TITLE
fix: do not publish a partial filter config when a reconcile read is interrupted

### DIFF
--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -8,6 +8,7 @@ package controller
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -334,6 +335,19 @@ func mergeHeaderMutations(routeLevel, backendLevel *aigv1b1.HTTPHeaderMutation) 
 	return result
 }
 
+// isCtxErr reports whether err is the reconcile's context being cancelled or timing out, rather than
+// a problem with the object being read.
+//
+// The distinction matters everywhere reconcileFilterConfigSecret skips a backend on error. Skipping
+// is right when the backend or its policy cannot be resolved — a missing object, a bad ref — because
+// the resulting config reflects the cluster. It is wrong when the read was interrupted, because then
+// the reconcile carries on and publishes a config in which the backend is missing, or present without
+// its credentials, until something triggers another reconcile. Returning instead lets
+// controller-runtime requeue with a fresh context.
+func isCtxErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
 // reconcileFilterConfigSecret updates the filter config secret for the external processor.
 func (c *GatewayController) reconcileFilterConfigSecret(
 	ctx context.Context,
@@ -430,6 +444,9 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 
 					bsp, err = c.getBSPForInferencePool(ctx, backendNamespace, backendRef.Name)
 					if err != nil {
+						if isCtxErr(err) {
+							return false, fmt.Errorf("reconcile interrupted while reading backend security policy for inference pool %s: %w", backendRef.Name, err)
+						}
 						c.logger.Error(err, "failed to get backend security policy for inference pool",
 							"backend_name", backendRef.Name, "aigatewayroute", aiGatewayRoute.Name,
 							"namespace", backendNamespace)
@@ -439,6 +456,9 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 					var backendObj *aigv1b1.AIServiceBackend
 					backendObj, bsp, err = c.backendWithMaybeBSP(ctx, backendNamespace, backendRef.Name)
 					if err != nil {
+						if isCtxErr(err) {
+							return false, fmt.Errorf("reconcile interrupted while reading backend %s: %w", backendRef.Name, err)
+						}
 						c.logger.Error(err, "failed to get backend or backend security policy. Skipping this backend.",
 							"backend_name", backendRef.Name, "aigatewayroute", aiGatewayRoute.Name,
 							"namespace", backendNamespace)
@@ -467,6 +487,9 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 				if bsp != nil {
 					b.Auth, err = c.bspToFilterAPIBackendAuth(ctx, bsp)
 					if err != nil {
+						if isCtxErr(err) {
+							return false, fmt.Errorf("reconcile interrupted while reading auth for backend security policy %s: %w", bsp.Name, err)
+						}
 						c.logger.Error(err, "failed to get backend auth from backend security policy. Skipping this backend.",
 							"backend_name", backendRef.Name, "backend_security_policy", bsp.Name,
 							"aigatewayroute", aiGatewayRoute.Name, "namespace", aiGatewayRoute.Namespace)
@@ -765,7 +788,7 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 		secretName := string(spec.APIKey.SecretRef.Name)
 		apiKey, getErr := c.getSecretData(ctx, namespace, secretName, apiKeyInSecret)
 		if getErr != nil {
-			return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+			return nil, getErr
 		}
 		auth = &filterapi.BackendAuth{APIKey: &filterapi.APIKeyAuth{Key: apiKey}}
 		hasStaticCred = true
@@ -773,7 +796,7 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 		secretName := string(spec.AzureAPIKey.SecretRef.Name)
 		apiKey, getErr := c.getSecretData(ctx, namespace, secretName, apiKeyInSecret)
 		if getErr != nil {
-			return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+			return nil, getErr
 		}
 		auth = &filterapi.BackendAuth{AzureAPIKey: &filterapi.AzureAPIKeyAuth{Key: apiKey}}
 		hasStaticCred = true
@@ -781,7 +804,7 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 		secretName := string(spec.AnthropicAPIKey.SecretRef.Name)
 		apiKey, getErr := c.getSecretData(ctx, namespace, secretName, apiKeyInSecret)
 		if getErr != nil {
-			return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+			return nil, getErr
 		}
 		auth = &filterapi.BackendAuth{AnthropicAPIKey: &filterapi.AnthropicAPIKeyAuth{Key: apiKey}}
 		hasStaticCred = true
@@ -807,7 +830,7 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 		}
 		credentialsLiteral, getErr := c.getSecretData(ctx, namespace, secretName, rotators.AwsCredentialsKey)
 		if getErr != nil {
-			return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+			return nil, getErr
 		}
 		// AWS returns early; CredentialOverride is blocked at the API validation layer.
 		return &filterapi.BackendAuth{
@@ -820,7 +843,7 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 		secretName := rotators.GetBSPSecretName(backendSecurityPolicy.Name)
 		azureAccessToken, getErr := c.getSecretData(ctx, namespace, secretName, rotators.AzureAccessTokenKey)
 		if getErr != nil {
-			return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+			return nil, getErr
 		}
 		auth = &filterapi.BackendAuth{AzureAuth: &filterapi.AzureAuth{AccessToken: azureAccessToken}}
 		hasStaticCred = true
@@ -842,7 +865,7 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 			secretName := rotators.GetBSPSecretName(backendSecurityPolicy.Name)
 			gcpAccessToken, getErr := c.getSecretData(ctx, namespace, secretName, rotators.GCPAccessTokenKey)
 			if getErr != nil {
-				return nil, fmt.Errorf("failed to get secret %s: %w", secretName, getErr)
+				return nil, getErr
 			}
 			auth = &filterapi.BackendAuth{
 				GCPAuth: &filterapi.GCPAuth{

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -23,11 +23,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	fake2 "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -1387,6 +1390,99 @@ func TestGatewayController_GetSecretData_ErrorCases(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "secrets \"missing-secret\" not found")
 	require.Empty(t, result)
+}
+
+// TestGatewayController_reconcileFilterConfigSecret_BailsOnContextCanceled pins that a cancelled
+// context aborts the reconcile instead of publishing a filter config in which the backend has no
+// credentials. Skipping the backend, as an unresolvable policy does, would look identical on the wire
+// but silently strip auth from live traffic until something triggers another reconcile.
+func TestGatewayController_reconcileFilterConfigSecret_BailsOnContextCanceled(t *testing.T) {
+	const gwNamespace, configNamespace = "ns", "some-namespace"
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	kube := fake2.NewClientset()
+	// Fail only the credential read. Failing every Secret Get would also break the config-bundle
+	// write and the reconcile would error regardless, which would make this test pass vacuously.
+	kube.PrependReactor("get", "secrets", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if get, ok := a.(k8stesting.GetAction); ok && get.GetName() == "api-key" {
+			return true, nil, context.Canceled
+		}
+		return false, nil, nil
+	})
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: gwNamespace},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+		},
+	}))
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "bsp", Namespace: gwNamespace},
+		Spec: aigv1b1.BackendSecurityPolicySpec{
+			Type:   aigv1b1.BackendSecurityPolicyTypeAPIKey,
+			APIKey: &aigv1b1.BackendSecurityPolicyAPIKey{SecretRef: &gwapiv1.SecretObjectReference{Name: "api-key"}},
+			TargetRefs: []gwapiv1a2.LocalPolicyTargetReference{
+				{Kind: "AIServiceBackend", Group: "aigateway.envoyproxy.io", Name: "apple"},
+			},
+		},
+	}))
+
+	routes := []aigv1b1.AIGatewayRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: gwNamespace},
+		Spec: aigv1b1.AIGatewayRouteSpec{Rules: []aigv1b1.AIGatewayRouteRule{
+			{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}}},
+		}},
+	}}
+
+	_, err := c.reconcileFilterConfigSecret(t.Context(), "gw", gwNamespace, configNamespace, routes, nil, "uuid", nil)
+	require.ErrorIs(t, err, context.Canceled)
+
+	_, getErr := kube.CoreV1().Secrets(configNamespace).Get(t.Context(),
+		FilterConfigBundleIndexSecretName("gw", gwNamespace), metav1.GetOptions{})
+	require.Error(t, getErr, "no filter config may be published when the credential could not be read")
+}
+
+// TestGatewayController_reconcileFilterConfigSecret_BailsOnContextDeadlineReadingBackend is the same
+// invariant one step earlier: an interrupted read of the AIServiceBackend must not publish a config
+// with that backend silently missing. Reads of AIServiceBackend go through the cached client, so this
+// is the rare unsynced-informer case rather than a network call, hence the interceptor.
+func TestGatewayController_reconcileFilterConfigSecret_BailsOnContextDeadlineReadingBackend(t *testing.T) {
+	const gwNamespace, configNamespace = "ns", "some-namespace"
+	inner, ok := requireNewFakeClientWithIndexes(t).(client.WithWatch)
+	require.True(t, ok)
+	fakeClient := interceptor.NewClient(inner, interceptor.Funcs{
+		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isBackend := obj.(*aigv1b1.AIServiceBackend); isBackend {
+				return context.DeadlineExceeded
+			}
+			return cl.Get(ctx, key, obj, opts...)
+		},
+	})
+	kube := fake2.NewClientset()
+	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	require.NoError(t, inner.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: gwNamespace},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			BackendRef: gwapiv1.BackendObjectReference{Name: "some-backend1", Namespace: ptr.To[gwapiv1.Namespace](gwNamespace)},
+		},
+	}))
+
+	routes := []aigv1b1.AIGatewayRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: gwNamespace},
+		Spec: aigv1b1.AIGatewayRouteSpec{Rules: []aigv1b1.AIGatewayRouteRule{
+			{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}}},
+		}},
+	}}
+
+	_, err := c.reconcileFilterConfigSecret(t.Context(), "gw", gwNamespace, configNamespace, routes, nil, "uuid", nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	_, getErr := kube.CoreV1().Secrets(configNamespace).Get(t.Context(),
+		FilterConfigBundleIndexSecretName("gw", gwNamespace), metav1.GetOptions{})
+	require.Error(t, getErr, "no filter config may be published when the backend could not be read")
 }
 
 func TestGatewayController_annotateGatewayPods(t *testing.T) {


### PR DESCRIPTION
**Description**

`reconcileFilterConfigSecret` logs and skips a backend on any error while resolving it, in three places. That is right when the object cannot be resolved — a missing Secret, a bad ref — because the published config then reflects the cluster. It is wrong when the read was interrupted: the reconcile carries on and writes a config in which the backend is missing entirely, or present with no auth at all, and requests to it break until something triggers another reconcile. There is no `ctx.Err()` check anywhere on this path today.

Adds `isCtxErr` and returns on `context.Canceled` and `context.DeadlineExceeded` at all three sites.

The trigger is a manager shutdown cancelling an in-flight reconcile — there is no `Timeout` on the controller's `rest.Config` and controller-runtime sets `QPS = -1`, so this is about cancellation rather than load. The window is bounded by leader failover, but a config with missing credentials means 401s from upstream providers for as long as it lasts.

**Related Issues/PRs (if applicable)**

None. #2494 reduces the credential reads on the same path and is independent of this.

**Special notes for reviewers (if applicable)**

- A cosmetic fix rides along: `getSecretData` already wraps its error with the secret name and the caller wrapped it again, so failures read `failed to get secret x: failed to get secret x: …`.
- Both bail-out tests fail only the read they target. Failing every Secret Get also breaks the config write, so the reconcile errors regardless and the test passes whether or not the fix is present — I hit that while writing the first one. Verified both fail with their bail-out removed.
- `AIServiceBackend` reads go through the cached client, which ignores a cancelled `ctx`, so `..._BailsOnContextDeadlineReadingBackend` uses `interceptor.NewClient` to stand in for the unsynced-informer case. It covers `DeadlineExceeded` where the credential test covers `Canceled`.
- No test for the inference-pool site: same code shape and same helper, and a much larger fixture.
