### PR TITLE
mcp: include backend extensions in merged capabilities

### DIFF
--- a/internal/mcpproxy/handlers_test.go
+++ b/internal/mcpproxy/handlers_test.go
@@ -2911,3 +2911,60 @@ func TestAddMCPHeaders_MetadataValueGuard(t *testing.T) {
 		})
 	}
 }
+
+// TestServePOST_InitializeRequest_ForwardsExtensions asserts a backend's extensions capability
+// reaches the client. Without it a backend that advertises an extension, e.g. MCP Apps
+// (io.modelcontextprotocol/ui), appears to support none once it is behind the proxy, so the client
+// never negotiates it and ignores the ui metadata the backend puts on its tools.
+func TestServePOST_InitializeRequest_ForwardsExtensions(t *testing.T) {
+	const initializeWithExtensions = `{
+"jsonrpc": "2.0",
+"id": 1,
+"result": {
+"protocolVersion": "2025-06-18",
+"capabilities": {
+"tools": {"listChanged": true},
+"extensions": {"io.modelcontextprotocol/ui": {}}
+},
+"serverInfo": {"name": "ui-backend", "version": "1.0.0"}
+}
+}`
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(sessionIDHeader) == "" {
+			w.Header().Set(sessionIDHeader, "test-session-123")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(initializeWithExtensions))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(testServer.Close)
+
+	proxy := newTestMCPProxy()
+	proxy.backendListenerAddr = testServer.URL
+
+	id, err := jsonrpc.MakeID("test-1")
+	require.NoError(t, err)
+	initReq := &jsonrpc.Request{Method: "initialize", ID: id, Params: []byte(`{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"c","version":"1"}}`)}
+	body, err := jsonrpc.EncodeMessage(initReq)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(internalapi.MCPRouteHeader, "test-route")
+	rr := httptest.NewRecorder()
+
+	proxy.servePOST(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp struct {
+		Result struct {
+			Capabilities struct {
+				Extensions map[string]any `json:"extensions"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Contains(t, resp.Result.Capabilities.Extensions, "io.modelcontextprotocol/ui")
+}

--- a/internal/mcpproxy/session.go
+++ b/internal/mcpproxy/session.go
@@ -683,6 +683,16 @@ func (s *session) mergedCapabilities() *mcpsdk.ServerCapabilities {
 				merged.Completions = &mcpsdk.CompletionCapabilities{}
 			}
 		}
+		for id, ext := range caps.Extensions {
+			if merged.Extensions == nil {
+				merged.Extensions = make(map[string]any, len(caps.Extensions))
+			}
+			// First backend to declare an extension wins, so the merge is stable regardless of
+			// map iteration order.
+			if _, ok := merged.Extensions[id]; !ok {
+				merged.Extensions[id] = ext
+			}
+		}
 	}
 	return merged
 }

--- a/internal/mcpproxy/session_test.go
+++ b/internal/mcpproxy/session_test.go
@@ -245,6 +245,25 @@ func TestMergedCapabilities(t *testing.T) {
 				Resources: &mcpsdk.ResourceCapabilities{ListChanged: true, Subscribe: true},
 			},
 		},
+		{
+			name: "union of extensions across backends",
+			backends: map[filterapi.MCPBackendName]*compositeSessionEntry{
+				"b1": {capabilities: &mcpsdk.ServerCapabilities{
+					Extensions: map[string]any{"io.modelcontextprotocol/ui": map[string]any{}},
+				}},
+				"b2": {capabilities: &mcpsdk.ServerCapabilities{
+					Tools:      &mcpsdk.ToolCapabilities{ListChanged: true},
+					Extensions: map[string]any{"example.com/other": map[string]any{}},
+				}},
+			},
+			want: &mcpsdk.ServerCapabilities{
+				Tools: &mcpsdk.ToolCapabilities{ListChanged: true},
+				Extensions: map[string]any{
+					"io.modelcontextprotocol/ui": map[string]any{},
+					"example.com/other":          map[string]any{},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
**Description**

`mergedCapabilities()` unions Tools, Prompts, Logging, Resources and Completions but drops Extensions, so a backend advertising `io.modelcontextprotocol/ui` looks like it supports no extensions once it is behind the proxy, and clients never negotiate MCP Apps.

Found this with an MCP Apps server behind an MCPRoute: the backend advertises the extension in initialize and its tool carries `_meta.ui.resourceUri`, but the client sees no extensions downstream and renders the tool result as text instead of the view.

The proxy does receive it. Before this change, with a backend whose initialize advertises the extension, the session log shows `Extensions:map[io.modelcontextprotocol/ui:map[]]` while the initialize response written downstream has no extensions at all.

Extensions are unioned like the other fields. The first backend to declare an id wins, so the result does not depend on map iteration order. Two tests: a case in TestMergedCapabilities, and TestServePOST_InitializeRequest_ForwardsExtensions which drives servePOST against a backend advertising the extension and asserts it survives into the downstream response.

This may not be sufficient on its own: handleInitializeRequest answers with a fixed protocolVersion of 2025-06-18, which predates extension negotiation, so a client keyed on the negotiated version could still ignore the map. Happy to fold that in here or leave it separate, whichever you prefer.

`TestServePOST_ToolsCallRequest` fails on main with or without this change, so it looks unrelated.

**Related Issues/PRs (if applicable)**

Fixes #2531