### PR TITLE
feat(controller): add version subcommand

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"os"
@@ -35,6 +36,7 @@ import (
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 	"github.com/envoyproxy/ai-gateway/internal/pprof"
 	"github.com/envoyproxy/ai-gateway/internal/ratelimit/runner"
+	"github.com/envoyproxy/ai-gateway/internal/version"
 )
 
 type flags struct {
@@ -408,7 +410,21 @@ func newZapOpts(logFormat string, level zapcore.LevelEnabler) []zap.Opts {
 	return opts
 }
 
+// handleVersion prints the controller version and returns true when the first
+// argument is the "version" subcommand, mirroring `envoy-gateway version`.
+func handleVersion(args []string, stdout io.Writer) bool {
+	if len(args) == 0 || args[0] != "version" {
+		return false
+	}
+	_, _ = fmt.Fprintf(stdout, "Envoy AI Gateway Controller: %s\n", version.Parse())
+	return true
+}
+
 func main() {
+	if handleVersion(os.Args[1:], os.Stdout) {
+		return
+	}
+
 	setupLog := ctrl.Log.WithName("setup")
 
 	parsedFlags, err := parseAndValidateFlags(os.Args[1:])
@@ -418,6 +434,7 @@ func main() {
 	}
 
 	ctrl.SetLogger(zap.New(newZapOpts(parsedFlags.logFormat, parsedFlags.logLevel)...))
+	setupLog.Info("starting Envoy AI Gateway controller", "version", version.Parse())
 	k8sConfig := ctrl.GetConfigOrDie()
 
 	lis, err := net.Listen("tcp", parsedFlags.extensionServerPort)

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -407,3 +407,23 @@ func TestSetupCache(t *testing.T) {
 		}, c.DefaultNamespaces)
 	})
 }
+
+func Test_handleVersion(t *testing.T) {
+	t.Run("version subcommand", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		require.True(t, handleVersion([]string{"version"}, out))
+		require.Equal(t, "Envoy AI Gateway Controller: dev\n", out.String())
+	})
+
+	t.Run("no args", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		require.False(t, handleVersion(nil, out))
+		require.Empty(t, out.String())
+	})
+
+	t.Run("regular flags", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		require.False(t, handleVersion([]string{"--logLevel", "debug"}, out))
+		require.Empty(t, out.String())
+	})
+}


### PR DESCRIPTION
**Description**

Adds a `version` subcommand to the AI Gateway controller binary, mirroring `envoy-gateway version`:

```console
$ ai-gateway-controller version
Envoy AI Gateway Controller: v1.0.0
```

This gives operators (e.g. the Juju charm automation in the linked issue) a reliable way to probe the deployed controller workload version. The controller also now logs its version at startup, matching what the external processor already does.

The issue discussion also floated a `/version` HTTP endpoint as a possibly more idiomatic alternative. This PR implements the command for parity with `envoy-gateway` since it is small and unblocks version probing now; happy to follow up with an endpoint (or rework this PR) if maintainers prefer that direction.

Fixes #2322

**Notes**
- `make precommit test` passes locally.
- Per the contributing guidelines' transparency policy: this change was written with AI assistance; I understand and take full ownership of the code.