### PR TITLE
fix(examples): use published inference test image

### DIFF
--- a/examples/inference-pool/with-annotations.yaml
+++ b/examples/inference-pool/with-annotations.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: upstream
-          image: registry.k8s.io/ai-gateway/testupstream:v0.0.0-latest
+          image: docker.io/envoyproxy/ai-gateway-testupstream:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
**Description**

The annotated InferencePool example references `registry.k8s.io/ai-gateway/testupstream:v0.0.0-latest`, which cannot be pulled because that repository is not published in the Kubernetes registry.

This change uses `docker.io/envoyproxy/ai-gateway-testupstream:latest`, matching the test upstream image already used by the base InferencePool example and the repository's other runnable examples and E2E manifests.

**Related Issues/PRs (if applicable)**

Fixes #2572

**Special notes for reviewers (if applicable)**

Validation:
- Parsed every document in `examples/inference-pool/with-annotations.yaml` with PyYAML
- Verified no example still references `registry.k8s.io/ai-gateway/testupstream`
- `git diff --check`

This change was developed with assistance from OpenAI Codex. I understand the change and take responsibility for the submitted code.