### PR TITLE
translator: serialize non-streaming Bedrock reasoning_content as plain string

### DIFF
--- a/internal/translator/openai_awsbedrock.go
+++ b/internal/translator/openai_awsbedrock.go
@@ -471,10 +471,18 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) ResponseBody(_ map[string
 			// redacted content go to thinking_blocks (they cannot be represented in a
 			// plain string). This mirrors the streaming path and the Gemini helper.
 			if rt := output.ReasoningContent.ReasoningText; rt != nil {
-				choice.Message.ReasoningContent = &openai.ReasoningContentUnion{Value: rt.Text}
-				choice.Message.ThinkingBlocks = append(choice.Message.ThinkingBlocks, openai.ThinkingBlock{
-					Type: "thinking", Thinking: rt.Text, Signature: rt.Signature,
-				})
+				// Only set reasoning_content when there is actual text; a
+				// signature-only block must not emit an empty string.
+				if rt.Text != "" {
+					choice.Message.ReasoningContent = &openai.ReasoningContentUnion{Value: rt.Text}
+				}
+				// Surface the block (text and/or signature) so a signature still
+				// round-trips even without accompanying text.
+				if rt.Text != "" || rt.Signature != "" {
+					choice.Message.ThinkingBlocks = append(choice.Message.ThinkingBlocks, openai.ThinkingBlock{
+						Type: "thinking", Thinking: rt.Text, Signature: rt.Signature,
+					})
+				}
 			}
 			if rc := output.ReasoningContent.RedactedContent; rc != nil {
 				choice.Message.ThinkingBlocks = append(choice.Message.ThinkingBlocks, openai.ThinkingBlock{

--- a/internal/translator/openai_awsbedrock.go
+++ b/internal/translator/openai_awsbedrock.go
@@ -467,10 +467,19 @@ func (o *openAIToAWSBedrockTranslatorV1ChatCompletion) ResponseBody(_ map[string
 				choice.Message.Content = output.Text
 			}
 		case output.ReasoningContent != nil:
-			choice.Message.ReasoningContent = &openai.ReasoningContentUnion{
-				Value: &openai.ReasoningContent{
-					ReasoningContent: output.ReasoningContent,
-				},
+			// Reasoning text goes to the plain-string reasoning_content; signature and
+			// redacted content go to thinking_blocks (they cannot be represented in a
+			// plain string). This mirrors the streaming path and the Gemini helper.
+			if rt := output.ReasoningContent.ReasoningText; rt != nil {
+				choice.Message.ReasoningContent = &openai.ReasoningContentUnion{Value: rt.Text}
+				choice.Message.ThinkingBlocks = append(choice.Message.ThinkingBlocks, openai.ThinkingBlock{
+					Type: "thinking", Thinking: rt.Text, Signature: rt.Signature,
+				})
+			}
+			if rc := output.ReasoningContent.RedactedContent; rc != nil {
+				choice.Message.ThinkingBlocks = append(choice.Message.ThinkingBlocks, openai.ThinkingBlock{
+					Type: "redacted_thinking", Data: base64.StdEncoding.EncodeToString(rc),
+				})
 			}
 		}
 	}

--- a/internal/translator/openai_awsbedrock_test.go
+++ b/internal/translator/openai_awsbedrock_test.go
@@ -1840,16 +1840,11 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody(t *testing.T)
 						Index:        0,
 						FinishReason: openai.ChatCompletionChoicesFinishReasonStop,
 						Message: openai.ChatCompletionResponseChoiceMessage{
-							Role:    awsbedrock.ConversationRoleAssistant,
-							Content: ptr.To("This is the final answer."),
-							ReasoningContent: &openai.ReasoningContentUnion{
-								Value: &openai.ReasoningContent{
-									ReasoningContent: &awsbedrock.ReasoningContentBlock{
-										ReasoningText: &awsbedrock.ReasoningTextBlock{
-											Text: "This is the model's thought process.",
-										},
-									},
-								},
+							Role:             awsbedrock.ConversationRoleAssistant,
+							Content:          ptr.To("This is the final answer."),
+							ReasoningContent: &openai.ReasoningContentUnion{Value: "This is the model's thought process."},
+							ThinkingBlocks: []openai.ThinkingBlock{
+								{Type: "thinking", Thinking: "This is the model's thought process."},
 							},
 						},
 					},
@@ -2355,15 +2350,19 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody_WithReasoning
 	require.Equal(t, "9.11 is greater than 9.8.", *message.Content)
 
 	require.NotNil(t, message.ReasoningContent, "Reasoning content should not be nil")
-	reasoningBlock, _ := message.ReasoningContent.Value.(*openai.ReasoningContent)
-	require.NotNil(t, reasoningBlock, "The nested reasoning content block should not be nil")
-	require.NotEmpty(t, reasoningBlock.ReasoningContent.ReasoningText.Text, "The reasoning text itself should not be empty")
+	reasoningText, ok := message.ReasoningContent.Value.(string)
+	require.True(t, ok, "reasoning_content should be a plain string")
+	require.Equal(t, "The user wants to compare two numbers. 9.11 is larger than 9.8.", reasoningText)
+
+	require.Len(t, message.ThinkingBlocks, 1, "Reasoning text should be echoed in thinking_blocks")
+	require.Equal(t, "thinking", message.ThinkingBlocks[0].Type)
+	require.Equal(t, reasoningText, message.ThinkingBlocks[0].Thinking)
 
 	var untypedResponse map[string]interface{}
 	err = json.Unmarshal(outputBody, &untypedResponse)
 	require.NoError(t, err)
 
-	// Traverse the map to verify the structure: reasoning_content["reasoningContent"].
+	// Verify reasoning_content is serialized as a plain string on the wire.
 	choices, ok := untypedResponse["choices"].([]interface{})
 	require.True(t, ok, "JSON should have a 'choices' array")
 	require.Len(t, choices, 1)
@@ -2373,11 +2372,68 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody_WithReasoning
 
 	messageMap, ok := choice["message"].(map[string]interface{})
 	require.True(t, ok, "Choice should have a 'message' map")
-	reasoningContent, ok := messageMap["reasoning_content"].(map[string]interface{})
-	require.True(t, ok, "Message should have a 'reasoning_content' map")
+	reasoningContent, ok := messageMap["reasoning_content"].(string)
+	require.True(t, ok, "Message should have a 'reasoning_content' string")
+	require.Equal(t, "The user wants to compare two numbers. 9.11 is larger than 9.8.", reasoningContent)
+}
 
-	_, ok = reasoningContent["reasoningContent"]
-	require.True(t, ok, "The 'reasoning_content' object should have a nested 'reasoningContent' key")
+func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody_WithReasoningSignatureAndRedacted(t *testing.T) {
+	// A signature and redacted reasoning content cannot live in the plain-string
+	// reasoning_content, so they must surface via thinking_blocks.
+	redactedBytes := []byte("a redacted thought")
+	mockBedrockResponse := awsbedrock.ConverseResponse{
+		Output: &awsbedrock.ConverseOutput{
+			Message: awsbedrock.Message{
+				Role: awsbedrock.ConversationRoleAssistant,
+				Content: []*awsbedrock.ContentBlock{
+					{
+						ReasoningContent: &awsbedrock.ReasoningContentBlock{
+							ReasoningText: &awsbedrock.ReasoningTextBlock{
+								Text:      "Let me think about this.",
+								Signature: "sig_xyz",
+							},
+						},
+					},
+					{
+						ReasoningContent: &awsbedrock.ReasoningContentBlock{
+							RedactedContent: redactedBytes,
+						},
+					},
+					{
+						Text: ptr.To("The answer is 42."),
+					},
+				},
+			},
+		},
+		StopReason: ptr.To(awsbedrock.StopReasonEndTurn),
+	}
+
+	body, err := json.Marshal(mockBedrockResponse)
+	require.NoError(t, err)
+
+	o := &openAIToAWSBedrockTranslatorV1ChatCompletion{}
+	_, outputBody, _, _, err := o.ResponseBody(nil, bytes.NewBuffer(body), false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, outputBody)
+
+	var openAIResponse openai.ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(outputBody, &openAIResponse))
+	require.Len(t, openAIResponse.Choices, 1)
+	message := openAIResponse.Choices[0].Message
+
+	require.NotNil(t, message.Content)
+	require.Equal(t, "The answer is 42.", *message.Content)
+
+	reasoningText, ok := message.ReasoningContent.Value.(string)
+	require.True(t, ok, "reasoning_content should be a plain string")
+	require.Equal(t, "Let me think about this.", reasoningText)
+
+	require.Len(t, message.ThinkingBlocks, 2)
+	require.Equal(t, "thinking", message.ThinkingBlocks[0].Type)
+	require.Equal(t, "Let me think about this.", message.ThinkingBlocks[0].Thinking)
+	require.Equal(t, "sig_xyz", message.ThinkingBlocks[0].Signature)
+	require.Equal(t, "redacted_thinking", message.ThinkingBlocks[1].Type)
+	require.Equal(t, base64.StdEncoding.EncodeToString(redactedBytes), message.ThinkingBlocks[1].Data)
 }
 
 func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_Streaming_WithRedactedContent(t *testing.T) {

--- a/internal/translator/openai_awsbedrock_test.go
+++ b/internal/translator/openai_awsbedrock_test.go
@@ -2436,6 +2436,58 @@ func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody_WithReasoning
 	require.Equal(t, base64.StdEncoding.EncodeToString(redactedBytes), message.ThinkingBlocks[1].Data)
 }
 
+func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_ResponseBody_WithReasoningSignatureOnly(t *testing.T) {
+	// A reasoning block carrying only a signature (no text) must not emit an empty
+	// reasoning_content string; the signature still round-trips via thinking_blocks.
+	mockBedrockResponse := awsbedrock.ConverseResponse{
+		Output: &awsbedrock.ConverseOutput{
+			Message: awsbedrock.Message{
+				Role: awsbedrock.ConversationRoleAssistant,
+				Content: []*awsbedrock.ContentBlock{
+					{
+						ReasoningContent: &awsbedrock.ReasoningContentBlock{
+							ReasoningText: &awsbedrock.ReasoningTextBlock{
+								Signature: "sig_only",
+							},
+						},
+					},
+					{
+						Text: ptr.To("The answer is 42."),
+					},
+				},
+			},
+		},
+		StopReason: ptr.To(awsbedrock.StopReasonEndTurn),
+	}
+
+	body, err := json.Marshal(mockBedrockResponse)
+	require.NoError(t, err)
+
+	o := &openAIToAWSBedrockTranslatorV1ChatCompletion{}
+	_, outputBody, _, _, err := o.ResponseBody(nil, bytes.NewBuffer(body), false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, outputBody)
+
+	var openAIResponse openai.ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(outputBody, &openAIResponse))
+	require.Len(t, openAIResponse.Choices, 1)
+	message := openAIResponse.Choices[0].Message
+
+	require.Nil(t, message.ReasoningContent, "reasoning_content must be absent when there is no reasoning text")
+	require.Len(t, message.ThinkingBlocks, 1)
+	require.Equal(t, "thinking", message.ThinkingBlocks[0].Type)
+	require.Empty(t, message.ThinkingBlocks[0].Thinking)
+	require.Equal(t, "sig_only", message.ThinkingBlocks[0].Signature)
+
+	// reasoning_content must not appear on the wire at all.
+	var untypedResponse map[string]interface{}
+	require.NoError(t, json.Unmarshal(outputBody, &untypedResponse))
+	choices := untypedResponse["choices"].([]interface{})
+	messageMap := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+	_, hasReasoning := messageMap["reasoning_content"]
+	require.False(t, hasReasoning, "reasoning_content key must be omitted for a signature-only block")
+}
+
 func TestOpenAIToAWSBedrockTranslatorV1ChatCompletion_Streaming_WithRedactedContent(t *testing.T) {
 	redactedBytes := []byte("a redacted thought")
 	inputEvents := []awsbedrock.ConverseStreamEvent{


### PR DESCRIPTION
**Description**

The non-streaming AWS Bedrock path still serialized `reasoning_content` as the legacy nested object (`reasoning_content.reasoningContent.reasoningText.text`) instead of a plain string. OpenAI-compatible clients that follow the de-facto `reasoning_content: string` convention break on this — Open WebUI raises `sequence item 0: expected str instance, dict found` when concatenating reasoning.

This closes the remaining gap in the reasoning-content convention:

| Path | Non-streaming | Streaming |
|---|---|---|
| Gemini/Vertex | ✅ #1995 | ✅ #2319 |
| AWS Bedrock | ❌ **this PR** | ✅ #2319 |

`openai_awsbedrock.go` now mirrors the streaming path and the Gemini helper: the reasoning text goes to the plain-string `reasoning_content`, and the signature / redacted content move to `thinking_blocks` (they cannot be represented in a plain string). Existing translator goldens are updated to the new wire shape, plus a new regression test covering signature and redacted content.

Per the generative AI policy: this change was developed with an AI assistant (Claude); I take ownership of the code and will address review feedback.

**Related Issues/PRs (if applicable)**

Fixes #2519
Related PR: #2319 (streaming counterpart), #1995 (Gemini non-streaming)

**Special notes for reviewers (if applicable)**

This is the non-streaming follow-up @johnugeorge asked for in #2519. The signature/redacted-content routing to `thinking_blocks` matches what #2319 already does for streaming.
