### PR TITLE
feat: apply header_order load balancing policy for dynamic backend ordering

### DIFF
--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -26,6 +26,8 @@ import (
 	upstream_codecv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/upstream_codec/v3"
 	httpconnectionmanagerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -42,6 +44,12 @@ const (
 	extProcUDSClusterName = "ai-gateway-extproc-uds"
 	aiGatewayExtProcName  = "envoy.filters.http.ext_proc/aigateway"
 	noBackendRefIndex     = -1
+	// headerOrderLbPolicyName is the registered name of the custom Envoy LoadBalancingPolicy
+	// extension. Requires a custom Envoy build; see
+	// source/extensions/load_balancing_policies/header_order in the Envoy checkout.
+	headerOrderLbPolicyName = "envoy.load_balancing_policies.header_order"
+	// headerOrderLbConfigTypeURL is the Any type URL for the header_order extension's config proto.
+	headerOrderLbConfigTypeURL = "type.googleapis.com/envoy.extensions.load_balancing_policies.header_order.v3.HeaderOrder"
 )
 
 type aiGatewayClusterName struct {
@@ -121,6 +129,14 @@ func (s *Server) PostTranslateModify(ctx context.Context, req *egextension.PostT
 	// Apply the per-rule stream idle timeout to the generated routes.
 	if err = s.applyStreamIdleTimeouts(ctx, req.Routes); err != nil {
 		return nil, fmt.Errorf("failed to apply stream idle timeouts: %w", err)
+	}
+
+	// Attach the header_order LoadBalancingPolicy extension to clusters generated for
+	// AIGatewayRoute rules whose backends use more than one distinct Priority, enabling
+	// per-attempt (initial attempt and every retry) custom ordering driven by the
+	// EndpointOrderMetadataNamespace/EndpointOrderMetadataKey dynamic metadata.
+	if err = s.applyHeaderOrderLoadBalancingPolicy(ctx, req.Clusters); err != nil {
+		return nil, fmt.Errorf("failed to apply header order load balancing policy: %w", err)
 	}
 
 	// Ensure the AI Gateway external processor UDS cluster exists.
@@ -262,6 +278,150 @@ func (s *Server) maybeSetStreamIdleTimeout(ctx context.Context, route *routev3.R
 	}
 	action.RetryPolicy.PerTryIdleTimeout = durationpb.New(timeout)
 	return nil
+}
+
+// applyHeaderOrderLoadBalancingPolicy walks the generated clusters and, for every cluster
+// generated for an AIGatewayRoute rule whose backends use more than one distinct Priority,
+// wraps the cluster's existing LoadBalancingPolicy with a custom Envoy LoadBalancingPolicy
+// extension (envoy.load_balancing_policies.header_order). That extension reads an ordered
+// list of priority indices from the EndpointOrderMetadataNamespace/EndpointOrderMetadataKey
+// dynamic metadata (set by a custom ext_proc upstream of the router) and forces *every*
+// attempt -- the initial attempt and every retry alike -- to target the priority at the
+// corresponding position in that list, delegating actual host selection within that priority
+// (and full fallback, if the metadata is absent/malformed) to the cluster's original
+// LoadBalancingPolicy.
+//
+// Unlike a RetryPriority extension (only consulted on retries), this is a full LoadBalancer
+// extension, so it also covers the initial attempt.
+//
+// This requires a custom Envoy build with the envoy.load_balancing_policies.header_order
+// extension registered; see source/extensions/load_balancing_policies/header_order in the
+// Envoy checkout.
+func (s *Server) applyHeaderOrderLoadBalancingPolicy(ctx context.Context, clusters []*clusterv3.Cluster) error {
+	cache := make(map[client.ObjectKey]*aigv1b1.AIGatewayRoute)
+	for _, cluster := range clusters {
+		if err := s.maybeSetHeaderOrderLoadBalancingPolicy(ctx, cluster, cache); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// maybeSetHeaderOrderLoadBalancingPolicy wraps the cluster's LoadBalancingPolicy with the
+// header_order extension when the cluster was generated for an AIGatewayRoute rule that
+// configures more than one distinct BackendRef Priority, and the cluster already has a
+// LoadBalancingPolicy to use as the child/fallback policy.
+func (s *Server) maybeSetHeaderOrderLoadBalancingPolicy(ctx context.Context, cluster *clusterv3.Cluster, cache map[client.ObjectKey]*aigv1b1.AIGatewayRoute) error {
+	clusterName, err := parseAIGatewayClusterName(cluster.Name)
+	if err != nil {
+		// Not an AIGatewayRoute-owned cluster (e.g. the extproc-uds or InferencePool EPP
+		// clusters).
+		return nil
+	}
+	if clusterName.backendRefIndex != noBackendRefIndex {
+		// A dedicated per-backendRef cluster (Envoy Gateway's NeedsClusterPerSetting case):
+		// there is no single PrioritySet spanning all of the rule's backends here, so
+		// header_order has nothing useful to reorder for this cluster.
+		return nil
+	}
+
+	aigwRoute, err := s.retrieveAndCacheAIGatewayRoute(ctx, cache, client.ObjectKey{Namespace: clusterName.namespace, Name: clusterName.routeName})
+	if err != nil {
+		return err
+	}
+	if aigwRoute == nil {
+		// Not an AIGatewayRoute-owned cluster, or it was deleted during translation.
+		return nil
+	}
+
+	// The list of rules in the AIGatewayRoute may have changed since this cluster was
+	// generated, so we check the rule index is still valid before applying the extension.
+	if clusterName.ruleIndex >= len(aigwRoute.Spec.Rules) {
+		return nil
+	}
+
+	rule := aigwRoute.Spec.Rules[clusterName.ruleIndex]
+	if countDistinctBackendPriorities(rule.BackendRefs) < 2 {
+		// Nothing to reorder: all backends share the same Priority tier.
+		return nil
+	}
+
+	if cluster.LoadBalancingPolicy == nil || len(cluster.LoadBalancingPolicy.Policies) == 0 {
+		// Nothing safe to wrap as the child/fallback policy. Rather than guessing at an
+		// equivalent LoadBalancingPolicy for whatever legacy Cluster.LbPolicy enum value
+		// might be in effect, leave the cluster's load balancing untouched.
+		s.log.Info("skipping header_order load balancing policy: cluster has no LoadBalancingPolicy to wrap",
+			"cluster", cluster.Name)
+		return nil
+	}
+
+	headerOrderAny, err := buildHeaderOrderLoadBalancingPolicyAny(
+		internalapi.EndpointOrderMetadataNamespace, internalapi.EndpointOrderMetadataKey, cluster.LoadBalancingPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to build header_order load balancing policy config: %w", err)
+	}
+
+	cluster.LoadBalancingPolicy = &clusterv3.LoadBalancingPolicy{
+		Policies: []*clusterv3.LoadBalancingPolicy_Policy{{
+			TypedExtensionConfig: &corev3.TypedExtensionConfig{
+				Name:        headerOrderLbPolicyName,
+				TypedConfig: headerOrderAny,
+			},
+		}},
+	}
+	return nil
+}
+
+// countDistinctBackendPriorities returns the number of distinct Priority values among the
+// given AIServiceBackend refs, skipping InferencePool refs (their fallback is handled by the
+// endpoint picker, not Priority tiers). A ref with an unset Priority is treated as Priority 0.
+func countDistinctBackendPriorities(refs []aigv1b1.AIGatewayRouteRuleBackendRef) int {
+	distinctPriorities := make(map[uint32]struct{})
+	for i := range refs {
+		ref := &refs[i]
+		if ref.IsInferencePool() {
+			continue
+		}
+		var priority uint32
+		if ref.Priority != nil {
+			priority = *ref.Priority
+		}
+		distinctPriorities[priority] = struct{}{}
+	}
+	return len(distinctPriorities)
+}
+
+// buildHeaderOrderLoadBalancingPolicyAny hand-encodes the Any payload for
+// envoy.extensions.load_balancing_policies.header_order.v3.HeaderOrder{metadata_namespace:
+// metadataNamespace, metadata_key: metadataKey, fallback_policy: fallbackPolicy}.
+//
+// This is a temporary workaround: the header_order extension is a custom Envoy addition (see
+// source/extensions/load_balancing_policies/header_order in the Envoy checkout) that does not
+// yet have generated Go bindings in github.com/envoyproxy/go-control-plane. Rather than a
+// generic recursive protobuf encoder, this only needs to hand-encode our own message's three
+// top-level fields: two plain strings (field numbers 1 and 2) and one embedded submessage
+// (field number 3) whose *contents* are produced by the real, generated
+// clusterv3.LoadBalancingPolicy type via proto.Marshal -- so no part of fallbackPolicy's own
+// (arbitrarily complex) wire format needs to be hand-rolled. Field lengths are encoded with
+// protowire's varint helpers, so this is not limited to short strings. Once a fork/vendor of
+// go-control-plane ships generated types for this extension, replace this with a normal
+// toAny(&header_orderv3.HeaderOrder{...}) call using the toAny helper in extensionserver.go.
+func buildHeaderOrderLoadBalancingPolicyAny(metadataNamespace, metadataKey string, fallbackPolicy *clusterv3.LoadBalancingPolicy) (*anypb.Any, error) {
+	fallbackBytes, err := proto.Marshal(fallbackPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal fallback LoadBalancingPolicy: %w", err)
+	}
+	var b []byte
+	b = protowire.AppendTag(b, 1, protowire.BytesType) // metadata_namespace
+	b = protowire.AppendString(b, metadataNamespace)
+	b = protowire.AppendTag(b, 2, protowire.BytesType) // metadata_key
+	b = protowire.AppendString(b, metadataKey)
+	b = protowire.AppendTag(b, 3, protowire.BytesType) // fallback_policy
+	b = protowire.AppendBytes(b, fallbackBytes)
+	return &anypb.Any{
+		TypeUrl: headerOrderLbConfigTypeURL,
+		Value:   b,
+	}, nil
 }
 
 // retrieveAndCacheAIGatewayRoute returns the AIGatewayRoute for the key and saves the result.

--- a/internal/extensionserver/post_translate_modify_test.go
+++ b/internal/extensionserver/post_translate_modify_test.go
@@ -8,16 +8,25 @@ package extensionserver
 import (
 	"testing"
 
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	httpconnectionmanagerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 )
 
@@ -437,4 +446,220 @@ func Test_findListenerRouteConfigs(t *testing.T) {
 	}
 	names := findListenerRouteConfigs(l)
 	require.ElementsMatch(t, []string{"foo", "bar"}, names)
+}
+
+func TestCountDistinctBackendPriorities(t *testing.T) {
+	tests := []struct {
+		name     string
+		refs     []aigv1b1.AIGatewayRouteRuleBackendRef
+		expected int
+	}{
+		{
+			name:     "no backends",
+			refs:     nil,
+			expected: 0,
+		},
+		{
+			name: "all unset priority (defaults to 0)",
+			refs: []aigv1b1.AIGatewayRouteRuleBackendRef{
+				{Name: "b1"}, {Name: "b2"},
+			},
+			expected: 1,
+		},
+		{
+			name: "distinct priorities",
+			refs: []aigv1b1.AIGatewayRouteRuleBackendRef{
+				{Name: "b1", Priority: ptr.To(uint32(0))},
+				{Name: "b2", Priority: ptr.To(uint32(1))},
+			},
+			expected: 2,
+		},
+		{
+			name: "same explicit priority",
+			refs: []aigv1b1.AIGatewayRouteRuleBackendRef{
+				{Name: "b1", Priority: ptr.To(uint32(2))},
+				{Name: "b2", Priority: ptr.To(uint32(2))},
+			},
+			expected: 1,
+		},
+		{
+			name: "InferencePool refs are ignored",
+			refs: []aigv1b1.AIGatewayRouteRuleBackendRef{
+				{Name: "b1", Priority: ptr.To(uint32(0))},
+				{
+					Name:     "pool1",
+					Group:    ptr.To("inference.networking.k8s.io"),
+					Kind:     ptr.To("InferencePool"),
+					Priority: ptr.To(uint32(1)),
+				},
+			},
+			expected: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, countDistinctBackendPriorities(tt.refs))
+		})
+	}
+}
+
+// decodeHeaderOrderAny is a minimal hand-rolled decoder mirroring
+// buildHeaderOrderLoadBalancingPolicyAny's encoding, used to verify the encoded Any without
+// requiring generated Go bindings for the header_order proto.
+func decodeHeaderOrderAny(t *testing.T, b []byte) (metadataNamespace, metadataKey string, fallbackPolicy *clusterv3.LoadBalancingPolicy) {
+	t.Helper()
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		require.Positive(t, n)
+		require.Equal(t, protowire.BytesType, typ)
+		b = b[n:]
+		v, n := protowire.ConsumeBytes(b)
+		require.Positive(t, n)
+		b = b[n:]
+		switch num {
+		case 1:
+			metadataNamespace = string(v)
+		case 2:
+			metadataKey = string(v)
+		case 3:
+			fallbackPolicy = &clusterv3.LoadBalancingPolicy{}
+			require.NoError(t, proto.Unmarshal(v, fallbackPolicy))
+		default:
+			t.Fatalf("unexpected field number %d", num)
+		}
+	}
+	return metadataNamespace, metadataKey, fallbackPolicy
+}
+
+func TestBuildHeaderOrderLoadBalancingPolicyAny(t *testing.T) {
+	fallback := &clusterv3.LoadBalancingPolicy{
+		Policies: []*clusterv3.LoadBalancingPolicy_Policy{{
+			TypedExtensionConfig: &corev3.TypedExtensionConfig{
+				Name: "envoy.load_balancing_policies.round_robin",
+			},
+		}},
+	}
+
+	any, err := buildHeaderOrderLoadBalancingPolicyAny("envoy.ai_gateway.endpoint_order", "order", fallback)
+	require.NoError(t, err)
+	require.Equal(t, headerOrderLbConfigTypeURL, any.TypeUrl)
+
+	gotNamespace, gotKey, gotFallback := decodeHeaderOrderAny(t, any.Value)
+	require.Equal(t, "envoy.ai_gateway.endpoint_order", gotNamespace)
+	require.Equal(t, "order", gotKey)
+	require.True(t, proto.Equal(fallback, gotFallback))
+}
+
+func newAIGatewayRouteWithBackendPriorities(namespace, name string, priorities ...uint32) *aigv1b1.AIGatewayRoute {
+	refs := make([]aigv1b1.AIGatewayRouteRuleBackendRef, len(priorities))
+	for i, p := range priorities {
+		refs[i] = aigv1b1.AIGatewayRouteRuleBackendRef{Name: "backend", Priority: ptr.To(p)}
+	}
+	return &aigv1b1.AIGatewayRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: aigv1b1.AIGatewayRouteSpec{
+			Rules: []aigv1b1.AIGatewayRouteRule{{BackendRefs: refs}},
+		},
+	}
+}
+
+func TestServer_maybeSetHeaderOrderLoadBalancingPolicy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, aigv1b1.AddToScheme(scheme))
+
+	existingPolicy := &clusterv3.LoadBalancingPolicy{
+		Policies: []*clusterv3.LoadBalancingPolicy_Policy{{
+			TypedExtensionConfig: &corev3.TypedExtensionConfig{
+				Name: "envoy.load_balancing_policies.round_robin",
+			},
+		}},
+	}
+
+	tests := []struct {
+		name             string
+		clusterName      string
+		loadBalancing    *clusterv3.LoadBalancingPolicy
+		route            *aigv1b1.AIGatewayRoute
+		expectWrapped    bool
+		expectUnmodified bool
+	}{
+		{
+			name:             "not an AIGatewayRoute cluster",
+			clusterName:      "some-other-cluster",
+			loadBalancing:    existingPolicy,
+			expectUnmodified: true,
+		},
+		{
+			name:             "per-backendRef cluster is skipped",
+			clusterName:      "httproute/ns/route/rule/0/backend/0",
+			loadBalancing:    existingPolicy,
+			route:            newAIGatewayRouteWithBackendPriorities("ns", "route", 0, 1),
+			expectUnmodified: true,
+		},
+		{
+			name:             "AIGatewayRoute not found",
+			clusterName:      "httproute/ns/missing/rule/0",
+			loadBalancing:    existingPolicy,
+			expectUnmodified: true,
+		},
+		{
+			name:             "rule index out of range",
+			clusterName:      "httproute/ns/route/rule/5",
+			loadBalancing:    existingPolicy,
+			route:            newAIGatewayRouteWithBackendPriorities("ns", "route", 0, 1),
+			expectUnmodified: true,
+		},
+		{
+			name:             "single distinct priority is skipped",
+			clusterName:      "httproute/ns/route/rule/0",
+			loadBalancing:    existingPolicy,
+			route:            newAIGatewayRouteWithBackendPriorities("ns", "route", 0, 0),
+			expectUnmodified: true,
+		},
+		{
+			name:             "no existing LoadBalancingPolicy to wrap is skipped",
+			clusterName:      "httproute/ns/route/rule/0",
+			loadBalancing:    nil,
+			route:            newAIGatewayRouteWithBackendPriorities("ns", "route", 0, 1),
+			expectUnmodified: true,
+		},
+		{
+			name:          "multiple distinct priorities wraps the existing policy",
+			clusterName:   "httproute/ns/route/rule/0",
+			loadBalancing: existingPolicy,
+			route:         newAIGatewayRouteWithBackendPriorities("ns", "route", 0, 1),
+			expectWrapped: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.route != nil {
+				builder = builder.WithObjects(tt.route)
+			}
+			s := &Server{log: zap.New(), k8sClient: builder.Build()}
+
+			cluster := &clusterv3.Cluster{Name: tt.clusterName, LoadBalancingPolicy: tt.loadBalancing}
+			cache := make(map[client.ObjectKey]*aigv1b1.AIGatewayRoute)
+			err := s.maybeSetHeaderOrderLoadBalancingPolicy(t.Context(), cluster, cache)
+			require.NoError(t, err)
+
+			if tt.expectUnmodified {
+				require.Equal(t, tt.loadBalancing, cluster.LoadBalancingPolicy)
+				return
+			}
+
+			require.True(t, tt.expectWrapped)
+			require.Len(t, cluster.LoadBalancingPolicy.Policies, 1)
+			policy := cluster.LoadBalancingPolicy.Policies[0].TypedExtensionConfig
+			require.Equal(t, headerOrderLbPolicyName, policy.Name)
+			require.Equal(t, headerOrderLbConfigTypeURL, policy.TypedConfig.TypeUrl)
+
+			gotNamespace, gotKey, gotFallback := decodeHeaderOrderAny(t, policy.TypedConfig.Value)
+			require.Equal(t, internalapi.EndpointOrderMetadataNamespace, gotNamespace)
+			require.Equal(t, internalapi.EndpointOrderMetadataKey, gotKey)
+			require.True(t, proto.Equal(tt.loadBalancing, gotFallback))
+		})
+	}
 }

--- a/internal/internalapi/internalapi.go
+++ b/internal/internalapi/internalapi.go
@@ -74,6 +74,17 @@ const (
 	// This is the default header name in the reference implementation:
 	// https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/2b5b337b45c3289e5f9367b2c19deef021722fcd/pkg/epp/server/runserver.go#L63
 	EndpointPickerHeaderKey = "x-gateway-destination-endpoint"
+	// EndpointOrderMetadataNamespace is the dynamic metadata namespace a custom ext_proc sets,
+	// upstream of the router filter, to specify the desired per-request attempt order of
+	// backend Priority tiers (see aigv1b1.AIGatewayRouteRuleBackendRef.Priority). It is
+	// consumed on the data plane by the custom Envoy "envoy.retry_priorities.header_order"
+	// RetryPriority extension, which is attached to eligible routes by the extension server
+	// (see maybeSetHeaderOrderRetryPriority).
+	EndpointOrderMetadataNamespace = "envoy.ai_gateway.endpoint_order"
+	// EndpointOrderMetadataKey is the key, within EndpointOrderMetadataNamespace, whose value
+	// must be a list of numbers representing the ordered list of priority indices, e.g.
+	// [3, 0, 2].
+	EndpointOrderMetadataKey = "order"
 )
 
 const (


### PR DESCRIPTION
**Description**

Adds support for dynamic per-request LLM backend ordering by wrapping cluster
`LoadBalancingPolicy` configurations with the Envoy
`envoy.load_balancing_policies.header_order` extension when an `AIGatewayRoute`
rule contains multiple distinct `AIGatewayRouteRuleBackendRef.Priority` values.

The extension server:
- Reads `AIGatewayRoute` backend priorities from the per-rule cluster
  generated for a route.
- Builds a hand-encoded protobuf `Any` payload for the `HeaderOrder` config
  that stores the dynamic metadata namespace (`envoy.ai_gateway.endpoint_order`)
  and key (`order`) used by the extension, plus the cluster's existing load
  balancing policy as a fallback.
- Attaches the wrapped policy to the per-rule cluster so both initial attempts
  and retries use the priority order supplied by an upstream ext_proc.

Constants for the metadata namespace and key were added to
`internal/internalapi/internalapi.go`, and unit tests covering all skip paths
and successful wrapping were added to
`internal/extensionserver/post_translate_modify_test.go`.

This change works together with the corresponding Envoy `header_order` load
balancing and retry priority extensions in envoyproxy/envoy.

**Related Issues/PRs (if applicable)**

Related Envoy extension PR: envoyproxy/envoy#46559

**Special notes for reviewers (if applicable)**

- The hand-rolled protobuf Any encoding is intentional because the
  `header_order` API is not yet vendored in this repository.
- The Go code is not yet tested end-to-end; unit tests are included.
- Portions of this change were developed with the assistance of a generative AI
  tool and reviewed by the author.
