### PR TITLE
fix: support parameterized JSON content types

### DIFF
--- a/internal/mcpproxy/content_type.go
+++ b/internal/mcpproxy/content_type.go
@@ -1,0 +1,17 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package mcpproxy
+
+import (
+	"mime"
+	"strings"
+)
+
+// isJSONMediaType reports whether contentType is a valid application/json media type.
+func isJSONMediaType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	return err == nil && strings.EqualFold(mediaType, "application/json")
+}

--- a/internal/mcpproxy/content_type_test.go
+++ b/internal/mcpproxy/content_type_test.go
@@ -1,0 +1,33 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package mcpproxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsJSONMediaType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{name: "plain", contentType: "application/json", want: true},
+		{name: "parameterized", contentType: "application/json; charset=UTF-8", want: true},
+		{name: "case variation", contentType: "Application/JSON; Charset=utf-8", want: true},
+		{name: "malformed", contentType: `application/json; charset="unterminated`, want: false},
+		{name: "missing", contentType: "", want: false},
+		{name: "non JSON", contentType: "text/event-stream", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isJSONMediaType(tt.contentType))
+		})
+	}
+}

--- a/internal/mcpproxy/handlers.go
+++ b/internal/mcpproxy/handlers.go
@@ -804,7 +804,7 @@ func (m *mcpRequestContext) handleToolCallRequest(ctx context.Context, s *sessio
 }
 
 func copyProxyHeaders(resp *http.Response, w http.ResponseWriter) {
-	isJSONResponse := resp.Header.Get("Content-Type") == "application/json"
+	isJSONResponse := isJSONMediaType(resp.Header.Get("Content-Type"))
 	for k, v := range resp.Header {
 		// Skip content-length header for non JSON response since we might modify the response.
 		if !isJSONResponse && strings.EqualFold(k, "content-length") {
@@ -827,7 +827,7 @@ func (m *mcpRequestContext) proxyResponseBody(ctx context.Context, s *session, w
 	// Try to decode as a single JSON-RPC message first; if that fails, fall through to the
 	// SSE parser using the already-read bytes.
 	var sseReader io.Reader = resp.Body
-	if resp.Header.Get("Content-Type") == "application/json" {
+	if isJSONMediaType(resp.Header.Get("Content-Type")) {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			m.l.Error("failed to read response body", slog.String("error", err.Error()))

--- a/internal/mcpproxy/session.go
+++ b/internal/mcpproxy/session.go
@@ -447,7 +447,7 @@ func (s *session) sendRequestPerBackend(ctx context.Context, eventChan chan<- *b
 		return fmt.Errorf("MCP GET request failed with status code %d, body=%s", httpResp.StatusCode, string(body))
 	}
 
-	if httpResp.Header.Get("Content-Type") == "application/json" {
+	if isJSONMediaType(httpResp.Header.Get("Content-Type")) {
 		// Try to decode as a single JSON-RPC message first.
 		var respBody []byte
 		respBody, err = io.ReadAll(bodyReader)


### PR DESCRIPTION
**Description**

Parse MCP response media types instead of comparing the raw `Content-Type` header. This recognizes valid parameterized and case-varied `application/json` values across all MCP proxy response paths, rejects malformed media types, and preserves non-JSON/SSE handling.

Tests cover plain, parameterized, case-varied, malformed, missing, and SSE media types. Local verification passed with `go test ./internal/mcpproxy -count=1` and `make precommit`.

**Related Issues/PRs (if applicable)**

Fixes #2568

**Special notes for reviewers (if applicable)**

Hermes Agent was used to help investigate the issue, draft the implementation and tests, and review the change. I reviewed and understand the submitted code and take responsibility for it.