### PR TITLE
feat(tracing): opt-in user.id span attribute from a configured request header

### DIFF
--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -105,6 +105,14 @@ func (t *requestTracerImpl[ReqT, RespT, ChunkT]) StartSpanAndInjectHeaders(
 		attrs := make([]attribute.KeyValue, 0, len(t.headerAttributes))
 		for headerName, attrName := range t.headerAttributes {
 			if headerValue, ok := headers[headerName]; ok {
+				// user.id is consumer-supplied end-user attribution:
+				// stamped only on authenticated consumer traffic, and
+				// bounded first — see boundedUserIDValue.
+				if attrName == otelAttrUserID {
+					if headerValue, ok = boundedUserIDValue(t.headerAttributes, headers, headerValue); !ok {
+						continue
+					}
+				}
 				attrs = append(attrs, attribute.String(attrName, headerValue))
 			}
 		}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -229,7 +229,10 @@ func NewTracingFromEnv(ctx context.Context, stdout io.Writer, headerAttributeMap
 	propagator := autoprop.NewTextMapPropagator()
 
 	// Use provided header attribute mapping.
-	headerAttrs := headerAttributeMapping
+	// Merge the optional user.id header mapping (env-configured) into the
+	// request tracers' header attributes. The MCP tracer below deliberately
+	// keeps the unmerged input; see envUserIDHeader's doc for why.
+	headerAttrs := withUserIDHeaderFromEnv(headerAttributeMapping, os.Stderr)
 
 	tracer := tp.Tracer("envoyproxy/ai-gateway")
 	return &tracingImpl{
@@ -310,7 +313,11 @@ func NewTracingFromEnv(ctx context.Context, stdout io.Writer, headerAttributeMap
 			recorders.countTokens,
 			headerAttrs,
 		),
-		mcpTracer: newMCPTracer(tracer, propagator, headerAttrs, recorders.mcp),
+		// MCP tracer deliberately gets the ORIGINAL mapping (not the
+		// user.id-merged headerAttrs): its meta-first lookup would bypass
+		// both the sanitizer and the consumer-auth gate — see
+		// envUserIDHeader's doc.
+		mcpTracer: newMCPTracer(tracer, propagator, headerAttributeMapping, recorders.mcp),
 		shutdown:  tp.Shutdown, // we have to shut down what we create.
 	}, nil
 }

--- a/internal/tracing/user_id_attribute.go
+++ b/internal/tracing/user_id_attribute.go
@@ -1,0 +1,151 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package tracing
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// envUserIDHeader names the HTTP request header whose value is stamped onto
+// spans as the OpenInference `user.id` attribute (e.g. "x-ai-user-id"), so
+// trace backends that understand OpenInference (e.g. Arize Phoenix) can
+// filter/group traces by end user natively. Unset/empty = feature off,
+// upstream behavior exactly.
+//
+// Unlike requestHeaderAttributes (whose one deployed mapping,
+// x-client-id:consumer.id, is stamped from a header the GATEWAY injects
+// post-auth and a client cannot spoof), the user-id header is supplied by
+// the CONSUMER application on behalf of its logged-in end user. That makes
+// it untrusted input headed for a trace store, and it is treated
+// accordingly — see boundedUserIDValue:
+//
+//   - Trust boundary: the value is stamped ONLY when the request also
+//     carries the authenticated consumer identity (the header that
+//     requestHeaderAttributes maps to `consumer.id`). That header is set by
+//     the gateway's API-key auth filter after a key validates, so its
+//     presence is in-band evidence the request passed consumer auth. No
+//     consumer.id mapping configured, or header absent = fail closed, no
+//     user.id attribute. The value is attribution METADATA only — it must
+//     never feed authorization decisions.
+//   - Bounding: the value is sanitized to printable ASCII and capped in
+//     length before it reaches the span, so a hostile consumer cannot smuggle
+//     control bytes or megabyte blobs into the trace store. The bound covers
+//     ONLY this user.id lane: values flowing through requestHeaderAttributes
+//     mappings (upstream's default agent-session-id:session.id included) are
+//     stamped verbatim and unbounded — pre-existing upstream behavior this
+//     patch does not change.
+//
+// The MCP tracer is deliberately NOT extended: this mapping is merged only
+// into the request tracers' headerAttributes (see NewTracingFromEnv), never
+// into the MCP tracer's, whose meta-first lookup would bypass both the
+// sanitizer and the consumer-auth gate.
+const envUserIDHeader = "AI_GATEWAY_TRACING_USER_ID_HEADER"
+
+// otelAttrUserID is the OpenInference span attribute for the end user's
+// identity. https://github.com/Arize-ai/openinference — Phoenix keys its
+// user filtering/grouping on exactly this attribute.
+const otelAttrUserID = "user.id"
+
+// otelAttrConsumerID is the span attribute the deployment maps its
+// gateway-injected consumer-identity header to (requestHeaderAttributes,
+// e.g. "x-client-id:consumer.id"). boundedUserIDValue keys its
+// authenticated-consumer gate on this attribute NAME so the gate composes
+// with whatever header the deployment designates, without hard-coding the
+// header itself here.
+const otelAttrConsumerID = "consumer.id"
+
+// maxUserIDValueLen caps the stamped user.id value. Real ids are short
+// (Mongo ObjectIds are 24 chars, Auth0 `sub` claims and emails well under
+// 100); the cap only exists to bound hostile input.
+const maxUserIDValueLen = 256
+
+// withUserIDHeaderFromEnv returns headerAttributeMapping with the
+// envUserIDHeader mapping (header -> user.id) merged in, or the input
+// unchanged when the env is unset. The input map is never mutated — the
+// caller passes the ORIGINAL map to the MCP tracer (see envUserIDHeader's
+// doc for why MCP is excluded).
+//
+// Collision fail-safe: if the env names a header that headerAttributeMapping
+// already maps (case-insensitively) to some attribute — e.g.
+// AI_GATEWAY_TRACING_USER_ID_HEADER=x-client-id colliding with the deployed
+// x-client-id:consumer.id mapping — the EXISTING mapping wins: the input is
+// returned unchanged (user.id stamping stays off) and an explicit error
+// naming both mappings is written to errOut. Silently overriding would let
+// one misconfigured env var replace consumer.id with a consumer-supplied
+// value on every span, destroying consumer attribution.
+func withUserIDHeaderFromEnv(headerAttributeMapping map[string]string, errOut io.Writer) map[string]string {
+	header := strings.ToLower(strings.TrimSpace(os.Getenv(envUserIDHeader)))
+	if header == "" {
+		return headerAttributeMapping
+	}
+	for existingHeader, attrName := range headerAttributeMapping {
+		if strings.EqualFold(existingHeader, header) {
+			fmt.Fprintf(errOut,
+				"AI Gateway tracing: ignoring %s=%q: header %q is already mapped to span attribute %q by the configured header-attribute mapping; keeping %q -> %q, refusing the %q -> %q override, and DISABLING user.id stamping (point the env at a header not present in the mapping)\n",
+				envUserIDHeader, header, existingHeader, attrName, existingHeader, attrName, header, otelAttrUserID)
+			return headerAttributeMapping
+		}
+	}
+	merged := make(map[string]string, len(headerAttributeMapping)+1)
+	for k, v := range headerAttributeMapping {
+		merged[k] = v
+	}
+	merged[header] = otelAttrUserID
+	return merged
+}
+
+// boundedUserIDValue applies the user.id trust boundary and bounding to a
+// raw header value. It returns the value to stamp and true, or "" and false
+// when the attribute must not be stamped:
+//
+//   - false unless some header that headerAttributes maps to consumer.id is
+//     present (non-empty) in the request — i.e. unless the gateway's auth
+//     filter marked the request as authenticated consumer traffic. Fail
+//     closed: no consumer.id mapping configured means user.id never stamps.
+//   - the value is reduced to printable ASCII (bytes 0x20..0x7E; anything
+//     else, including UTF-8 multibyte sequences and control bytes, becomes
+//     '_') and truncated to maxUserIDValueLen bytes.
+//   - false when the sanitized value contains nothing but underscores and
+//     spaces. That drops values with no printable content (all replacement
+//     damage) AND raw values made only of literal underscores/spaces —
+//     printable, but indistinguishable from damage and worthless as an id.
+func boundedUserIDValue(headerAttributes map[string]string, headers map[string]string, raw string) (string, bool) {
+	authenticated := false
+	for headerName, attrName := range headerAttributes {
+		if attrName == otelAttrConsumerID && headers[headerName] != "" {
+			authenticated = true
+			break
+		}
+	}
+	if !authenticated {
+		return "", false
+	}
+	sanitized := sanitizeUserIDValue(raw)
+	if strings.Trim(sanitized, "_ ") == "" {
+		return "", false
+	}
+	return sanitized, true
+}
+
+// sanitizeUserIDValue maps every byte outside printable ASCII to '_'
+// (replacement, not deletion, so hostile bytes stay visible as damage
+// instead of silently splicing the remainder together) and truncates to
+// maxUserIDValueLen bytes.
+func sanitizeUserIDValue(raw string) string {
+	if len(raw) > maxUserIDValueLen {
+		raw = raw[:maxUserIDValueLen]
+	}
+	b := []byte(raw)
+	for i, c := range b {
+		if c < 0x20 || c > 0x7e {
+			b[i] = '_'
+		}
+	}
+	return string(b)
+}

--- a/internal/tracing/user_id_attribute_test.go
+++ b/internal/tracing/user_id_attribute_test.go
@@ -1,0 +1,278 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package tracing
+
+import (
+	"bytes"
+	"context"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
+	"github.com/envoyproxy/ai-gateway/internal/testing/testotel"
+)
+
+// otlpStringAttrs flattens an OTLP span's attributes to a string map.
+func otlpStringAttrs(s *tracev1.Span) map[string]string {
+	attrs := make(map[string]string, len(s.Attributes))
+	for _, kv := range s.Attributes {
+		attrs[kv.Key] = kv.Value.GetStringValue()
+	}
+	return attrs
+}
+
+// consumerIDMapping mirrors the deployed requestHeaderAttributes value: the
+// gateway-injected consumer identity header mapped to consumer.id.
+func consumerIDMapping() map[string]string {
+	return map[string]string{"x-client-id": "consumer.id"}
+}
+
+// startChatSpanWithHeaders builds tracing from env with the given
+// requestHeaderAttributes mapping, starts one chat-completion span with the
+// given request headers, and returns its exported attributes.
+func startChatSpanWithHeaders(t *testing.T, mapping, headers map[string]string) map[string]string {
+	collector := testotel.StartOTLPCollector()
+	t.Cleanup(collector.Close)
+	collector.SetEnv(t.Setenv)
+
+	result, err := NewTracingFromEnv(t.Context(), io.Discard, mapping)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = result.Shutdown(context.Background()) })
+
+	span := result.ChatCompletionTracer().StartSpanAndInjectHeaders(
+		t.Context(),
+		headers,
+		propagation.MapCarrier{},
+		&openai.ChatCompletionRequest{Model: openai.ModelGPT5Nano},
+		[]byte("{}"),
+	)
+	require.NotNil(t, span)
+	span.EndSpan()
+
+	v1Span := collector.TakeSpan()
+	require.NotNil(t, v1Span)
+	return otlpStringAttrs(v1Span)
+}
+
+// TestNewTracingFromEnv_UserIDHeader verifies that with
+// AI_GATEWAY_TRACING_USER_ID_HEADER set, a request that carries both the
+// gateway-injected consumer identity (x-client-id, post-auth) and the
+// consumer-supplied user-id header gets user.id stamped on the SAME span
+// as consumer.id. The env value is case-insensitive (Envoy delivers header
+// keys lowercased).
+func TestNewTracingFromEnv_UserIDHeader(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "X-AI-User-ID")
+
+	attrs := startChatSpanWithHeaders(t, consumerIDMapping(), map[string]string{
+		"x-client-id":  "librechat",
+		"x-ai-user-id": "auth0|64f1c2d3e4a5b6c7d8e9f0a1",
+	})
+	require.Equal(t, "librechat", attrs["consumer.id"])
+	require.Equal(t, "auth0|64f1c2d3e4a5b6c7d8e9f0a1", attrs["user.id"])
+}
+
+// TestNewTracingFromEnv_UserIDHeader_CollisionKeepsExistingMapping pins the
+// collision fail-safe end to end: when the env names the same header the
+// deployment already maps to consumer.id (case differences included), the
+// EXISTING mapping wins — consumer.id is stamped exactly as before and
+// user.id never appears. Silently overriding would kill consumer
+// attribution on every span from one misconfigured env var.
+func TestNewTracingFromEnv_UserIDHeader_CollisionKeepsExistingMapping(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "X-Client-ID") // collides with x-client-id:consumer.id.
+
+	attrs := startChatSpanWithHeaders(t, consumerIDMapping(), map[string]string{
+		"x-client-id":  "librechat",
+		"x-ai-user-id": "alice",
+	})
+	require.Equal(t, "librechat", attrs["consumer.id"])
+	require.NotContains(t, attrs, "user.id")
+}
+
+// TestWithUserIDHeaderFromEnv_CollisionLogsError pins the merge helper's
+// collision behavior: the input mapping comes back unchanged (no user.id
+// entry) and the error written to errOut names the env var, the colliding
+// header, and both attributes involved.
+func TestWithUserIDHeaderFromEnv_CollisionLogsError(t *testing.T) {
+	t.Setenv(envUserIDHeader, " X-Client-ID ")
+	var errBuf bytes.Buffer
+	in := consumerIDMapping()
+	out := withUserIDHeaderFromEnv(in, &errBuf)
+	require.Equal(t, consumerIDMapping(), out)
+	require.Equal(t, consumerIDMapping(), in)
+
+	msg := errBuf.String()
+	require.Contains(t, msg, envUserIDHeader)
+	require.Contains(t, msg, `"x-client-id"`)
+	require.Contains(t, msg, `"consumer.id"`)
+	require.Contains(t, msg, `"user.id"`)
+}
+
+// TestNewTracingFromEnv_UserIDHeader_RequiresConsumerIdentity pins the trust
+// boundary: without the gateway-injected consumer identity header on the
+// request (i.e. traffic that did not pass consumer-key auth), the
+// consumer-supplied user-id header is NOT stamped.
+func TestNewTracingFromEnv_UserIDHeader_RequiresConsumerIdentity(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "x-ai-user-id")
+
+	attrs := startChatSpanWithHeaders(t, consumerIDMapping(), map[string]string{
+		"x-ai-user-id": "mallory",
+	})
+	require.NotContains(t, attrs, "user.id")
+	require.NotContains(t, attrs, "consumer.id")
+}
+
+// TestNewTracingFromEnv_UserIDHeader_EmptyConsumerIdentity pins that an
+// EMPTY consumer-identity header (present, no value) does not count as
+// authenticated consumer traffic: user.id is not stamped.
+func TestNewTracingFromEnv_UserIDHeader_EmptyConsumerIdentity(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "x-ai-user-id")
+
+	attrs := startChatSpanWithHeaders(t, consumerIDMapping(), map[string]string{
+		"x-client-id":  "",
+		"x-ai-user-id": "alice",
+	})
+	require.NotContains(t, attrs, "user.id")
+}
+
+// TestNewTracingFromEnv_UserIDHeader_NoConsumerMappingFailsClosed pins the
+// fail-closed side of the gate: when NO header is mapped to consumer.id at
+// all (requestHeaderAttributes empty), user.id is never stamped — even for
+// a request carrying both headers.
+func TestNewTracingFromEnv_UserIDHeader_NoConsumerMappingFailsClosed(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "x-ai-user-id")
+
+	attrs := startChatSpanWithHeaders(t, nil, map[string]string{
+		"x-client-id":  "librechat",
+		"x-ai-user-id": "alice",
+	})
+	require.NotContains(t, attrs, "user.id")
+}
+
+// TestNewTracingFromEnv_UserIDHeader_DefaultOff pins the default: env unset
+// (or empty) leaves upstream behavior exactly — the user-id header is
+// ignored even when present alongside a valid consumer identity.
+func TestNewTracingFromEnv_UserIDHeader_DefaultOff(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	// Pin to empty so an ambient value in the invoking shell/CI can't flip
+	// the default under test (same idiom as the remote-parent-as-link pin).
+	t.Setenv(envUserIDHeader, "")
+
+	attrs := startChatSpanWithHeaders(t, consumerIDMapping(), map[string]string{
+		"x-client-id":  "librechat",
+		"x-ai-user-id": "alice",
+	})
+	require.Equal(t, "librechat", attrs["consumer.id"])
+	require.NotContains(t, attrs, "user.id")
+}
+
+// TestNewTracingFromEnv_UserIDHeader_Bounded verifies the value bounding: a
+// hostile value is reduced to printable ASCII (control bytes and UTF-8
+// multibyte sequences become '_') and truncated to maxUserIDValueLen bytes
+// before it reaches the trace store.
+func TestNewTracingFromEnv_UserIDHeader_Bounded(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "x-ai-user-id")
+
+	hostile := "alice\r\nx-injected: 1\x00\x1b[31mé" + strings.Repeat("A", maxUserIDValueLen)
+	attrs := startChatSpanWithHeaders(t, consumerIDMapping(), map[string]string{
+		"x-client-id":  "librechat",
+		"x-ai-user-id": hostile,
+	})
+
+	got, ok := attrs["user.id"]
+	require.True(t, ok)
+	require.Len(t, got, maxUserIDValueLen)
+	// \r\n, \x00, \x1b each become one '_'; "[31m" is printable and stays;
+	// é is two UTF-8 bytes — two replacement chars.
+	require.True(t, strings.HasPrefix(got, "alice__x-injected: 1__[31m__AAA"), got)
+	for _, c := range []byte(got) {
+		require.GreaterOrEqual(t, c, byte(0x20))
+		require.LessOrEqual(t, c, byte(0x7e))
+	}
+}
+
+// TestNewTracingFromEnv_UserIDHeader_NothingPrintable verifies a value with
+// no printable content is dropped rather than stamped as underscores.
+func TestNewTracingFromEnv_UserIDHeader_NothingPrintable(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "x-ai-user-id")
+
+	attrs := startChatSpanWithHeaders(t, consumerIDMapping(), map[string]string{
+		"x-client-id":  "librechat",
+		"x-ai-user-id": "\x00\x01 é ",
+	})
+	require.NotContains(t, attrs, "user.id")
+	require.Equal(t, "librechat", attrs["consumer.id"])
+}
+
+// TestNewTracingFromEnv_UserIDHeader_MCPUntouched pins that the MCP tracer
+// does not pick up the env-configured mapping: its meta-first lookup would
+// bypass both the sanitizer and the consumer-auth gate, so the merge is
+// request-tracers-only (see envUserIDHeader's doc).
+func TestNewTracingFromEnv_UserIDHeader_MCPUntouched(t *testing.T) {
+	internaltesting.ClearTestEnv(t)
+	t.Setenv(envUserIDHeader, "x-ai-user-id")
+	collector, tracing := newTracingFromEnvForTest(t, io.Discard)
+
+	reqID, err := jsonrpc.MakeID("id")
+	require.NoError(t, err)
+	r := &jsonrpc.Request{ID: reqID, Method: "initialize"}
+	p := &mcp.InitializeParams{Meta: map[string]any{"x-ai-user-id": "mallory"}}
+	span := tracing.MCPTracer().StartSpanAndInjectMeta(t.Context(), r, p, nil)
+	require.NotNil(t, span)
+	span.EndSpan()
+
+	v1Span := collector.TakeSpan()
+	require.NotNil(t, v1Span)
+	require.NotContains(t, otlpStringAttrs(v1Span), "user.id")
+}
+
+// TestWithUserIDHeaderFromEnv_DoesNotMutateInput guards the merge helper:
+// the caller's map must come back untouched (the MCP tracer receives it).
+func TestWithUserIDHeaderFromEnv_DoesNotMutateInput(t *testing.T) {
+	t.Setenv(envUserIDHeader, " X-AI-User-ID ")
+	in := consumerIDMapping()
+	out := withUserIDHeaderFromEnv(in, io.Discard)
+	require.Equal(t, consumerIDMapping(), in)
+	require.Equal(t, map[string]string{
+		"x-client-id":  "consumer.id",
+		"x-ai-user-id": "user.id",
+	}, out)
+
+	t.Setenv(envUserIDHeader, "")
+	require.Equal(t, consumerIDMapping(), withUserIDHeaderFromEnv(consumerIDMapping(), io.Discard))
+}
+
+// TestSanitizeUserIDValue is the byte-level table for the sanitizer.
+func TestSanitizeUserIDValue(t *testing.T) {
+	for _, tc := range []struct {
+		name, in, want string
+	}{
+		{"clean", "auth0|abc123", "auth0|abc123"},
+		{"email", "alice@example.com", "alice@example.com"},
+		{"control_bytes", "a\x00b\x1fc\x7fd", "a_b_c_d"},
+		{"crlf", "a\r\nb", "a__b"},
+		{"utf8_multibyte", "é", "__"},
+		{"truncated", strings.Repeat("a", maxUserIDValueLen+10), strings.Repeat("a", maxUserIDValueLen)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, sanitizeUserIDValue(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2589.

Adds an opt-in env, `AI_GATEWAY_TRACING_USER_ID_HEADER=<header>`, that stamps the named request header onto the same spans that carry `consumer.id`, as the OpenInference `user.id` attribute — so backends like Phoenix can filter/group by end user for eval and cost attribution in multi-user consumers.

Because the header is caller-supplied end-user attribution (untrusted, unlike a gateway-injected post-auth header), the mapping is guarded:

- **Auth-gated**: stamped only when the request also carries a header the deployment maps to `consumer.id` (in-band proof it passed the auth filter); fail-closed when no `consumer.id` mapping exists.
- **Bounded**: 256 bytes, printable ASCII, dropped entirely when nothing meaningful survives — this lane only; other header→attribute mappings stay verbatim.
- **Collision fail-safe**: if the env names a header already present in the header→attribute mapping, the existing mapping wins, an explicit error is logged, and user.id stamping is disabled — a misconfigured env can never replace `consumer.id`.

Env unset = byte-identical current behavior. The MCP tracer is deliberately excluded (its meta-first lookup would bypass both the sanitizer and the auth gate).

`go test ./internal/tracing/` green; tests cover the gate, the bound, the collision fail-safe, and end-to-end OTLP span content. We run this in production; happy to reshape (flag vs env, naming) per maintainer preference.