### PR TITLE
feat: validate Valkey rate-limit backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,11 @@ test-e2e: build-e2e ## Run the end-to-end tests with a local kind cluster.
 	@echo "Run E2E tests"
 	@go test -v ./tests/e2e/... $(GO_TEST_ARGS) $(GO_TEST_E2E_ARGS)
 
+.PHONY: test-e2e-ratelimit-valkey
+test-e2e-ratelimit-valkey: build-e2e ## Run rate-limit e2e tests against Valkey.
+	@echo "Run Valkey rate-limit E2E tests"
+	@E2E_RATELIMIT_STORAGE=valkey go test -v ./tests/e2e/... -run 'Test_Examples_(TokenRateLimit|BackendQuotaRateLimit)$$' $(GO_TEST_E2E_ARGS)
+
 # This runs the end-to-end tests for the controller and extproc with a local kind cluster.
 .PHONY: test-e2e-inference-extension
 test-e2e-inference-extension: build-e2e ## Run the end-to-end tests with a local kind cluster for Gateway API Inference Extension.

--- a/examples/token_ratelimit/README.md
+++ b/examples/token_ratelimit/README.md
@@ -7,13 +7,15 @@ of each request.
 
 ## Files in This Directory
 
-- **`envoy-gateway-values-addon.yaml`**: Envoy Gateway values addon for rate limiting. Combine with `../../manifests/envoy-gateway-values.yaml`.
-- **`redis.yaml`**: Redis deployment required for rate limiting. Deploy this before enabling rate limiting in Envoy Gateway.
+- **`envoy-gateway-values-addon.yaml`** and **`redis.yaml`**: Redis rate-limit backend and matching Envoy Gateway values addon.
+- **`envoy-gateway-values-valkey-addon.yaml`** and **`valkey.yaml`**: Valkey rate-limit backend and matching values addon. The example pins `valkey/valkey:8.1.8-alpine`.
 - **`token_ratelimit.yaml`**: Example AIGatewayRoute configuration that demonstrates token-based rate limiting.
 
 ## Quick Start
 
-1. Install Envoy Gateway with base configuration + rate limiting addon:
+1. Choose a Redis-protocol rate-limit backend and install Envoy Gateway with its matching addon.
+
+   Redis:
 
    ```bash
    helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
@@ -24,10 +26,29 @@ of each request.
      -f envoy-gateway-values-addon.yaml
    ```
 
-2. Deploy Redis:
+   Valkey:
+
+   ```bash
+   helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
+     --version v0.0.0-latest \
+     --namespace envoy-gateway-system \
+     --create-namespace \
+     -f ../../manifests/envoy-gateway-values.yaml \
+     -f envoy-gateway-values-valkey-addon.yaml
+   ```
+
+2. Deploy the backend selected in the previous step:
+
+   Redis:
 
    ```bash
    kubectl apply -f redis.yaml
+   ```
+
+   Valkey (pinned to `valkey/valkey:8.1.8-alpine`):
+
+   ```bash
+   kubectl apply -f valkey.yaml
    ```
 
 3. Apply the token rate limit example:
@@ -51,3 +72,5 @@ helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
 ```
 
 For detailed documentation, see the [usage-based rate limiting guide](https://gateway.envoyproxy.io/ai-gateway/docs/capabilities/traffic/usage-based-ratelimiting).
+
+Valkey compatibility for this existing Redis-protocol rate-limit path is tracked in [#2522](https://github.com/envoyproxy/ai-gateway/issues/2522).

--- a/examples/token_ratelimit/envoy-gateway-values-valkey-addon.yaml
+++ b/examples/token_ratelimit/envoy-gateway-values-valkey-addon.yaml
@@ -1,0 +1,28 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+# This addon keeps Envoy Gateway's Redis backend configuration and points it at
+# the Valkey Service from valkey.yaml. Valkey is compatible with this Redis
+# protocol boundary; it is not a separate Envoy Gateway backend type.
+config:
+  envoyGateway:
+    provider:
+      kubernetes:
+        rateLimitDeployment:
+          patch:
+            type: StrategicMerge
+            value:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - imagePullPolicy: IfNotPresent
+                        name: envoy-ratelimit
+                        image: docker.io/envoyproxy/ratelimit:60d8e81b
+    rateLimit:
+      backend:
+        type: Redis
+        redis:
+          url: valkey.valkey-system.svc.cluster.local:6379

--- a/examples/token_ratelimit/valkey.yaml
+++ b/examples/token_ratelimit/valkey.yaml
@@ -1,0 +1,50 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+# This is a simple Valkey deployment that is used by the Envoy Gateway rate
+# limiting feature through its Redis protocol interface.
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: valkey-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  namespace: valkey-system
+  labels:
+    app: valkey
+spec:
+  ports:
+    - name: valkey
+      port: 6379
+  selector:
+    app: valkey
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey
+  namespace: valkey-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+        - image: valkey/valkey:8.1.8-alpine
+          imagePullPolicy: IfNotPresent
+          name: valkey
+          ports:
+            - name: valkey
+              containerPort: 6379
+      restartPolicy: Always

--- a/site/docs/capabilities/traffic/quota-policy.md
+++ b/site/docs/capabilities/traffic/quota-policy.md
@@ -38,10 +38,16 @@ Key features of QuotaPolicy:
 :::tip Prerequisites
 Quota enforcement uses the same infrastructure as usage-based rate limiting:
 
-1. **Redis Deployment**: A Redis instance for storing quota counters. See the [redis.yaml example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/redis.yaml) for a simple deployment.
-2. **Envoy Gateway Configuration**: Envoy Gateway must be configured at installation time to enable rate limiting and point to your Redis instance. See the [Envoy Gateway Installation Guide](../../getting-started/prerequisites.md#additional-features-rate-limiting-inferencepool-etc).
+1. **Redis-protocol backend**: The external `envoyproxy/ratelimit` service stores quota counters through its Redis protocol connection. Redis and Valkey are supported choices; see the [Redis example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/redis.yaml) or [Valkey example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/valkey.yaml).
+2. **Envoy Gateway Configuration**: Envoy Gateway must be configured at installation time to enable rate limiting and point to the selected backend. See the [Envoy Gateway Installation Guide](../../getting-started/prerequisites.md#additional-features-rate-limiting-inferencepool-etc).
 
 See [Usage-based Rate Limiting](./usage-based-ratelimiting.md) for more detail on the rate limit infrastructure that QuotaPolicy builds on.
+:::
+
+:::note Valkey compatibility
+
+Valkey is validated for the documented quota counter and `429` enforcement flows through the existing external rate-limit service. Keep `rateLimit.backend.type: Redis` and configure the endpoint for the Valkey Service; no Valkey-specific API is introduced. Semantic caching and a new AI Gateway datastore are outside this scope. See the [pinned Valkey example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/valkey.yaml) and [#2522](https://github.com/envoyproxy/ai-gateway/issues/2522).
+
 :::
 
 ## Configuration

--- a/site/docs/capabilities/traffic/usage-based-ratelimiting.md
+++ b/site/docs/capabilities/traffic/usage-based-ratelimiting.md
@@ -59,9 +59,15 @@ For model providers with OpenAI schema transformations (like AWS Bedrock), AI Ga
 
 Rate limiting requires two components to be configured:
 
-1. **Redis Deployment**: A Redis instance must be running to store rate limit data. See the [redis.yaml example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/redis.yaml) for a simple deployment.
+1. **Redis-protocol backend**: The external `envoyproxy/ratelimit` service owns the Redis protocol connection and requires a backend for rate-limit counters. Redis and Valkey are supported choices; see the [Redis example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/redis.yaml) or [Valkey example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/valkey.yaml).
 
-2. **Envoy Gateway Configuration**: Envoy Gateway must be configured at installation time to enable rate limiting and point to your Redis instance. See [Envoy Gateway Installation Guide](../../getting-started/prerequisites.md#additional-features-rate-limiting-inferencepool-etc)
+2. **Envoy Gateway Configuration**: Envoy Gateway must be configured at installation time to enable rate limiting and point to the selected backend. See [Envoy Gateway Installation Guide](../../getting-started/prerequisites.md#additional-features-rate-limiting-inferencepool-etc)
+
+:::
+
+:::note Valkey compatibility
+
+Valkey is validated as a Redis-protocol backend for the documented token counter and `429` enforcement flows. Keep `rateLimit.backend.type: Redis` and point its endpoint at the Valkey Service; Valkey does not add a new Envoy Gateway backend type. Semantic caching and an AI Gateway datastore are outside this compatibility scope. See the [pinned Valkey example](https://github.com/envoyproxy/ai-gateway/blob/main/examples/token_ratelimit/valkey.yaml) and [#2522](https://github.com/envoyproxy/ai-gateway/issues/2522).
 
 :::
 

--- a/tests/e2e/backend_quota_ratelimit_test.go
+++ b/tests/e2e/backend_quota_ratelimit_test.go
@@ -6,7 +6,6 @@
 package e2e
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -27,19 +26,8 @@ import (
 // using the QuotaPolicy CRD. This verifies that the upstream rate limit filter
 // enforces per-model token quotas on requests to AIServiceBackends.
 func Test_Examples_BackendQuotaRateLimit(t *testing.T) {
-	// Apply Redis manifest (shared with token rate limit tests).
-	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), "../../examples/token_ratelimit/redis.yaml"))
-	t.Cleanup(func() {
-		_ = e2elib.KubectlDeleteManifest(context.Background(), "../../examples/token_ratelimit/redis.yaml")
-	})
-
-	// Wait for the redis pod to be ready so that the rate limit service can connect.
-	e2elib.RequireWaitForPodReady(t, "redis-system", "app=redis")
-
-	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), "testdata/backend_quota_ratelimit.yaml"))
-	t.Cleanup(func() {
-		_ = e2elib.KubectlDeleteManifest(context.Background(), "testdata/backend_quota_ratelimit.yaml")
-	})
+	storage := applyRateLimitStorage(t)
+	applyQuotaRateLimitManifest(t, storage)
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-quota-ratelimit"
 	e2elib.RequireWaitForGatewayPodReady(t, egSelector)
@@ -47,8 +35,8 @@ func Test_Examples_BackendQuotaRateLimit(t *testing.T) {
 	// Wait for the AI Gateway rate limit service to be ready.
 	e2elib.RequireWaitForPodReady(t, e2elib.EnvoyGatewayNamespace, "app=envoy-ai-gateway-ratelimit")
 
-	// Flush any existing quota keys in Redis to start with a clean state.
-	flushQuotaKeys(t)
+	// Flush any existing quota keys in the selected Redis-protocol backend.
+	flushQuotaKeys(t, storage)
 
 	// makeRequest sends a chat completion request via the test upstream with the
 	// specified total_tokens in the fake response and asserts the expected status code.
@@ -89,54 +77,54 @@ func Test_Examples_BackendQuotaRateLimit(t *testing.T) {
 	// The QuotaPolicy sets a quota of 10 total tokens per hour for "quota-test-model".
 	t.Run("per-model quota", func(t *testing.T) {
 		makeRequest("quota-test-model", 20, http.StatusOK)
-		requireQuotaUsage(t, "quota-test-model", 21)
+		requireQuotaUsage(t, storage, "quota-test-model", 21)
 		makeRequest("quota-test-model", 5, http.StatusTooManyRequests)
-		requireQuotaUsage(t, "quota-test-model", 22)
+		requireQuotaUsage(t, storage, "quota-test-model", 22)
 	})
 }
 
-// redisExec runs a redis-cli command on the Redis pod and returns the output.
-func redisExec(t *testing.T, args ...string) string {
+// rateLimitStorageExec runs the selected storage CLI command and returns its output.
+func rateLimitStorageExec(t *testing.T, storage e2elib.RateLimitStorage, args ...string) string {
 	t.Helper()
 	cmdArgs := append([]string{
-		"exec", "-n", "redis-system",
-		"deploy/redis", "--",
-		"redis-cli",
+		"exec", "-n", storage.Namespace,
+		"deploy/" + storage.Deployment, "--",
+		storage.CLI,
 	}, args...)
 	cmd := exec.CommandContext(t.Context(), "kubectl", cmdArgs...)
 	out, err := cmd.Output()
-	require.NoError(t, err, "redis-cli %v failed", args)
+	require.NoError(t, err, "%s %v failed", storage.CLI, args)
 	return strings.TrimSpace(string(out))
 }
 
-// flushQuotaKeys deletes all quota-related keys from Redis.
-func flushQuotaKeys(t *testing.T) {
+// flushQuotaKeys deletes all quota-related keys from the selected storage backend.
+func flushQuotaKeys(t *testing.T, storage e2elib.RateLimitStorage) {
 	t.Helper()
-	keys := redisExec(t, "KEYS", "ai-gateway-quota_*")
+	keys := rateLimitStorageExec(t, storage, "KEYS", "ai-gateway-quota_*")
 	if keys == "" {
 		return
 	}
 	for _, key := range strings.Split(keys, "\n") {
 		key = strings.TrimSpace(key)
 		if key != "" {
-			redisExec(t, "DEL", key)
+			rateLimitStorageExec(t, storage, "DEL", key)
 		}
 	}
 }
 
-// getQuotaUsage retrieves the current quota counter value from Redis for the given model.
+// getQuotaUsage retrieves the current quota counter value from the selected backend for a model.
 // The key pattern is: ai-gateway-quota_backend_name_{backend}_model_name_override_{model}_{timestamp}
-func getQuotaUsage(t *testing.T, modelName string) (int, bool) {
+func getQuotaUsage(t *testing.T, storage e2elib.RateLimitStorage, modelName string) (int, bool) {
 	t.Helper()
 	pattern := fmt.Sprintf("ai-gateway-quota_backend_name_*_model_name_override_%s_*", modelName)
-	keys := redisExec(t, "KEYS", pattern)
+	keys := rateLimitStorageExec(t, storage, "KEYS", pattern)
 	if keys == "" {
 		return 0, false
 	}
 	// Use the first matching key (there should be exactly one per model per time window).
 	key := strings.Split(keys, "\n")[0]
 	key = strings.TrimSpace(key)
-	val := redisExec(t, "GET", key)
+	val := rateLimitStorageExec(t, storage, "GET", key)
 	if val == "" {
 		return 0, false
 	}
@@ -145,13 +133,13 @@ func getQuotaUsage(t *testing.T, modelName string) (int, bool) {
 	return n, true
 }
 
-// requireQuotaUsage polls Redis until the quota counter for the given model reaches
+// requireQuotaUsage polls the selected backend until the quota counter for a model reaches
 // the expected value. The stream-done rate limit entry updates Redis asynchronously
 // after the response, so polling is necessary.
-func requireQuotaUsage(t *testing.T, modelName string, expected int) {
+func requireQuotaUsage(t *testing.T, storage e2elib.RateLimitStorage, modelName string, expected int) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		usage, ok := getQuotaUsage(t, modelName)
+		usage, ok := getQuotaUsage(t, storage, modelName)
 		return ok && usage == expected
 	}, 30*time.Second, 500*time.Millisecond,
 		"quota counter for model %q did not reach expected value %d", modelName, expected)

--- a/tests/e2e/dynamic_metadata_ratelimit_test.go
+++ b/tests/e2e/dynamic_metadata_ratelimit_test.go
@@ -50,12 +50,7 @@ func Test_DynamicMetadataRateLimit(t *testing.T) {
 		t.Skipf("needs Envoy Gateway %s, have %s", e2elib.EnvoyGatewayLatestVersion, e2elib.EnvoyGatewayVersion())
 	}
 
-	// Apply Redis manifest (shared with the other rate limit tests). The Envoy
-	// Gateway global rate limit service (envoy-ratelimit) is backed by Redis.
-	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), "../../examples/token_ratelimit/redis.yaml"))
-	t.Cleanup(func() {
-		_ = e2elib.KubectlDeleteManifest(context.Background(), "../../examples/token_ratelimit/redis.yaml")
-	})
+	applyRateLimitStorage(t)
 
 	const manifest = "testdata/dynamic_metadata_ratelimit.yaml"
 	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
@@ -66,12 +61,11 @@ func Test_DynamicMetadataRateLimit(t *testing.T) {
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-dynamic-ratelimit"
 	e2elib.RequireWaitForGatewayPodReady(t, egSelector)
 
-	// Wait for the redis pod to be ready so that the rate limit can be performed
-	// correctly. Until the redis pod is ready, envoy-ratelimit will be in
+	// Wait for the selected backend to be ready so that the rate limit can be
+	// performed correctly. Until it is ready, envoy-ratelimit will be in
 	// CrashLoopBackOff, so restart it to get a clean state up faster.
 	require.NoError(t, e2elib.KubectlRestartDeployment(t.Context(), e2elib.EnvoyGatewayNamespace, "envoy-ratelimit"))
 	e2elib.RequireWaitForPodReady(t, e2elib.EnvoyGatewayNamespace, "app.kubernetes.io/component=ratelimit")
-	e2elib.RequireWaitForPodReady(t, "redis-system", "app=redis")
 
 	// The auth server supplies the budget, and requests fail closed if it isn't up.
 	e2elib.RequireWaitForPodReady(t, "default", "app=ext-auth-server-dynamic-ratelimit")

--- a/tests/e2e/ratelimit_storage_test.go
+++ b/tests/e2e/ratelimit_storage_test.go
@@ -1,0 +1,45 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/tests/internal/e2elib"
+)
+
+func applyRateLimitStorage(t *testing.T) e2elib.RateLimitStorage {
+	t.Helper()
+	storage := e2elib.SelectedRateLimitStorage()
+	require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), storage.Manifest))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(context.Background(), storage.Manifest)
+	})
+	e2elib.RequireWaitForPodReady(t, storage.Namespace, storage.PodSelector)
+	return storage
+}
+
+func applyQuotaRateLimitManifest(t *testing.T, storage e2elib.RateLimitStorage) {
+	t.Helper()
+	const manifest = "testdata/backend_quota_ratelimit.yaml"
+	contents, err := os.ReadFile(manifest)
+	require.NoError(t, err)
+	const redisURL = "redis.redis-system.svc.cluster.local:6379"
+	contentsString := string(contents)
+	if count := strings.Count(contentsString, redisURL); count != 1 {
+		t.Fatalf("rate-limit manifest contains %d occurrences of expected backend URL %q, want 1", count, redisURL)
+	}
+	contents = []byte(strings.Replace(contentsString, redisURL, storage.URL, 1))
+	require.NoError(t, e2elib.KubectlApplyManifestStdin(t.Context(), string(contents)))
+	t.Cleanup(func() {
+		_ = e2elib.KubectlDeleteManifest(context.Background(), manifest)
+	})
+}

--- a/tests/e2e/token_ratelimit_test.go
+++ b/tests/e2e/token_ratelimit_test.go
@@ -37,29 +37,29 @@ const tenantIDMetricsLabel = "tenant_id"
 
 func Test_Examples_TokenRateLimit(t *testing.T) {
 	const manifestDir = "../../examples/token_ratelimit"
+	storage := e2elib.SelectedRateLimitStorage()
 	// Apply specific manifest files, not the entire directory (to avoid applying Helm values files)
 	manifests := []string{
-		manifestDir + "/redis.yaml",
+		storage.Manifest,
 		manifestDir + "/token_ratelimit.yaml",
 	}
 	for _, manifest := range manifests {
 		require.NoError(t, e2elib.KubectlApplyManifest(t.Context(), manifest))
+		appliedManifest := manifest
+		t.Cleanup(func() {
+			_ = e2elib.KubectlDeleteManifest(context.Background(), appliedManifest)
+		})
 	}
-	t.Cleanup(func() {
-		for _, manifest := range manifests {
-			_ = e2elib.KubectlDeleteManifest(context.Background(), manifest)
-		}
-	})
 
 	const egSelector = "gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway-token-ratelimit"
 	e2elib.RequireWaitForGatewayPodReady(t, egSelector)
 
-	// Wait for the redis pod to be ready so that the rate limit can be performed correctly.
-	// Until the redis pod is ready, envoy-ratelimit deployment will be in CrashLoopBackOff, so restart it so
+	// Wait for the selected Redis-protocol backend to be ready before rate limiting.
+	// Until it is ready, envoy-ratelimit deployment will be in CrashLoopBackOff, so restart it so
 	// we can have it up and running faster in a clean state.
 	require.NoError(t, e2elib.KubectlRestartDeployment(t.Context(), e2elib.EnvoyGatewayNamespace, "envoy-ratelimit"))
 	e2elib.RequireWaitForPodReady(t, e2elib.EnvoyGatewayNamespace, "app.kubernetes.io/component=ratelimit")
-	e2elib.RequireWaitForPodReady(t, "redis-system", "app=redis")
+	e2elib.RequireWaitForPodReady(t, storage.Namespace, storage.PodSelector)
 
 	const modelName = "rate-limit-funky-model"
 	makeRequest := func(userID string, input, output, total int, cachedInput *int, expStatus int) {

--- a/tests/internal/e2elib/e2elib.go
+++ b/tests/internal/e2elib/e2elib.go
@@ -412,6 +412,49 @@ func EnvoyGatewaySupportsLimitFromMetadata() bool {
 	return EnvoyGatewayVersion() == EnvoyGatewayLatestVersion
 }
 
+// RateLimitStorage describes the Redis-protocol backend used by the e2e rate limit tests.
+// Set E2E_RATELIMIT_STORAGE=valkey to run the same tests against the Valkey example.
+type RateLimitStorage struct {
+	Name        string
+	Manifest    string
+	ValuesAddon string
+	Namespace   string
+	PodSelector string
+	Deployment  string
+	CLI         string
+	URL         string
+}
+
+// SelectedRateLimitStorage returns the storage backend selected for e2e tests.
+func SelectedRateLimitStorage() RateLimitStorage {
+	switch os.Getenv("E2E_RATELIMIT_STORAGE") {
+	case "", "redis":
+		return RateLimitStorage{
+			Name:        "Redis",
+			Manifest:    "../../examples/token_ratelimit/redis.yaml",
+			ValuesAddon: "../../examples/token_ratelimit/envoy-gateway-values-addon.yaml",
+			Namespace:   "redis-system",
+			PodSelector: "app=redis",
+			Deployment:  "redis",
+			CLI:         "redis-cli",
+			URL:         "redis.redis-system.svc.cluster.local:6379",
+		}
+	case "valkey":
+		return RateLimitStorage{
+			Name:        "Valkey",
+			Manifest:    "../../examples/token_ratelimit/valkey.yaml",
+			ValuesAddon: "../../examples/token_ratelimit/envoy-gateway-values-valkey-addon.yaml",
+			Namespace:   "valkey-system",
+			PodSelector: "app=valkey",
+			Deployment:  "valkey",
+			CLI:         "valkey-cli",
+			URL:         "valkey.valkey-system.svc.cluster.local:6379",
+		}
+	default:
+		panic(fmt.Sprintf("unsupported E2E_RATELIMIT_STORAGE value %q; use redis or valkey", os.Getenv("E2E_RATELIMIT_STORAGE")))
+	}
+}
+
 // initEnvoyGateway initializes the Envoy Gateway in the kind cluster following the quickstart guide:
 // https://gateway.envoyproxy.io/latest/tasks/quickstart/
 func initEnvoyGateway(ctx context.Context, namespace string, inferenceExtension bool) (err error) {
@@ -429,7 +472,7 @@ func initEnvoyGateway(ctx context.Context, namespace string, inferenceExtension 
 		"oci://docker.io/envoyproxy/gateway-helm", "--version", egVersion,
 		"-n", "envoy-gateway-system", "--create-namespace",
 		"-f", "../../manifests/envoy-gateway-values.yaml",
-		"-f", "../../examples/token_ratelimit/envoy-gateway-values-addon.yaml",
+		"-f", SelectedRateLimitStorage().ValuesAddon,
 		"--set", fmt.Sprintf("config.envoyGateway.extensionManager.service.fqdn.hostname=ai-gateway-controller.%s.svc.cluster.local", namespace),
 	}
 	if inferenceExtension {

--- a/tests/internal/e2elib/e2elib_test.go
+++ b/tests/internal/e2elib/e2elib_test.go
@@ -1,0 +1,41 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package e2elib
+
+import "testing"
+
+func TestSelectedRateLimitStorage(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         string
+		wantName      string
+		wantNamespace string
+	}{
+		{name: "default", wantName: "Redis", wantNamespace: "redis-system"},
+		{name: "redis", value: "redis", wantName: "Redis", wantNamespace: "redis-system"},
+		{name: "valkey", value: "valkey", wantName: "Valkey", wantNamespace: "valkey-system"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("E2E_RATELIMIT_STORAGE", tt.value)
+			storage := SelectedRateLimitStorage()
+			if storage.Name != tt.wantName || storage.Namespace != tt.wantNamespace {
+				t.Fatalf("SelectedRateLimitStorage() = %#v, want %s in %s", storage, tt.wantName, tt.wantNamespace)
+			}
+		})
+	}
+}
+
+func TestSelectedRateLimitStorageRejectsUnsupportedValue(t *testing.T) {
+	t.Setenv("E2E_RATELIMIT_STORAGE", "valkeyy")
+	defer func() {
+		if recover() == nil {
+			t.Fatal("SelectedRateLimitStorage() did not reject unsupported value")
+		}
+	}()
+	SelectedRateLimitStorage()
+}


### PR DESCRIPTION
## Description

This commit adds a selectable Valkey backend to the rate-limit examples and end-to-end tests while preserving Redis as the default. It documents the existing Redis-protocol integration and provides a dedicated validation target.

The changes make it possible to run the existing token and quota rate-limit flows against Valkey without introducing a new gateway datastore, client dependency, or Envoy Gateway backend type. The Redis path remains the default for compatibility.

## Related Issues/PRs (if applicable)

Related issue: #2522

## Special notes for reviewers (if applicable)

- The implementation is intentionally additive: existing Redis examples and default test behavior are preserved.
- Valkey is configured through Envoy Gateway's existing rateLimit.backend.type: Redis interface.
- The end-to-end suite supports E2E_RATELIMIT_STORAGE=valkey, and make test-e2e-ratelimit-valkey provides the dedicated validation target.
- Focused Redis and Valkey end-to-end tests passed, along with make test and the documentation build.
- No gateway source dependency or gateway-owned datastore was added.