### PR TITLE
fix(anthropic): close tool block before text

### DIFF
--- a/internal/translator/openai_helper.go
+++ b/internal/translator/openai_helper.go
@@ -644,6 +644,7 @@ type openAIStreamToAnthropicState struct {
 	messageStarted   bool // flag indicating emitted message_start
 	hasOpenBlock     bool // flag indicating emitted content_block_start but not content_block_stop
 	hasThinkingBlock bool // flag indicating the open block is a thinking block
+	hasToolBlock     bool // flag indicating the open block is a tool_use block
 	closingEmitted   bool // flag indicating emitted content_block_stop + message_delta + message_stop
 	messageID        string
 	model            string
@@ -785,11 +786,18 @@ func (s *openAIStreamToAnthropicState) handleChunk(chunk *openai.ChatCompletionR
 
 		// Handle text content.
 		if delta.Content != nil && *delta.Content != "" {
-			// Close any open thinking block before starting a text block.
+			// Close any open non-text block before starting a text block.
 			if s.hasThinkingBlock {
 				if err := s.closeThinkingBlock(out); err != nil {
 					return err
 				}
+			} else if s.hasToolBlock {
+				if err := s.emitContentBlockStop(out); err != nil {
+					return err
+				}
+				s.hasOpenBlock = false
+				s.hasToolBlock = false
+				s.blockIndex++
 			}
 			// Emit textblockstart if not started
 			if !s.hasOpenBlock {
@@ -891,6 +899,7 @@ func (s *openAIStreamToAnthropicState) handleReasoningDelta(rc *openai.StreamRea
 			return err
 		}
 		s.hasOpenBlock = false
+		s.hasToolBlock = false
 		s.blockIndex++
 	}
 	// Ensure the thinking block is open before emitting any delta.
@@ -968,6 +977,7 @@ func (s *openAIStreamToAnthropicState) closeThinkingBlock(out *[]byte) error {
 	}
 	s.hasOpenBlock = false
 	s.hasThinkingBlock = false
+	s.hasToolBlock = false
 	s.blockIndex++
 	return nil
 }
@@ -982,6 +992,7 @@ func (s *openAIStreamToAnthropicState) handleToolCallDelta(tc *openai.ChatComple
 				return err
 			}
 			s.hasThinkingBlock = false
+			s.hasToolBlock = false
 			s.blockIndex++
 		}
 
@@ -996,6 +1007,7 @@ func (s *openAIStreamToAnthropicState) handleToolCallDelta(tc *openai.ChatComple
 		}
 		s.activeTools[tc.Index] = tool
 		s.hasOpenBlock = true
+		s.hasToolBlock = true
 
 		// Emit content_block_start for the new tool_use block.
 		payload := sseContentBlockStartTool{

--- a/internal/translator/openai_helper_test.go
+++ b/internal/translator/openai_helper_test.go
@@ -733,6 +733,57 @@ func TestOpenAIStreamToAnthropicState_ProcessBuffer_ToolCallStreaming(t *testing
 	require.JSONEq(t, `{"type":"message_stop"}`, events[5].data)
 }
 
+func TestOpenAIStreamToAnthropicState_ProcessBuffer_ToolCallThenText(t *testing.T) {
+	state := &openAIStreamToAnthropicState{
+		activeTools:  make(map[int64]*streamToolCall),
+		requestModel: "claude-3",
+	}
+
+	input := "data: {\"id\":\"chatcmpl-tool-text\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call-read\",\"function\":{\"name\":\"Read\",\"arguments\":\"{\\\"file_path\\\":\\\"README.md\\\"}\"},\"type\":\"function\"}]}}],\"model\":\"qwen-3.6-27b\"}\n\n" +
+		"data: {\"id\":\"chatcmpl-tool-text\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Reading the file.\"},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-tool-text\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n"
+
+	state.buffer.WriteString(input)
+
+	var out []byte
+	err := state.processBuffer(&out, true)
+	require.NoError(t, err)
+
+	events := parseSSEEventsFromBytes(out)
+	require.Len(t, events, 9)
+	require.JSONEq(t, `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call-read","name":"Read","input":{}}}`, events[1].data)
+	require.JSONEq(t, `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\":\"README.md\"}"}}`, events[2].data)
+	require.JSONEq(t, `{"type":"content_block_stop","index":0}`, events[3].data)
+	require.JSONEq(t, `{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`, events[4].data)
+	require.JSONEq(t, `{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Reading the file."}}`, events[5].data)
+	require.JSONEq(t, `{"type":"content_block_stop","index":1}`, events[6].data)
+}
+
+func TestOpenAIStreamToAnthropicState_ProcessBuffer_ToolCallThenReasoning(t *testing.T) {
+	state := &openAIStreamToAnthropicState{
+		activeTools:  make(map[int64]*streamToolCall),
+		requestModel: "claude-3",
+	}
+
+	input := `data: {"id":"chatcmpl-tool-reasoning","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-read","function":{"name":"Read","arguments":""},"type":"function"}]}}],"model":"qwen-3.6-27b"}` + "\n\n" +
+		`data: {"id":"chatcmpl-tool-reasoning","choices":[{"index":0,"delta":{"reasoning_content":{"text":"Checking the file."}}}]}` + "\n\n" +
+		`data: {"id":"chatcmpl-tool-reasoning","choices":[{"index":0,"delta":{"content":"Reading the file."},"finish_reason":"stop"}]}` + "\n\n" +
+		`data: {"id":"chatcmpl-tool-reasoning","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}` + "\n\n"
+
+	state.buffer.WriteString(input)
+
+	var out []byte
+	err := state.processBuffer(&out, true)
+	require.NoError(t, err)
+
+	events := parseSSEEventsFromBytes(out)
+	require.Len(t, events, 11)
+	require.JSONEq(t, `{"type":"content_block_stop","index":0}`, events[2].data)
+	require.JSONEq(t, `{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}}`, events[3].data)
+	require.JSONEq(t, `{"type":"content_block_stop","index":1}`, events[5].data)
+	require.JSONEq(t, `{"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`, events[6].data)
+}
+
 func TestOpenAIStreamToAnthropicState_ProcessBuffer_EndOfStreamClosing(t *testing.T) {
 	// Verify endOfStream triggers closing events when no usage chunk is present.
 	state := &openAIStreamToAnthropicState{


### PR DESCRIPTION
**Description**

Close an open Anthropic `tool_use` block before translating a following OpenAI text delta. This keeps content blocks and indexes valid when models stream a tool call followed by text.

Adds regression coverage for this stream shape.

**Related Issues/PRs (if applicable)**

Fixes #2490

**Special notes for reviewers (if applicable)**

None.

⚒️ with ❤️ by @siemens