### PR TITLE
fix: skip empty envoy gateway namespace in getObjectsForGateway

### DIFF
--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -1325,9 +1325,12 @@ func (c *GatewayController) getObjectsForGateway(ctx context.Context, gw *gwapiv
 		"%s=%s,%s=%s", egOwningGatewayNameLabel, gw.Name, egOwningGatewayNamespaceLabel, gw.Namespace,
 	)}
 
+	// The Envoy Gateway namespace is only a candidate when it is distinct from the Gateway's namespace.
+	// An empty one is skipped as well since listing the empty namespace lists every namespace, which
+	// returns the Gateway's own objects a second time and trips the consistency check below.
 	candidateNamespaces := make([]string, 1, 2)
 	candidateNamespaces[0] = gw.Namespace
-	if c.envoyGatewayNamespace != gw.Namespace {
+	if c.envoyGatewayNamespace != "" && c.envoyGatewayNamespace != gw.Namespace {
 		candidateNamespaces = append(candidateNamespaces, c.envoyGatewayNamespace)
 	}
 

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -4007,3 +4007,28 @@ func TestGatewayController_getObjectsForGatewaySameNamespace(t *testing.T) {
 	require.Len(t, pods, 1)
 	require.Len(t, deployments, 1)
 }
+
+func TestGatewayController_getObjectsForGatewayEmptyEnvoyGatewayNamespace(t *testing.T) {
+	const gwName, ns = "gw", "ns"
+	labels := map[string]string{
+		egOwningGatewayNameLabel:      gwName,
+		egOwningGatewayNamespaceLabel: ns,
+	}
+	gw := &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: ns}}
+
+	kube := fake2.NewClientset()
+	// An empty Envoy Gateway namespace must not be listed: listing the empty namespace means
+	// listing across all namespaces, which returns the Gateway's own objects a second time.
+	c := newTestGatewayController(requireNewFakeClientWithIndexes(t), kube, ctrl.Log, "",
+		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
+
+	_, err := kube.CoreV1().Pods(ns).Create(t.Context(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: ns, Labels: labels},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	namespace, pods, _, _, err := c.getObjectsForGateway(t.Context(), gw)
+	require.NoError(t, err)
+	require.Equal(t, ns, namespace)
+	require.Len(t, pods, 1)
+}


### PR DESCRIPTION
**Description**

# Issue #2492 — `getObjectsForGateway` namespace dedup

## 1. Root cause

The symptom reported in #2492 is the gateway reconciler aborting with

```
failed to get objects for gateway internal: found gateway-labeled objects in multiple namespaces: [envoy-gateway-system envoy-gateway-system]
```

Because `Reconcile` returns early, the per-gateway filter-config Secret is never written, the
pod-mutator logs `filter config secret not found, skipping mutation`, and no `ai-gateway-extproc`
container is injected — the MCP data plane is dead.

`getObjectsForGateway` (`internal/controller/gateway.go`) looks for the Envoy proxy workloads in the
two namespaces where Envoy Gateway may place them: the Gateway's own namespace, or the Envoy Gateway
control-plane namespace. It lists each candidate, appends every candidate that yielded objects to
`distinctNamespaces`, and errors out when more than one namespace produced results. That check is
only sound if the candidate list contains genuinely distinct namespaces; otherwise the *same*
objects are listed twice and the same namespace is recorded twice, producing a false positive. The
duplicated name in the error message (`[<ns> <ns>]`) is the tell.

The exact case in the report — Gateway deployed into `envoy-gateway-system`, so
`gw.Namespace == c.envoyGatewayNamespace` — **is already fixed on `main`** by #2304 (merged
2026-07-01), which appends the Envoy Gateway namespace only when it differs. Both the fix and its
regression tests are present at this HEAD. The remaining part of #2492 is a release question
(backport to `release/v1.0` vs. ship in v1.1), which is a maintainer decision and not something a
code change here can answer; per RELEASES.md the mechanics are a cherry-pick PR onto `release/v1.0`
followed by a `v1.0.1` tag cut from that branch.

What #2304 did *not* close is the other way two candidates can collapse onto the same objects: an
**empty** Envoy Gateway namespace. `c.envoyGatewayNamespace` is plumbed from the
`--envoyGatewayNamespace` flag, which the Helm chart renders unconditionally from
`.Values.envoyGateway.namespace` (`manifests/charts/ai-gateway-helm/templates/deployment.yaml:58`),
so a values override that blanks or unsets that key ships `--envoyGatewayNamespace=` to the
controller. `""` is not "no namespace" in client-go — it means *all* namespaces. The second list
then re-returns every object already found in the Gateway's namespace, `distinctNamespaces` becomes
`[<ns> ""]`, and the reconciler fails with the identical error and the identical downstream outage:

```
found gateway-labeled objects in multiple namespaces: [ns ]
```

(note the empty second entry). Even without the hard error, the duplicated pods/deployments would
be patched twice by `annotateGatewayPods`.

## 2. The fix and why

One guard in the candidate-namespace construction:

```go
if c.envoyGatewayNamespace != "" && c.envoyGatewayNamespace != gw.Namespace {
    candidateNamespaces = append(candidateNamespaces, c.envoyGatewayNamespace)
}
```

An empty Envoy Gateway namespace carries no information about where the proxies live, and listing it
actively harms: it re-scans the Gateway's namespace under a different label, which is precisely the
duplicate-listing shape #2304 set out to eliminate. Skipping it keeps the candidate list to
genuinely distinct namespaces, which is the invariant the `len(distinctNamespaces) > 1` check
depends on. This is deliberately the same shape of fix as #2304 (a condition on the append, not a
restructuring of the consistency check) so it stays a trivially reviewable candidate for the same
`release/v1.0` backport.

Behaviour with a properly configured controller (the default `envoy-gateway-system`, or any
non-empty value) is untouched: the guard only fires on the empty string, which today can only
produce the false-positive error, never a correct result.

## 3. Files changed

- `internal/controller/gateway.go` — skip an empty `envoyGatewayNamespace` when building
  `candidateNamespaces`; comment explaining why both the duplicate and the empty case are excluded.
- `internal/controller/gateway_test.go` — new
  `TestGatewayController_getObjectsForGatewayEmptyEnvoyGatewayNamespace`, sitting next to the two
  tests #2304 added, asserting no error and exactly one pod when the controller is built with an
  empty Envoy Gateway namespace.

## 4. Risk / uncertainty

- **Low blast radius.** The only behaviour change is for `envoyGatewayNamespace == ""`, a
  configuration that is currently broken outright (any Gateway with running proxies errors the
  reconcile).
- **Judgement call worth flagging:** empty could alternatively be read as "search cluster-wide",
  which is what v0.6.0 and earlier did with a single `List("")` before #2274 narrowed it to a
  per-namespace iteration. Supporting that intent properly would mean deriving the distinct-namespace
  check from the namespaces of the returned objects rather than from the candidate list. I did not
  do that: it is a larger change, nothing documents empty as a cluster-wide opt-in, and it would be a
  poor backport candidate. If maintainers do want cluster-wide search restored, this guard should be
  replaced by that object-derived check rather than extended.
- **Not addressed here:** the backport/release-timing questions in #2492, and the fact that a
  *genuine* two-namespace split (e.g. stale workloads after an Envoy Gateway deployment-mode change)
  still hard-fails reconciliation forever with no self-healing. That is existing intended behaviour
  and out of scope for this issue.

## 5. How I verified it

Go 1.26.4, from the repo root.

- Wrote the test first and confirmed it fails against unmodified `main`, reproducing the issue's
  error string with the empty second entry:
  ```
  --- FAIL: TestGatewayController_getObjectsForGatewayEmptyEnvoyGatewayNamespace
      Error: Received unexpected error:
             found gateway-labeled objects in multiple namespaces: [ns ]
  ```
- After the fix, all three `getObjectsForGateway` tests pass, including the two from #2304:
  ```
  $ go test ./internal/controller/ -run TestGatewayController_getObjectsForGateway -v
  --- PASS: TestGatewayController_getObjectsForGatewayNamespaceInconsistency (0.08s)
  --- PASS: TestGatewayController_getObjectsForGatewaySameNamespace (0.01s)
  --- PASS: TestGatewayController_getObjectsForGatewayEmptyEnvoyGatewayNamespace (0.00s)
  PASS
  ```
- Full package suite and static checks clean:
  ```
  $ go build ./... && go vet ./internal/controller/ && go test ./internal/controller/
  ok  	github.com/envoyproxy/ai-gateway/internal/controller	5.462s
  ```

Not run: `make precommit` (lint/codegen toolchain not fetched in this environment) and the e2e
suites, which need a cluster.