### PR TITLE
fix: route streaming tool state by content block index

### DIFF
--- a/internal/translator/anthropic_helper.go
+++ b/internal/translator/anthropic_helper.go
@@ -836,6 +836,12 @@ type streamingToolCall struct {
 	id        string
 	name      string
 	inputJSON string
+	// openaiIndex is this call's index within the OpenAI tool_calls array,
+	// assigned in tool-block arrival order. It is not the Anthropic content
+	// block index: OpenAI indexes are dense across tool calls only, while
+	// Anthropic block indexes count every block, including text and
+	// thinking.
+	openaiIndex int64
 }
 
 // anthropicStreamParser manages the stateful translation of an Anthropic SSE stream
@@ -843,6 +849,10 @@ type streamingToolCall struct {
 type anthropicStreamParser struct {
 	buffer          bytes.Buffer
 	activeMessageID string
+	// activeToolCalls is keyed by the Anthropic content block index carried
+	// on every content_block_* event, so lookups are position-independent:
+	// text or thinking blocks interleaved between tool blocks cannot
+	// desynchronize the routing of input_json_delta or content_block_stop.
 	activeToolCalls map[int64]*streamingToolCall
 	toolIndex       int64
 	tokenUsage      metrics.TokenUsage
@@ -1003,7 +1013,7 @@ func (p *anthropicStreamParser) Process(body io.Reader, endOfStream bool, span t
 
 		// Add active tool calls to the final chunk.
 		var toolCalls []openai.ChatCompletionChunkChoiceDeltaToolCall
-		for toolIndex, tool := range p.activeToolCalls {
+		for _, tool := range p.activeToolCalls {
 			toolCalls = append(toolCalls, openai.ChatCompletionChunkChoiceDeltaToolCall{
 				ID:   &tool.id,
 				Type: openai.ChatCompletionMessageToolCallTypeFunction,
@@ -1011,7 +1021,7 @@ func (p *anthropicStreamParser) Process(body io.Reader, endOfStream bool, span t
 					Name:      tool.name,
 					Arguments: tool.inputJSON,
 				},
-				Index: toolIndex,
+				Index: tool.openaiIndex,
 			})
 		}
 
@@ -1122,11 +1132,14 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 				}
 			}
 
-			// Store the complete input JSON in our state.
-			p.activeToolCalls[p.toolIndex] = &streamingToolCall{
-				id:        event.ContentBlock.ID,
-				name:      event.ContentBlock.Name,
-				inputJSON: argsJSON,
+			// Store the complete input JSON in our state, keyed by the
+			// Anthropic block index; the OpenAI tool_calls index advances
+			// only when a tool block starts.
+			p.activeToolCalls[event.Index] = &streamingToolCall{
+				id:          event.ContentBlock.ID,
+				name:        event.ContentBlock.Name,
+				inputJSON:   argsJSON,
+				openaiIndex: p.toolIndex,
 			}
 
 			delta := openai.ChatCompletionResponseChunkChoiceDelta{
@@ -1203,14 +1216,17 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 			delta := openai.ChatCompletionResponseChunkChoiceDelta{Content: &event.Delta.Text}
 			return p.constructOpenAIChatCompletionChunk(&delta, ""), nil
 		case string(constant.ValueOf[constant.InputJSONDelta]()):
-			tool, ok := p.activeToolCalls[p.toolIndex]
+			// Route by the event's own block index, never by "the last tool
+			// started": the two only coincide while no other block type
+			// interleaves.
+			tool, ok := p.activeToolCalls[event.Index]
 			if !ok {
-				return nil, fmt.Errorf("received input_json_delta for unknown tool at index %d", p.toolIndex)
+				return nil, fmt.Errorf("received input_json_delta for unknown content block at index %d", event.Index)
 			}
 			delta := openai.ChatCompletionResponseChunkChoiceDelta{
 				ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{
 					{
-						Index: p.toolIndex,
+						Index: tool.openaiIndex,
 						Function: openai.ChatCompletionMessageToolCallFunctionParam{
 							Arguments: event.Delta.PartialJSON,
 						},
@@ -1222,12 +1238,34 @@ func (p *anthropicStreamParser) handleAnthropicStreamEvent(eventType []byte, dat
 		}
 
 	case string(constant.ValueOf[constant.ContentBlockStop]()):
-		// This event is for state cleanup, no chunk is sent.
 		var event anthropic.ContentBlockStopEvent
 		if err := json.Unmarshal(data, &event); err != nil {
 			return nil, fmt.Errorf("unmarshal content_block_stop: %w", err)
 		}
-		delete(p.activeToolCalls, p.toolIndex)
+		// Only a tool block's own stop clears its state; a text or thinking
+		// block stopping must not evict a tool tracked under another index.
+		tool, ok := p.activeToolCalls[event.Index]
+		if !ok {
+			return nil, nil
+		}
+		delete(p.activeToolCalls, event.Index)
+		if tool.inputJSON == "" {
+			// Zero-argument tool: no input_json_delta ever arrived, and
+			// content_block_start already emitted Arguments:"" for the
+			// "input":{} case, so a client concatenating the stream ends up
+			// with "", which is not valid JSON. Emit a synthetic {}.
+			delta := openai.ChatCompletionResponseChunkChoiceDelta{
+				ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{
+					{
+						Index: tool.openaiIndex,
+						Function: openai.ChatCompletionMessageToolCallFunctionParam{
+							Arguments: "{}",
+						},
+					},
+				},
+			}
+			return p.constructOpenAIChatCompletionChunk(&delta, ""), nil
+		}
 		return nil, nil
 
 	case string(constant.ValueOf[constant.MessageStop]()):

--- a/internal/translator/anthropic_helper_toolrouting_test.go
+++ b/internal/translator/anthropic_helper_toolrouting_test.go
@@ -1,0 +1,160 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/json"
+)
+
+// sse formats one Anthropic SSE event block.
+func sse(eventType, data string) string {
+	return "event: " + eventType + "\ndata: " + data + "\n\n"
+}
+
+// feedEvents pushes raw SSE events through the stream parser one at a
+// time -- as they arrive on the wire, so ordering is what the parser
+// actually sees -- and returns every emitted OpenAI chunk.
+func feedEvents(t *testing.T, events []string) []openai.ChatCompletionResponseChunk {
+	t.Helper()
+	p := newAnthropicStreamParser("claude-test")
+	var raw []byte
+	for _, ev := range events {
+		_, newBody, _, _, err := p.Process(bytes.NewReader([]byte(ev)), false, nil)
+		require.NoError(t, err)
+		raw = append(raw, newBody...)
+	}
+	_, final, _, _, err := p.Process(bytes.NewReader(nil), true, nil)
+	require.NoError(t, err)
+	raw = append(raw, final...)
+
+	var chunks []openai.ChatCompletionResponseChunk
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		data, ok := strings.CutPrefix(line, "data: ")
+		if !ok || data == "[DONE]" || data == "" {
+			continue
+		}
+		var chunk openai.ChatCompletionResponseChunk
+		require.NoError(t, json.Unmarshal([]byte(data), &chunk), "chunk: %s", data)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+// argsByToolIndex accumulates streamed tool-call arguments per OpenAI
+// tool_calls index, the way an OpenAI client would.
+func argsByToolIndex(chunks []openai.ChatCompletionResponseChunk) map[int64]string {
+	acc := map[int64]string{}
+	for i := range chunks {
+		for _, choice := range chunks[i].Choices {
+			if choice.Delta == nil {
+				continue
+			}
+			for _, tc := range choice.Delta.ToolCalls {
+				acc[tc.Index] += tc.Function.Arguments
+			}
+		}
+	}
+	return acc
+}
+
+const toolRoutingMessageStart = `{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-test","usage":{"input_tokens":5,"output_tokens":0}}}`
+
+// Step 2 of Anthropic's accumulation contract appends a delta to the
+// block it names, so two open tool blocks accumulate separately however
+// their deltas are ordered. Routing by "last tool started" instead
+// appends both argument streams to whichever started last.
+func TestStreamToolRoutingInterleavedDeltas(t *testing.T) {
+	chunks := feedEvents(t, []string{
+		sse("message_start", toolRoutingMessageStart),
+		sse("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_A","name":"get_weather"}}`),
+		sse("content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_B","name":"get_time"}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"tz\":\"UTC\"}"}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Oslo\"}"}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":1}`),
+		sse("message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}`),
+		sse("message_stop", `{"type":"message_stop"}`),
+	})
+
+	args := argsByToolIndex(chunks)
+	require.JSONEq(t, `{"city":"Oslo"}`, args[0], "tool A arguments corrupted")
+	require.JSONEq(t, `{"tz":"UTC"}`, args[1], "tool B arguments corrupted")
+}
+
+// Step 3 of the contract closes the block the stop names. Keyed by
+// "last tool started", the stop for an earlier tool deletes the state
+// of the one still streaming, and its next input_json_delta fails the
+// whole response with "received input_json_delta for unknown tool".
+func TestStreamToolRoutingStopEvictsOtherTool(t *testing.T) {
+	p := newAnthropicStreamParser("claude-test")
+	events := []string{
+		sse("message_start", toolRoutingMessageStart),
+		sse("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_A","name":"get_weather"}}`),
+		sse("content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_B","name":"get_time"}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Oslo\"}"}}`),
+		// A finishes first, while B is still open.
+		sse("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"tz\":\"UTC\"}"}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":1}`),
+		sse("message_stop", `{"type":"message_stop"}`),
+	}
+	for _, ev := range events {
+		_, _, _, _, err := p.Process(bytes.NewReader([]byte(ev)), false, nil)
+		require.NoError(t, err, "event: %s", ev)
+	}
+}
+
+// The OpenAI tool_calls index is dense across tool calls, while the
+// Anthropic block index counts every block. Keying state by block index
+// must not leak block indexes into the OpenAI stream.
+func TestStreamToolRoutingOpenAIIndexesStayDense(t *testing.T) {
+	chunks := feedEvents(t, []string{
+		sse("message_start", toolRoutingMessageStart),
+		sse("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Checking."}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		sse("content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_A","name":"get_weather"}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Oslo\"}"}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":1}`),
+		sse("content_block_start", `{"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":2}`),
+		sse("content_block_start", `{"type":"content_block_start","index":3,"content_block":{"type":"tool_use","id":"toolu_B","name":"get_time"}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"{\"tz\":\"UTC\"}"}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":3}`),
+		sse("message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}`),
+		sse("message_stop", `{"type":"message_stop"}`),
+	})
+
+	args := argsByToolIndex(chunks)
+	require.Len(t, args, 2)
+	// OpenAI tool_calls indexes stay dense (0, 1) even though the Anthropic
+	// block indexes were 1 and 3.
+	require.JSONEq(t, `{"city":"Oslo"}`, args[0])
+	require.JSONEq(t, `{"tz":"UTC"}`, args[1])
+}
+
+// A tool that takes no arguments never receives an input_json_delta; the
+// accumulated OpenAI arguments must still be valid JSON.
+func TestStreamZeroArgumentToolEmitsEmptyObject(t *testing.T) {
+	chunks := feedEvents(t, []string{
+		sse("message_start", toolRoutingMessageStart),
+		sse("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_A","name":"get_current_time","input":{}}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		sse("message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":3}}`),
+		sse("message_stop", `{"type":"message_stop"}`),
+	})
+
+	args := argsByToolIndex(chunks)
+	require.JSONEq(t, "{}", args[0], "zero-argument tool must accumulate to valid JSON")
+}


### PR DESCRIPTION
**Description**

Anthropic documents an accumulation contract for streamed tool input, and it is
keyed by the content block index:

> **The accumulation contract:**
> 1. On `content_block_start` with `type: "tool_use"`, initialize an empty string: `input_json = ""`
> 2. For each `content_block_delta` with `type: "input_json_delta"`, append: `input_json += event.delta.partial_json`
> 3. On `content_block_stop`, parse the accumulated string

— "Accumulating tool input deltas" [1], which also states that "the accumulation
contract is the same as for standard tool-use streaming, so this section applies
with and without `eager_input_streaming`."

`event.index` is the key in every SDK example on that page. The Go one is
explicit about what the map is:

```go
toolInputs := map[int64]string{} // content block index -> accumulated JSON
```

This matches the streaming reference [2]: "Each content block has an `index` that
corresponds to its index in the final Message `content` array", and "each
`content_block_delta` event contains a `delta` of a type that updates the
`content` block at a given `index`."

This parser is a client of that contract, and implemented steps 2 and 3 against
a different key. Tool state was stored under `p.toolIndex` — a counter reset at
`message_start` and incremented on each tool block start, i.e. the *OpenAI*
`tool_calls` index — and the delta and stop handlers both looked state up under
that counter:

```go
p.activeToolCalls[p.toolIndex] = &streamingToolCall{...}  // content_block_start
tool, ok := p.activeToolCalls[p.toolIndex]                // input_json_delta
delete(p.activeToolCalls, p.toolIndex)                    // content_block_stop
```

The counter and the block index are different quantities. They agree only under
an assumption the parser never states: that at most one tool block is open, and
that every event belonging to it arrives before any other block starts.
`content_block_stop` shows the mismatch most plainly — it deletes a tool entry
addressed by the counter regardless of which block actually stopped, including
when the event names a text or thinking block. The handler already unmarshals
the event and has `event.Index` in hand; it just was not read.

To be straight about the justification: I am **not** claiming a current model
emits an order under which the old key misroutes. This is conforming to the
documented contract rather than to an emission order the contract does not
promise — and the docs are explicit that a stream's shape is not frozen. They
already carve out a non-tool `fallback` block that arrives as a
`content_block_start`/`content_block_stop` pair with no deltas between them, and
they state that "new event types may be added, and your code should handle
unknown event types gracefully".

One defect here does not depend on ordering:

**A zero-argument tool streams invalid JSON.** Per the contract, `input: {}` on
`content_block_start` is a placeholder — "the empty object marks the slot in the
content array" — so the parser correctly skips it and emits `Arguments:""`. If
no `input_json_delta` then contributes any JSON text, accumulation ends at `""`.
On the Anthropic side a client is told to guard the parse; on the OpenAI side
`tool_calls[].function.arguments` is expected to be a JSON string the client
parses, so the gateway has to render "no arguments" as `{}` rather than passing
`""` through. This is reachable today from a tool called with no arguments.

**The change**

State is keyed by the Anthropic block index, so `input_json_delta` and
`content_block_stop` resolve the block the event names. The OpenAI `tool_calls`
index is dense across tool calls while the Anthropic block index counts every
block — including text and thinking — so the OpenAI index is recorded separately
on each call as `openaiIndex` and remains what reaches the wire. Block indexes
stay internal. A zero-argument tool emits a synthetic `{}` on its
`content_block_stop`.

**Impact:** the Anthropic-to-OpenAI streaming path, for any backend using this
parser (`GCPAnthropic`, `AWSAnthropic`). The zero-argument case produces a 200
with tool arguments that do not parse. The routing changes are contract
conformance, latent under today's emission order.

**Related Issues/PRs (if applicable)**

Rebased onto #2585, which forwards `eager_input_streaming` and cites the same
doc page. No overlap in the diff — that PR is request-side
(`translateOpenAItoAnthropicTools`), this one is the response parser — but it
makes conformance here more load-bearing, since with eager streaming the
fragments the gateway forwards are no longer server-validated.

**Special notes for reviewers (if applicable)**

`anthropic_helper_toolrouting_test.go` feeds events through the parser one at a
time, in wire order, and accumulates arguments per OpenAI `tool_calls` index the
way a client would. Three of the four fail before this change:

| test | what it pins | before |
|---|---|---|
| `TestStreamToolRoutingInterleavedDeltas` | step 2: deltas append to the block they name | FAIL — tool A's arguments arrive empty |
| `TestStreamToolRoutingStopEvictsOtherTool` | step 3: a stop closes only the block it names | FAIL — `received input_json_delta for unknown tool` |
| `TestStreamZeroArgumentToolEmitsEmptyObject` | accumulated arguments are valid JSON | FAIL — arguments accumulate to `""` |
| `TestStreamToolRoutingOpenAIIndexesStayDense` | block indexes do not leak to the wire | passes before and after |

The first two construct streams that are legal under the documented contract
rather than replaying an order observed from a model — they are conformance
tests, not regression tests for a reported failure, and I would rather say so
than dress them up. The third is a present-day defect. The fourth passes both
ways; it pins the dense OpenAI index mapping this PR introduces, which is the
part most likely to be got wrong later.

One judgement call worth flagging: the synthetic `{}` for zero-argument tools is
a behaviour change, not just a routing fix. The alternative is to emit `{}` from
`content_block_start` instead of `""`, which is a smaller diff but sends the
arguments before the block is known to be empty, and contradicts the placeholder
semantics the contract gives `input: {}`. Happy to switch if you prefer that
shape.

The four tests above and `go test ./internal/extproc/... -count=1` pass on the
rebased branch. Two sets of pre-existing failures reproduce unmodified on `main`
and are unrelated to this change: four `internal/controller` tests
(`TestBackendSecurityPolicyController_{ReconcileOIDC_Fail,RotateCredential,
RotateExpiredCredential,ExecutionRotation}`), and — only on Go 1.27 / arm64 —
`TestOpenAIToAWSAnthropicTranslatorV1ChatCompletion_ResponseBody/response_with_tool_use`,
which is a whitespace-only JSON difference from `sonic` falling back to
`encoding/json` outside its supported toolchain range.

1: https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#accumulating-tool-input-deltas
2: https://platform.claude.com/docs/en/build-with-claude/streaming
