### PR TITLE
fix(translator): emit empty chunk on Anthropic ping to keep streams alive

### DIFF
--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -1248,8 +1248,13 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 		return nil, fmt.Errorf("anthropic stream error: %s - %s", errEvent.Error.Type, errEvent.Error.Message)
 
 	case "ping":
-		// Per documentation, ping events can be ignored.
-		return nil, nil
+		// Anthropic sends ping events periodically to keep the stream alive.
+		// Emit an empty chunk (empty delta, no finish reason) so that idle
+		// downstream connections stay alive during long gaps between content
+		// events. An empty delta does not carry content or the assistant role,
+		// so it does not consume the role-bearing "first chunk" slot; the role
+		// is still emitted on the first real content/tool-call chunk.
+		return p.constructOpenAIChatCompletionChunk(&openai.ChatCompletionResponseChunkChoiceDelta{}, ""), nil
 	}
 	return nil, nil
 }

--- a/internal/translator/openai_awsanthropic_test.go
+++ b/internal/translator/openai_awsanthropic_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -610,6 +611,63 @@ data: {"type": "message_stop"}
 		require.Contains(t, bodyStr, `"finish_reason":"stop"`)
 		require.Contains(t, bodyStr, `"prompt_tokens":25`)
 		require.Contains(t, bodyStr, `"completion_tokens":15`)
+		require.Contains(t, bodyStr, string(sseDoneMessage))
+		// The ping event is translated into an empty keep-alive chunk and does
+		// not consume the role-bearing first chunk: the role still lands on the
+		// first real content chunk.
+		require.Contains(t, bodyStr, `"delta":{}}`)
+		require.Contains(t, bodyStr, `"role":"assistant"`)
+	})
+
+	t.Run("emits empty keep-alive chunk on ping", func(t *testing.T) {
+		sseStream := `
+event: message_start
+data: {"type": "message_start", "message": {"id": "msg_ping", "type": "message", "role": "assistant", "content": [], "model": "claude-opus-4-20250514", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 5, "output_tokens": 1}}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hi"}}
+
+event: content_block_stop
+data: {"type": "content_block_stop", "index": 0}
+
+event: message_delta
+data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence":null}, "usage": {"output_tokens": 3}}
+
+event: message_stop
+data: {"type": "message_stop"}
+
+`
+		eventStreamData, err := wrapAnthropicSSEInEventStream(sseStream)
+		require.NoError(t, err)
+
+		openAIReq := &openai.ChatCompletionRequest{Stream: true, Model: "test-model", MaxTokens: new(int64)}
+		translator := NewChatCompletionOpenAIToAWSAnthropicTranslator("", "").(*openAIToAWSAnthropicTranslatorV1ChatCompletion)
+		_, _, err = translator.RequestBody(nil, openAIReq, false)
+		require.NoError(t, err)
+
+		_, bm, _, _, err := translator.ResponseBody(map[string]string{}, bytes.NewReader(eventStreamData), true, nil)
+		require.NoError(t, err)
+		require.NotNil(t, bm)
+
+		bodyStr := string(bm)
+		// Each ping produces exactly one empty-delta keep-alive chunk.
+		require.Equal(t, 2, strings.Count(bodyStr, `"delta":{}}`))
+		// The empty keep-alive chunks carry the active message ID so downstream
+		// clients see a well-formed chunk.
+		require.Contains(t, bodyStr, `"id":"msg_ping"`)
+		// The assistant role is still emitted on the first real content chunk,
+		// not consumed by the preceding ping chunk.
+		require.Contains(t, bodyStr, `"role":"assistant"`)
+		require.Contains(t, bodyStr, `"content":"Hi"`)
 		require.Contains(t, bodyStr, string(sseDoneMessage))
 	})
 


### PR DESCRIPTION
**Description**

When translating an Anthropic Messages **streaming** response into the OpenAI **Chat Completion** streaming format, the Anthropic `ping` event was silently dropped (`handleAnthropicStreamEvent` returned `nil, nil`), so no chunk was emitted downstream.

Anthropic emits `ping` events periodically to keep the stream alive. Dropping them means long gaps between content events (e.g. extended thinking or a slow first token) produce no bytes on the OpenAI-facing SSE stream, letting intermediary proxies / load balancers with idle-connection timeouts tear down the downstream connection before the first real content chunk arrives.

This PR emits an empty Chat Completion chunk (`{"choices":[{"index":0,"delta":{}}], ...}`) on `ping` instead. An empty delta carries no content or role, so it does **not** consume the role-bearing "first chunk" slot — the `assistant` role is still emitted on the first real content/tool-call chunk. This mirrors LiteLLM's effective behavior (its Anthropic iterator has no explicit `ping` branch and falls through to an empty chunk).

The change is in the shared `handleAnthropicStreamEvent`, so it covers both the AWS Bedrock (`openai_awsanthropic.go`) and GCP Vertex (`openai_gcpanthropic.go`) Anthropic paths. The Anthropic → Anthropic passthrough path is unaffected (it forwards `ping` as-is).

**Commit Message**

fix(translator): emit empty chunk on Anthropic ping to keep streams alive

**Related Issues/PRs (if applicable)**

Fixes #2548

**Testing**

- Augmented the existing "handles simple text stream" test to assert the ping now produces a keep-alive chunk and that the assistant role still appears on the real content chunk.
- Added a dedicated "emits empty keep-alive chunk on ping" test with two pings, asserting exactly two empty-delta chunks, that they carry the active message ID, and that the role/content still land on the real chunk.
- `go test ./internal/translator/`, `gofmt`, and `go vet` all pass.
