### PR TITLE
fix: remove stale content-encoding header on translated error responses

### DIFF
--- a/internal/extproc/processor_impl.go
+++ b/internal/extproc/processor_impl.go
@@ -572,6 +572,8 @@ func (u *upstreamProcessor[ReqT, RespT, RespChunkT, EndpointSpecT]) ProcessRespo
 			return nil, fmt.Errorf("failed to transform response error: %w", err)
 		}
 		headerMutation, bodyMutation := mutationsFromTranslationResult(newHeaders, newBody)
+		// Remove content-encoding header if original body encoded but was mutated in the processor.
+		headerMutation = removeContentEncodingIfNeeded(headerMutation, bodyMutation, decodingResult.isEncoded)
 		if u.parent.span != nil {
 			b := bodyMutation.GetBody()
 			if b == nil {

--- a/internal/extproc/processor_impl_test.go
+++ b/internal/extproc/processor_impl_test.go
@@ -7,6 +7,7 @@ package extproc
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -454,6 +455,40 @@ func Test_chatCompletionProcessorUpstreamFilter_ProcessResponseBody(t *testing.T
 		require.Len(t, commonRes.HeaderMutation.SetHeaders, 1)
 		require.Equal(t, "foo", commonRes.HeaderMutation.SetHeaders[0].Header.Key)
 		require.Equal(t, []byte("bar"), commonRes.HeaderMutation.SetHeaders[0].Header.RawValue)
+		mm.RequireRequestFailure(t)
+	})
+
+	// Verify the stale content-encoding header is removed when a compressed error body is replaced
+	// with the uncompressed translated error.
+	t.Run("non-2xx status removes content-encoding", func(t *testing.T) {
+		var compressed bytes.Buffer
+		gz := gzip.NewWriter(&compressed)
+		_, err := gz.Write([]byte("error-body"))
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+
+		expHeadMut := []internalapi.Header{{"foo", "bar"}}
+		expBodyMut := []byte("translated-error-body")
+		mm := &mockMetrics{}
+		mt := &mockTranslator{
+			t: t,
+			// The translator must receive the decompressed body.
+			expResponseBody:   &extprocv3.HttpBody{Body: []byte("error-body")},
+			retHeaderMutation: expHeadMut,
+			retBodyMutation:   expBodyMut,
+		}
+		p := &chatCompletionProcessorUpstreamFilter{
+			translator:       mt,
+			metrics:          mm,
+			responseHeaders:  map[string]string{":status": "500", "content-encoding": "gzip"},
+			responseEncoding: "gzip",
+			parent:           &chatCompletionProcessorRouterFilter{},
+		}
+		res, err := p.ProcessResponseBody(t.Context(), &extprocv3.HttpBody{Body: compressed.Bytes(), EndOfStream: true})
+		require.NoError(t, err)
+		commonRes := res.Response.(*extprocv3.ProcessingResponse_ResponseBody).ResponseBody.Response
+		require.Equal(t, "translated-error-body", string(commonRes.BodyMutation.GetBody()))
+		require.Contains(t, commonRes.HeaderMutation.RemoveHeaders, "content-encoding")
 		mm.RequireRequestFailure(t)
 	})
 


### PR DESCRIPTION
**Description**

When the upstream returns a compressed (`content-encoding: gzip`) error response, the non-2xx branch of `ProcessResponseBody` decompresses the body and replaces it with the uncompressed translated OpenAI-format error, but leaves the `content-encoding` header intact. Clients then fail to decode the response: browsers reject it with `ERR_CONTENT_DECODING_FAILED`, and SDKs such as `@ai-sdk/openai-compatible` mask the real error as "Failed to process error response" — exactly when the body is needed for debugging.

The success path already handles this via `removeContentEncodingIfNeeded` (added for #682); this change applies the same call to the error path, and adds a regression test that fails without the fix.

**Related Issues/PRs (if applicable)**

Fixes #2553

**Special notes for reviewers (if applicable)**

Per the generative AI policy: this change was developed with AI assistance (Claude); I have reviewed it and take full ownership.
