### PR TITLE
fix(translator): translate AWS Bedrock CountTokens errors to Anthropic error format

### DIFF
--- a/internal/translator/anthropic_awsbedrock.go
+++ b/internal/translator/anthropic_awsbedrock.go
@@ -848,7 +848,7 @@ func (a *anthropicToAWSBedrockTranslator) ResponseError(respHeaders map[string]s
 	anthropicError := anthropicschema.ErrorResponse{
 		Type: "error",
 		Error: anthropicschema.ErrorResponseMessage{
-			Type:    a.httpStatusToAnthropicErrorType(statusCode),
+			Type:    httpStatusToAnthropicErrorType(statusCode),
 			Message: errorMessage,
 		},
 	}
@@ -861,25 +861,4 @@ func (a *anthropicToAWSBedrockTranslator) ResponseError(respHeaders map[string]s
 		{contentLengthHeaderName, strconv.Itoa(len(mutatedBody))},
 	}
 	return
-}
-
-func (a *anthropicToAWSBedrockTranslator) httpStatusToAnthropicErrorType(statusCode string) string {
-	switch statusCode {
-	case "400":
-		return "invalid_request_error"
-	case "401":
-		return "authentication_error"
-	case "403":
-		return "permission_error"
-	case "404":
-		return "not_found_error"
-	case "429":
-		return "rate_limit_error"
-	case "500":
-		return "internal_server_error"
-	case "503":
-		return "service_unavailable_error"
-	default:
-		return "internal_server_error"
-	}
 }

--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -1396,6 +1396,33 @@ func awsAnthropicCountTokensPath(model string) string {
 	return fmt.Sprintf(awsBedrockCountTokensPathFormat, url.PathEscape(model))
 }
 
+// httpStatusToAnthropicErrorType maps an upstream HTTP status code to Anthropic's
+// error type taxonomy. Shared by translators that produce Anthropic-schema error
+// responses from a non-Anthropic-shaped upstream (e.g. AWS Bedrock's Converse and
+// CountTokens APIs), so a client always sees a well-formed
+// {"type":"error","error":{"type":...,"message":...}} envelope regardless of backend.
+// See: https://docs.claude.com/en/api/errors#http-errors
+func httpStatusToAnthropicErrorType(statusCode string) string {
+	switch statusCode {
+	case "400":
+		return "invalid_request_error"
+	case "401":
+		return "authentication_error"
+	case "403":
+		return "permission_error"
+	case "404":
+		return "not_found_error"
+	case "429":
+		return "rate_limit_error"
+	case "500":
+		return "internal_server_error"
+	case "503":
+		return "service_unavailable_error"
+	default:
+		return "internal_server_error"
+	}
+}
+
 // openAIToAnthropicCountTokensParams builds the Anthropic MessageCountTokensParams
 // from an OpenAI-compatible tokenize chat request. Shared by GCP and AWS Anthropic tokenize translators.
 //

--- a/internal/translator/counttokens_awsanthropic.go
+++ b/internal/translator/counttokens_awsanthropic.go
@@ -11,11 +11,13 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
 	anthropicschema "github.com/envoyproxy/ai-gateway/internal/apischema/anthropic"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/awsbedrock"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 	"github.com/envoyproxy/ai-gateway/internal/json"
 	"github.com/envoyproxy/ai-gateway/internal/metrics"
@@ -120,8 +122,44 @@ func (t *countTokensToAWSAnthropicTranslator) ResponseBody(_ map[string]string, 
 }
 
 // ResponseError implements [AnthropicCountTokensTranslator.ResponseError].
-func (t *countTokensToAWSAnthropicTranslator) ResponseError(_ map[string]string, _ io.Reader) (
+// AWS Bedrock's CountTokens API does not support every Anthropic model (e.g. it
+// returns a ValidationException for some models), and its error body is shaped
+// like [awsbedrock.BedrockException], not an Anthropic error. Translate it to
+// Anthropic's {"type":"error","error":{"type":...,"message":...}} envelope so
+// clients always see a well-formed error regardless of backend.
+func (t *countTokensToAWSAnthropicTranslator) ResponseError(respHeaders map[string]string, body io.Reader) (
 	newHeaders []internalapi.Header, mutatedBody []byte, err error,
 ) {
-	return nil, nil, nil
+	statusCode := respHeaders[statusHeaderName]
+	var errorMessage string
+	if v, ok := respHeaders[contentTypeHeaderName]; ok && strings.Contains(v, jsonContentType) {
+		var bedrockError awsbedrock.BedrockException
+		if err = json.NewDecoder(body).Decode(&bedrockError); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal error body: %w", err)
+		}
+		errorMessage = bedrockError.Message
+	} else {
+		var buf []byte
+		buf, err = io.ReadAll(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read error body: %w", err)
+		}
+		errorMessage = string(buf)
+	}
+	anthropicError := anthropicschema.ErrorResponse{
+		Type: "error",
+		Error: anthropicschema.ErrorResponseMessage{
+			Type:    httpStatusToAnthropicErrorType(statusCode),
+			Message: errorMessage,
+		},
+	}
+	mutatedBody, err = json.Marshal(anthropicError)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal error body: %w", err)
+	}
+	newHeaders = []internalapi.Header{
+		{contentTypeHeaderName, jsonContentType},
+		{contentLengthHeaderName, strconv.Itoa(len(mutatedBody))},
+	}
+	return
 }

--- a/internal/translator/counttokens_awsanthropic_test.go
+++ b/internal/translator/counttokens_awsanthropic_test.go
@@ -7,6 +7,7 @@ package translator
 
 import (
 	"encoding/base64"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -136,8 +137,103 @@ func TestCountTokensToAWSAnthropic_ResponseError(t *testing.T) {
 	translator := NewCountTokensToAWSAnthropicTranslator("bedrock-2023-05-31", "")
 	require.NotNil(t, translator)
 
-	hdrs, body, err := translator.ResponseError(nil, nil)
-	require.NoError(t, err)
-	require.Nil(t, hdrs)
-	require.Nil(t, body)
+	t.Run("AWS structured error response", func(t *testing.T) {
+		// Real-world repro: Bedrock's CountTokens API rejects some Anthropic models.
+		respHeaders := map[string]string{
+			statusHeaderName:       "400",
+			contentTypeHeaderName:  "application/json",
+			awsErrorTypeHeaderName: "ValidationException",
+		}
+		errorBody := `{"message": "The provided model doesn't support counting tokens"}`
+
+		headers, body, err := translator.ResponseError(respHeaders, strings.NewReader(errorBody))
+		require.NoError(t, err)
+		require.NotNil(t, body)
+		require.Len(t, headers, 2)
+		assert.Equal(t, contentTypeHeaderName, headers[0].Key())
+		assert.Equal(t, jsonContentType, headers[0].Value()) //nolint:testifylint // comparing header value, not JSON
+		assert.Equal(t, contentLengthHeaderName, headers[1].Key())
+		assert.Equal(t, strconv.Itoa(len(body)), headers[1].Value())
+
+		var errResp anthropicschema.ErrorResponse
+		require.NoError(t, json.Unmarshal(body, &errResp))
+		assert.Equal(t, "error", errResp.Type)
+		assert.Equal(t, "invalid_request_error", errResp.Error.Type)
+		assert.Equal(t, "The provided model doesn't support counting tokens", errResp.Error.Message)
+	})
+
+	t.Run("non-JSON error body", func(t *testing.T) {
+		headers, body, err := translator.ResponseError(
+			map[string]string{
+				statusHeaderName:      "503",
+				contentTypeHeaderName: "text/plain",
+			},
+			strings.NewReader("Service Unavailable"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, headers)
+		require.Len(t, headers, 2)
+		assert.Equal(t, contentLengthHeaderName, headers[1].Key())
+		assert.Equal(t, strconv.Itoa(len(body)), headers[1].Value())
+
+		var errResp anthropicschema.ErrorResponse
+		require.NoError(t, json.Unmarshal(body, &errResp))
+		assert.Equal(t, "error", errResp.Type)
+		assert.Equal(t, "service_unavailable_error", errResp.Error.Type)
+		assert.Equal(t, "Service Unavailable", errResp.Error.Message)
+	})
+
+	t.Run("malformed JSON error body", func(t *testing.T) {
+		_, _, err := translator.ResponseError(
+			map[string]string{
+				statusHeaderName:      "400",
+				contentTypeHeaderName: "application/json",
+			},
+			strings.NewReader(`{"message": not valid json`),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal error body")
+	})
+
+	t.Run("status code mappings", func(t *testing.T) {
+		tests := []struct {
+			status       string
+			expectedType string
+		}{
+			{"400", "invalid_request_error"},
+			{"401", "authentication_error"},
+			{"403", "permission_error"},
+			{"404", "not_found_error"},
+			{"429", "rate_limit_error"},
+			{"500", "internal_server_error"},
+			{"503", "service_unavailable_error"},
+			{"502", "internal_server_error"}, // default
+		}
+		for _, tt := range tests {
+			t.Run(tt.status, func(t *testing.T) {
+				_, body, err := translator.ResponseError(
+					map[string]string{
+						statusHeaderName:      tt.status,
+						contentTypeHeaderName: "text/plain",
+					},
+					strings.NewReader("error"),
+				)
+				require.NoError(t, err)
+				var errResp anthropicschema.ErrorResponse
+				require.NoError(t, json.Unmarshal(body, &errResp))
+				assert.Equal(t, tt.expectedType, errResp.Error.Type)
+			})
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		_, _, err := translator.ResponseError(
+			map[string]string{
+				statusHeaderName:      "500",
+				contentTypeHeaderName: "text/plain",
+			},
+			&errorReader{},
+		)
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
**Description**

AWS Bedrock's `CountTokens` API (used by the `AWSAnthropic` backend's `/v1/messages/count_tokens` translator) does not support every Anthropic model, and returns a `ValidationException` for the ones it doesn't. Before this change, `ResponseError` in `internal/translator/counttokens_awsanthropic.go` was a no-op stub that always returned `nil, nil, nil`, so this upstream error reached the client as Bedrock's raw error shape instead of a well-formed Anthropic error envelope (`{"type":"error","error":{"type":"...","message":"..."}}`).

This was confirmed directly against `aws bedrock-runtime count-tokens`, bypassing the gateway: `anthropic.claude-opus-5`, `anthropic.claude-sonnet-5`, and `anthropic.claude-opus-4-8` all return `ValidationException: The provided model doesn't support counting tokens`, while `anthropic.claude-sonnet-4-6` and `anthropic.claude-haiku-4-5-20251001-v1:0` succeed on the same account/region.

This change implements `ResponseError` following the same convention already used by two sibling translators in this codebase for the equivalent problem:

- `anthropic_awsbedrock.go`'s `ResponseError` (Anthropic-schema output, Bedrock Converse backend)
- `tokenize_awsanthropic.go`'s `ResponseError` (OpenAI-schema output, the same Bedrock CountTokens/InvokeModel API as this bug) — its existing test already uses the exact error message from this report.

Specifically: decode `awsbedrock.BedrockException` from the response body when `content-type` is JSON (falling back to the raw body as the error message otherwise, matching the established fallback behavior), then build an `anthropicschema.ErrorResponse` using a status-code to Anthropic-error-type mapping. That mapping (`httpStatusToAnthropicErrorType`) previously lived as a private method on `anthropicToAWSBedrockTranslator`; it's now a shared package-level function in `anthropic_helper.go` so both translators use the same, single implementation instead of a third copy. The gateway passes the upstream HTTP status code through to the client unchanged, so this only reshapes the error body, not the status code.

The surrounding Bedrock-error-decoding logic (decode-JSON-or-fall-back-to-raw-text) is intentionally left duplicated rather than fully deduplicated across translators — this mirrors the existing, already-established pattern in this codebase (the same shape of logic already exists independently in `openai_awsanthropic.go`, `anthropic_awsbedrock.go`, and `tokenize_awsanthropic.go`), keeping this fix small and focused rather than mixing in a larger refactor.

**Related Issues/PRs (if applicable)**

Fixes #2546
Related: #2078 (introduced this endpoint and this gap), #1360 (original feature request that #2078 implemented)

**Special notes for reviewers (if applicable)**

This PR was prepared with the assistance of an AI coding agent, per the project's generative AI policy. I've reviewed the change, understand it, and take ownership of it; happy to address review feedback directly.
