### PR TITLE
fix(translator): allowlist anthropic-beta flags forwarded to AWS Anthropic

### DIFF
--- a/internal/translator/anthropic_awsanthropic.go
+++ b/internal/translator/anthropic_awsanthropic.go
@@ -70,13 +70,43 @@ var awsBedrockSupportedAnthropicBetas = map[string]struct{}{
 	"web-search-2025-03-05":                    {},
 }
 
+// anthropicAPIToBedrockBetaAliases maps anthropic-beta flag names that only the Anthropic API
+// accepts onto the equivalent Bedrock flag name. The same feature is often exposed under
+// different flag names depending on the backend, and clients speaking the Anthropic API
+// dialect (e.g. Claude Code) send the Anthropic API name, which would otherwise be stripped
+// by the allowlist above, silently disabling the gated feature.
+//
+// advanced-tool-use-2025-11-20 is the Anthropic API umbrella flag for Tool Search,
+// Programmatic Tool Calling and Tool Use Examples. Bedrock supports only Tool Search,
+// exposed under the older-dated tool-search-tool-2025-10-19; the tool type strings
+// (tool_search_tool_regex_20251119 / tool_search_tool_bm25_20251119) are identical on both.
+// The umbrella flag's non-Bedrock-supported siblings are dropped by the allowlist as usual.
+//
+// Aliases are applied before the allowlist check in SetRequestHeaders.
+var anthropicAPIToBedrockBetaAliases = map[string]string{
+	"advanced-tool-use-2025-11-20": "tool-search-tool-2025-10-19",
+}
+
 // SetRequestHeaders implements [RequestHeadersSetter].
 func (a *anthropicToAWSAnthropicTranslator) SetRequestHeaders(headers map[string]string) {
 	var anthropicBetas []string
+	seen := map[string]struct{}{}
 	if betaHeader := headers["anthropic-beta"]; betaHeader != "" {
 		for _, beta := range strings.Split(betaHeader, ",") {
 			beta = strings.TrimSpace(beta)
+			// Translate Anthropic-API-only flag names to their Bedrock equivalents
+			// before the allowlist check.
+			if alias, ok := anthropicAPIToBedrockBetaAliases[beta]; ok {
+				beta = alias
+			}
 			if _, ok := awsBedrockSupportedAnthropicBetas[beta]; ok {
+				// An alias can collide with an explicitly sent flag (e.g. both
+				// advanced-tool-use-2025-11-20 and tool-search-tool-2025-10-19);
+				// forward each Bedrock flag only once.
+				if _, dup := seen[beta]; dup {
+					continue
+				}
+				seen[beta] = struct{}{}
 				anthropicBetas = append(anthropicBetas, beta)
 			}
 		}

--- a/internal/translator/anthropic_awsanthropic.go
+++ b/internal/translator/anthropic_awsanthropic.go
@@ -41,12 +41,42 @@ type anthropicToAWSAnthropicTranslator struct {
 	anthropicBetas []string
 }
 
+// awsBedrockSupportedAnthropicBetas is the allowlist of anthropic-beta flags that AWS Bedrock
+// accepts in the anthropic_beta request field. Bedrock rejects the entire request with a 400
+// "invalid beta flag" error if any unrecognized flag is present, so unsupported flags (e.g.
+// ones only the Anthropic API knows) must be stripped rather than forwarded.
+//
+// Every entry was confirmed accepted (HTTP 200) by live probes against Bedrock. Notably,
+// prompt-caching-2024-07-31, extended-cache-ttl-2025-04-11, files-api-2025-04-14,
+// code-execution-2025-05-22, memory-2025-08-18 and thinking-token-count-2026-05-13 were
+// probed and rejected. Extend this set only with flags verified against Bedrock.
+var awsBedrockSupportedAnthropicBetas = map[string]struct{}{
+	"computer-use-2024-10-22":                  {},
+	"computer-use-2025-01-24":                  {},
+	"context-1m-2025-08-07":                    {},
+	"context-management-2025-06-27":            {},
+	"dev-full-thinking-2025-05-14":             {},
+	"fine-grained-tool-streaming-2025-05-14":   {},
+	"interleaved-thinking-2025-05-14":          {},
+	"mcp-client-2025-04-04":                    {},
+	"mcp-client-2025-11-20":                    {},
+	"model-context-window-exceeded-2025-08-26": {},
+	"output-128k-2025-02-19":                   {},
+	"pdfs-2024-09-25":                          {},
+	"search-results-2025-06-09":                {},
+	"token-counting-2024-11-01":                {},
+	"token-efficient-tools-2025-02-19":         {},
+	"tool-search-tool-2025-10-19":              {},
+	"web-search-2025-03-05":                    {},
+}
+
 // SetRequestHeaders implements [RequestHeadersSetter].
 func (a *anthropicToAWSAnthropicTranslator) SetRequestHeaders(headers map[string]string) {
 	var anthropicBetas []string
 	if betaHeader := headers["anthropic-beta"]; betaHeader != "" {
 		for _, beta := range strings.Split(betaHeader, ",") {
-			if beta = strings.TrimSpace(beta); beta != "" {
+			beta = strings.TrimSpace(beta)
+			if _, ok := awsBedrockSupportedAnthropicBetas[beta]; ok {
 				anthropicBetas = append(anthropicBetas, beta)
 			}
 		}

--- a/internal/translator/anthropic_awsanthropic_test.go
+++ b/internal/translator/anthropic_awsanthropic_test.go
@@ -266,6 +266,26 @@ func TestAnthropicToAWSAnthropicTranslator_RequestBody_AnthropicBetaHeader(t *te
 			expected: []string{"interleaved-thinking-2025-05-14", "tool-search-tool-2025-10-19"},
 		},
 		{
+			name:     "Anthropic API umbrella flag is rewritten to the Bedrock tool search flag",
+			headers:  map[string]string{"anthropic-beta": "advanced-tool-use-2025-11-20"},
+			expected: []string{"tool-search-tool-2025-10-19"},
+		},
+		{
+			name:     "umbrella flag deduplicated with the explicitly sent Bedrock flag",
+			headers:  map[string]string{"anthropic-beta": "advanced-tool-use-2025-11-20,tool-search-tool-2025-10-19"},
+			expected: []string{"tool-search-tool-2025-10-19"},
+		},
+		{
+			name:     "umbrella flag combined with other supported flags",
+			headers:  map[string]string{"anthropic-beta": "interleaved-thinking-2025-05-14,advanced-tool-use-2025-11-20"},
+			expected: []string{"interleaved-thinking-2025-05-14", "tool-search-tool-2025-10-19"},
+		},
+		{
+			name:     "umbrella flag with unsupported siblings only forwards the mapped flag",
+			headers:  map[string]string{"anthropic-beta": "advanced-tool-use-2025-11-20,code-execution-2025-08-25,files-api-2025-04-14"},
+			expected: []string{"tool-search-tool-2025-10-19"},
+		},
+		{
 			name:    "only unsupported flags results in no anthropic_beta",
 			headers: map[string]string{"anthropic-beta": "prompt-caching-2024-07-31,memory-2025-08-18"},
 		},

--- a/internal/translator/anthropic_awsanthropic_test.go
+++ b/internal/translator/anthropic_awsanthropic_test.go
@@ -256,6 +256,20 @@ func TestAnthropicToAWSAnthropicTranslator_RequestBody_AnthropicBetaHeader(t *te
 			expected: []string{"interleaved-thinking-2025-05-14", "context-1m-2025-08-07"},
 		},
 		{
+			name:     "all five confirmed Bedrock flags",
+			headers:  map[string]string{"anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19,tool-search-tool-2025-10-19"},
+			expected: []string{"context-1m-2025-08-07", "interleaved-thinking-2025-05-14", "fine-grained-tool-streaming-2025-05-14", "token-efficient-tools-2025-02-19", "tool-search-tool-2025-10-19"},
+		},
+		{
+			name:     "unsupported flags are dropped",
+			headers:  map[string]string{"anthropic-beta": "interleaved-thinking-2025-05-14,prompt-caching-2024-07-31,tool-search-tool-2025-10-19"},
+			expected: []string{"interleaved-thinking-2025-05-14", "tool-search-tool-2025-10-19"},
+		},
+		{
+			name:    "only unsupported flags results in no anthropic_beta",
+			headers: map[string]string{"anthropic-beta": "prompt-caching-2024-07-31,memory-2025-08-18"},
+		},
+		{
 			name:    "no beta header",
 			headers: map[string]string{},
 		},

--- a/tests/e2e/testupstream_test.go
+++ b/tests/e2e/testupstream_test.go
@@ -463,3 +463,113 @@ func TestPromptCacheTranslationMatrix(t *testing.T) {
 		})
 	}
 }
+
+// TestAnthropicBetaHeaderTranslationMatrix proves anthropic-beta header flags survive
+// translation onto the AWSAnthropic InvokeModel body's anthropic_beta field, including
+// the rewrite of Anthropic-API-only flag names to their Bedrock equivalents.
+//
+// The matrix is derived from the "bedrock" column of litellm's beta header mapping
+// (https://github.com/BerriAI/litellm/blob/main/litellm/anthropic_beta_headers_config.json):
+//   - advanced-tool-use-2025-11-20 -> tool-search-tool-2025-10-19 (Anthropic API umbrella
+//     flag for Tool Search; Bedrock exposes the same tool_search_tool_*_20251119 tool types
+//     under the older-dated flag). This is the flag Claude Code sends.
+//   - tool-search-tool-2025-10-19 -> tool-search-tool-2025-10-19 (native Bedrock spelling).
+//   - code-execution-2025-08-25, files-api-2025-04-14 -> null (unsupported, must be dropped;
+//     Bedrock rejects the whole request with a 400 on unrecognized flags).
+func TestAnthropicBetaHeaderTranslationMatrix(t *testing.T) {
+	const manifest = "testdata/testupstream.yaml"
+	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(context.Background(), manifest)
+	})
+
+	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=translation-testupstream"
+	e2elib.RequireWaitForGatewayPodReady(t, egSelector)
+
+	const (
+		expPath    = "/model/anthropic.claude-cache-matrix/invoke"
+		expHost    = "testupstream.default.svc.cluster.local"
+		upstreamID = "primary"
+	)
+	fakeResponseBody := `{"id":"msg_beta","type":"message","role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":10,"output_tokens":1}}`
+
+	// The request carries a tool_search_tool_regex_20251119 tool definition, the real
+	// Claude Code request shape: the tool type string is identical on the Anthropic API
+	// and Bedrock, only the enabling beta flag name differs.
+	const requestBody = `{"model":"anthropic.claude-cache-matrix","max_tokens":16,"tools":[{"type":"tool_search_tool_regex_20251119","name":"tool_search_tool_regex"}],"messages":[{"role":"user","content":"hi"}]}`
+	const translatedBodyPrefix = `{"max_tokens":16,"tools":[{"type":"tool_search_tool_regex_20251119","name":"tool_search_tool_regex"}],"messages":[{"role":"user","content":"hi"}],"anthropic_version":"bedrock-2023-05-31"`
+
+	for _, tc := range []struct {
+		name string
+		// betaHeader is the anthropic-beta header value sent by the client.
+		betaHeader string
+		// expRequestBody is the exact AWSAnthropic InvokeModel body the testupstream
+		// server must receive (asserted byte-for-byte by the testupstream server).
+		expRequestBody string
+	}{
+		{
+			name:           "anthropic_api_umbrella_flag_rewritten",
+			betaHeader:     "advanced-tool-use-2025-11-20",
+			expRequestBody: translatedBodyPrefix + `,"anthropic_beta":["tool-search-tool-2025-10-19"]}`,
+		},
+		{
+			name:           "native_bedrock_flag_passthrough",
+			betaHeader:     "tool-search-tool-2025-10-19",
+			expRequestBody: translatedBodyPrefix + `,"anthropic_beta":["tool-search-tool-2025-10-19"]}`,
+		},
+		{
+			name:           "umbrella_and_native_flag_deduplicated",
+			betaHeader:     "advanced-tool-use-2025-11-20,tool-search-tool-2025-10-19",
+			expRequestBody: translatedBodyPrefix + `,"anthropic_beta":["tool-search-tool-2025-10-19"]}`,
+		},
+		{
+			name:           "umbrella_flag_with_other_supported_flags",
+			betaHeader:     "advanced-tool-use-2025-11-20,interleaved-thinking-2025-05-14",
+			expRequestBody: translatedBodyPrefix + `,"anthropic_beta":["tool-search-tool-2025-10-19","interleaved-thinking-2025-05-14"]}`,
+		},
+		{
+			name:           "unsupported_siblings_dropped",
+			betaHeader:     "advanced-tool-use-2025-11-20,code-execution-2025-08-25,files-api-2025-04-14",
+			expRequestBody: translatedBodyPrefix + `,"anthropic_beta":["tool-search-tool-2025-10-19"]}`,
+		},
+		{
+			name:           "only_unsupported_flags_no_anthropic_beta",
+			betaHeader:     "code-execution-2025-08-25",
+			expRequestBody: translatedBodyPrefix + `}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Eventually(t, func() bool {
+				fwd := e2elib.RequireNewHTTPPortForwarder(t, e2elib.EnvoyGatewayNamespace, egSelector, e2elib.EnvoyGatewayDefaultServicePort)
+				defer fwd.Kill()
+
+				req, err := http.NewRequest(http.MethodPost, fwd.Address()+"/anthropic/v1/messages", strings.NewReader(requestBody))
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("anthropic-beta", tc.betaHeader)
+				req.Header.Set(testupstreamlib.ResponseBodyHeaderKey, base64.StdEncoding.EncodeToString([]byte(fakeResponseBody)))
+				req.Header.Set(testupstreamlib.ExpectedPathHeaderKey, base64.StdEncoding.EncodeToString([]byte(expPath)))
+				req.Header.Set(testupstreamlib.ExpectedHostKey, expHost)
+				req.Header.Set(testupstreamlib.ExpectedTestUpstreamIDKey, upstreamID)
+				req.Header.Set(testupstreamlib.ExpectedRequestBodyHeaderKey, base64.StdEncoding.EncodeToString([]byte(tc.expRequestBody)))
+
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Logf("error: %v", err)
+					return false
+				}
+				defer func() { _ = resp.Body.Close() }()
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Logf("error reading response body: %v", err)
+					return false
+				}
+				if resp.StatusCode != http.StatusOK {
+					t.Logf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+					return false
+				}
+				return true
+			}, 20*time.Second, 1*time.Second)
+		})
+	}
+}


### PR DESCRIPTION
**Description**

This commit filters the `anthropic-beta` request header values forwarded to AWS Anthropic (Bedrock) backends against an allowlist of flags Bedrock actually accepts, instead of forwarding every value verbatim into the `anthropic_beta` request body field.

AWS Bedrock rejects the entire request with a 400 `"invalid beta flag"` error when `anthropic_beta` contains a flag it does not recognize. Clients such as Claude Code send beta flags targeting the Anthropic API (e.g. `prompt-caching-2024-07-31`, `extended-cache-ttl-2025-04-11`, `files-api-2025-04-14`), so a single unsupported flag previously broke the whole request through the gateway. Unsupported flags are now stripped, and the `anthropic_beta` field is omitted entirely when nothing supported remains.

The allowlist contains 17 flags, each confirmed accepted (HTTP 200) by live probes against Bedrock:

`context-1m-2025-08-07`, `context-management-2025-06-27`, `interleaved-thinking-2025-05-14`, `dev-full-thinking-2025-05-14`, `fine-grained-tool-streaming-2025-05-14`, `token-efficient-tools-2025-02-19`, `token-counting-2024-11-01`, `tool-search-tool-2025-10-19`, `computer-use-2024-10-22`, `computer-use-2025-01-24`, `mcp-client-2025-04-04`, `mcp-client-2025-11-20`, `web-search-2025-03-05`, `search-results-2025-06-09`, `output-128k-2025-02-19`, `pdfs-2024-09-25`, `model-context-window-exceeded-2025-08-26`

Probed and confirmed rejected (documented in the code comment so they are not re-added from Anthropic docs): `prompt-caching-2024-07-31`, `extended-cache-ttl-2025-04-11`, `thinking-token-count-2026-05-13`, `files-api-2025-04-14`, `code-execution-2025-05-22`, `memory-2025-08-18`.

Unit tests cover the full allowlisted set, mixed supported/unsupported headers, and the all-unsupported case.

A second commit rewrites Anthropic-API-only flag names to their Bedrock equivalents before the allowlist check. The same feature can be gated under different flag names depending on the backend: the Anthropic API gates Tool Search (plus Programmatic Tool Calling and Tool Use Examples) under the umbrella flag `advanced-tool-use-2025-11-20`, while Bedrock exposes Tool Search under the older-dated `tool-search-tool-2025-10-19`. The `tool_search_tool_regex_20251119` / `tool_search_tool_bm25_20251119` tool type strings are identical on both. Clients speaking the Anthropic API dialect (e.g. Claude Code) send the umbrella flag, which the allowlist alone would strip, silently disabling tool search; the gateway now maps it to the Bedrock flag (deduplicating when both spellings are sent), matching the translation litellm ships in `anthropic_beta_headers_config.json`. An e2e matrix (`TestAnthropicBetaHeaderTranslationMatrix`) asserts the exact upstream `InvokeModel` body for the umbrella flag, the native Bedrock spelling, dedup, mixed supported/unsupported, and all-unsupported cases.

**Related Issues/PRs (if applicable)**
N/A

**Special notes for reviewers (if applicable)**
I raised this PR because requests from Claude Code to Bedrock-backed routes failed with 400s whenever the client sent a beta flag Bedrock does not support, even though the remaining flags were valid. Stripping unsupported flags at the gateway matches how the gateway already normalizes other Bedrock-specific request shapes.

The allowlist is intentionally limited to probe-verified flags rather than Anthropic's documented beta list, since an incorrect entry would reintroduce the exact 400 this change prevents. Extending it is a one-line change per newly verified flag.

I used an AI coding assistant to help implement this change, and I reviewed and verified the code and tests, including the live Bedrock probes behind the allowlist.
