### PR TITLE
feat: add authorizationServerMetadataUrl to MCPRoute OAuth

### DIFF
--- a/api/v1alpha1/mcp_route.go
+++ b/api/v1alpha1/mcp_route.go
@@ -355,6 +355,24 @@ type MCPRouteOAuth struct {
 	// +optional
 	JWKS *JWKS `json:"jwks,omitempty"`
 
+	// AuthorizationServerMetadataURL is the URL the controller fetches the OAuth 2.0 Authorization
+	// Server Metadata document from, as defined in RFC 8414. When set, it replaces the well-known
+	// URIs derived from Issuer.
+	//
+	// Set this when the metadata lives somewhere the issuer does not lead to, for example an issuer
+	// of "https://example.com/api/idp/authn" whose document is served only at
+	// "https://example.com/api/idp/v4/authn/.well-known/openid-configuration".
+	//
+	// Issuer is unaffected by this field. It continues to identify the authorization server in the
+	// protected resource metadata the gateway publishes, and to derive the well-known URIs when this
+	// field is unset. When JWKS is not set, the JWKS URI is discovered from the document fetched here.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=uri
+	// +kubebuilder:validation:MaxLength=1024
+	// +optional
+	AuthorizationServerMetadataURL *string `json:"authorizationServerMetadataUrl,omitempty"`
+
 	// ProtectedResourceMetadata defines the OAuth 2.0 Resource Server Metadata as per RFC 8414.
 	// This is used to expose the metadata endpoint for mcp clients to discover the authorization servers,
 	// supported scopes, and JWKS URI.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1434,6 +1434,11 @@ func (in *MCPRouteOAuth) DeepCopyInto(out *MCPRouteOAuth) {
 		*out = new(JWKS)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AuthorizationServerMetadataURL != nil {
+		in, out := &in.AuthorizationServerMetadataURL, &out.AuthorizationServerMetadataURL
+		*out = new(string)
+		**out = **in
+	}
 	in.ProtectedResourceMetadata.DeepCopyInto(&out.ProtectedResourceMetadata)
 	if in.ClaimToHeaders != nil {
 		in, out := &in.ClaimToHeaders, &out.ClaimToHeaders

--- a/api/v1beta1/mcp_route.go
+++ b/api/v1beta1/mcp_route.go
@@ -448,6 +448,24 @@ type MCPRouteOAuth struct {
 	// +optional
 	JWKS *JWKS `json:"jwks,omitempty"`
 
+	// AuthorizationServerMetadataURL is the URL the controller fetches the OAuth 2.0 Authorization
+	// Server Metadata document from, as defined in RFC 8414. When set, it replaces the well-known
+	// URIs derived from Issuer.
+	//
+	// Set this when the metadata lives somewhere the issuer does not lead to, for example an issuer
+	// of "https://example.com/api/idp/authn" whose document is served only at
+	// "https://example.com/api/idp/v4/authn/.well-known/openid-configuration".
+	//
+	// Issuer is unaffected by this field. It continues to identify the authorization server in the
+	// protected resource metadata the gateway publishes, and to derive the well-known URIs when this
+	// field is unset. When JWKS is not set, the JWKS URI is discovered from the document fetched here.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=uri
+	// +kubebuilder:validation:MaxLength=1024
+	// +optional
+	AuthorizationServerMetadataURL *string `json:"authorizationServerMetadataUrl,omitempty"`
+
 	// ProtectedResourceMetadata defines the OAuth 2.0 Resource Server Metadata as per RFC 8414.
 	// This is used to expose the metadata endpoint for mcp clients to discover the authorization servers,
 	// supported scopes, and JWKS URI.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1581,6 +1581,11 @@ func (in *MCPRouteOAuth) DeepCopyInto(out *MCPRouteOAuth) {
 		*out = new(JWKS)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AuthorizationServerMetadataURL != nil {
+		in, out := &in.AuthorizationServerMetadataURL, &out.AuthorizationServerMetadataURL
+		*out = new(string)
+		**out = **in
+	}
 	in.ProtectedResourceMetadata.DeepCopyInto(&out.ProtectedResourceMetadata)
 	if in.ClaimToHeaders != nil {
 		in, out := &in.ClaimToHeaders, &out.ClaimToHeaders

--- a/internal/controller/mcp_route_security_policy.go
+++ b/internal/controller/mcp_route_security_policy.go
@@ -716,9 +716,66 @@ func (e *invalidMetadataError) Unwrap() error { return e.err }
 // fetchOAuthAuthServerMetadata fetches OAuth authorization server metadata from the well-known endpoint
 // with exponential backoff retry logic. It returns the fetched metadata or an error if all attempts fail.
 func fetchOAuthAuthServerMetadata(authServer, metadataURL string, maxRetryElapsedTime time.Duration) (*OAuthAuthServerMetadata, error) {
+	// An explicitly configured metadata URL is used verbatim: the whole point of the field is that
+	// the document lives somewhere the issuer does not lead to, so there is nothing to derive.
+	if metadataURL != "" {
+		metadata, err := fetchFirstUsableMetadata([]string{metadataURL}, maxRetryElapsedTime)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch authorization server metadata from %q: %w", metadataURL, err)
+		}
+		return metadata, nil
+	}
+
+	authServerURL, err := url.Parse(authServer)
+	if err != nil {
+		return nil, fmt.Errorf("invalid authorization server URL: %w", err)
+	}
+
+	// Build the well-known URL according to the spec: https://datatracker.ietf.org/doc/html/rfc8414#section-3
+	// Some providers like Descope do not honor the spec and put the well-known endpoint
+	// after the issuer path, so we try a set of variants to maximize compatibility.
+	// See: https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-server-metadata-discovery
+	wellKnownURLVariants := []string{
+		fmt.Sprintf("%s://%s%s%s",
+			authServerURL.Scheme,
+			authServerURL.Host,
+			oauthWellKnownAuthorizationServerMetadataPath,
+			strings.TrimSuffix(authServerURL.Path, "/"),
+		),
+		fmt.Sprintf("%s://%s%s%s",
+			authServerURL.Scheme,
+			authServerURL.Host,
+			oidcWellKnownMetadataPath,
+			strings.TrimSuffix(authServerURL.Path, "/"),
+		),
+		fmt.Sprintf("%s://%s%s%s",
+			authServerURL.Scheme,
+			authServerURL.Host,
+			strings.TrimSuffix(authServerURL.Path, "/"),
+			oauthWellKnownAuthorizationServerMetadataPath,
+		),
+		fmt.Sprintf("%s://%s%s%s",
+			authServerURL.Scheme,
+			authServerURL.Host,
+			strings.TrimSuffix(authServerURL.Path, "/"),
+			oidcWellKnownMetadataPath,
+		),
+	}
+
+	metadata, err := fetchFirstUsableMetadata(wellKnownURLVariants, maxRetryElapsedTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover authorization server metadata for issuer %q: %w", authServer, err)
+	}
+	return metadata, nil
+}
+
+// fetchFirstUsableMetadata tries each candidate URL in order, with exponential backoff per URL,
+// and returns the first usable document. A URL that answers with a 4xx or with a document we
+// cannot use is a miss, and the next URL is tried. Any other failure is returned immediately.
+func fetchFirstUsableMetadata(candidateURLs []string, maxRetryElapsedTime time.Duration) (*OAuthAuthServerMetadata, error) {
 	httpClient := &http.Client{Timeout: httpClientTimeout}
 
-	operation := func(wellKnownURL string, metadata *OAuthAuthServerMetadata) error {
+	fetchOnce := func(wellKnownURL string, metadata *OAuthAuthServerMetadata) error {
 		resp, err := httpClient.Get(wellKnownURL)
 		if err != nil {
 			urlError, dnsError := &url.Error{}, &net.DNSError{}
@@ -769,66 +826,13 @@ func fetchOAuthAuthServerMetadata(authServer, metadataURL string, maxRetryElapse
 		return nil
 	}
 
-	// An explicitly configured metadata URL is used verbatim: the whole point of the field is that
-	// the document lives somewhere the issuer does not lead to, so there is nothing to derive.
-	if metadataURL != "" {
-		return fetchFromWellKnownURLs(metadataURL, []string{metadataURL}, operation, maxRetryElapsedTime)
-	}
-
-	authServerURL, err := url.Parse(authServer)
-	if err != nil {
-		return nil, fmt.Errorf("invalid authorization server URL: %w", err)
-	}
-
-	// Build the well-known URL according to the spec: https://datatracker.ietf.org/doc/html/rfc8414#section-3
-	// Some providers like Descope do not honor the spec and put the well-known endpoint
-	// after the issuer path, so we try a set of variants to maximize compatibility.
-	// See: https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-server-metadata-discovery
-	wellKnownURLVariants := []string{
-		fmt.Sprintf("%s://%s%s%s",
-			authServerURL.Scheme,
-			authServerURL.Host,
-			oauthWellKnownAuthorizationServerMetadataPath,
-			strings.TrimSuffix(authServerURL.Path, "/"),
-		),
-		fmt.Sprintf("%s://%s%s%s",
-			authServerURL.Scheme,
-			authServerURL.Host,
-			oidcWellKnownMetadataPath,
-			strings.TrimSuffix(authServerURL.Path, "/"),
-		),
-		fmt.Sprintf("%s://%s%s%s",
-			authServerURL.Scheme,
-			authServerURL.Host,
-			strings.TrimSuffix(authServerURL.Path, "/"),
-			oauthWellKnownAuthorizationServerMetadataPath,
-		),
-		fmt.Sprintf("%s://%s%s%s",
-			authServerURL.Scheme,
-			authServerURL.Host,
-			strings.TrimSuffix(authServerURL.Path, "/"),
-			oidcWellKnownMetadataPath,
-		),
-	}
-
-	return fetchFromWellKnownURLs(authServer, wellKnownURLVariants, operation, maxRetryElapsedTime)
-}
-
-// fetchFromWellKnownURLs tries each URL in order and returns the first usable document.
-// A URL that answers with a 4xx or with a document we cannot use is a miss, and the next URL is tried.
-func fetchFromWellKnownURLs(
-	subject string,
-	wellKnownURLs []string,
-	operation func(string, *OAuthAuthServerMetadata) error,
-	maxRetryElapsedTime time.Duration,
-) (*OAuthAuthServerMetadata, error) {
 	var lastErr error
-	for _, wellKnownURL := range wellKnownURLs {
+	for _, wellKnownURL := range candidateURLs {
 		var metadata OAuthAuthServerMetadata
 		b := backoff.NewExponentialBackOff()
 		b.MaxElapsedTime = maxRetryElapsedTime
 		err := backoff.Retry(func() error {
-			return operation(wellKnownURL, &metadata)
+			return fetchOnce(wellKnownURL, &metadata)
 		}, b)
 		if err == nil { // Success.
 			return &metadata, nil
@@ -852,7 +856,7 @@ func fetchFromWellKnownURLs(
 
 	// We can only get here if every URL was a 4xx or returned an unusable document.
 	// Return the last failure.
-	return nil, fmt.Errorf("no usable authorization server metadata found for %q: %w", subject, lastErr)
+	return nil, fmt.Errorf("no usable metadata at any candidate URL: %w", lastErr)
 }
 
 func oauthProtectedResourceMetadataName(mcpRouteName string) string {

--- a/internal/controller/mcp_route_security_policy.go
+++ b/internal/controller/mcp_route_security_policy.go
@@ -124,7 +124,7 @@ func (c *MCPRouteController) ensureSecurityPolicy(ctx context.Context, mcpRoute 
 		} else {
 			// Auto-discover JWKS URI from authorization server metadata.
 			c.logger.Info("Auto-discovering JWKS URI from authorization server metadata", "issuer", oauth.Issuer)
-			jwksURI, discoveryErr := c.discoverJWKSURI(oauth.Issuer)
+			jwksURI, discoveryErr := c.discoverJWKSURI(oauth)
 			if discoveryErr != nil {
 				return fmt.Errorf("failed to auto-discover JWKS URI: %w", discoveryErr)
 			}
@@ -456,7 +456,10 @@ func (c *MCPRouteController) ensureOAuthAuthServerMetadataHRF(ctx context.Contex
 	}
 
 	// Build OAuth authorization server metadata JSON response.
-	metadataJSON := c.buildOAuthAuthServerMetadataJSON(mcpRoute.Spec.SecurityPolicy.OAuth)
+	metadataJSON, err := c.buildOAuthAuthServerMetadataJSON(mcpRoute.Spec.SecurityPolicy.OAuth)
+	if err != nil {
+		return err
+	}
 
 	// Configure direct response with OAuth authorization server metadata.
 	httpRouteFilter.Spec = egv1a1.HTTPRouteFilterSpec{
@@ -522,12 +525,13 @@ func buildOAuthProtectedResourceMetadataJSON(auth *aigv1b1.MCPRouteOAuth) string
 }
 
 // buildOAuthAuthServerMetadataJSON constructs the OAuth authorization server metadata JSON response.
-// It first attempts to fetch metadata from the authorization server's well-known endpoint,
-// and falls back to hardcoded values if the fetch fails.
+// It fetches the metadata from the URL configured in AuthorizationServerMetadataURL, or, when that is
+// unset, from the well-known endpoints derived from the issuer. A failure to fetch a configured URL is
+// returned as an error; a failure to discover from the issuer falls back to hardcoded values.
 // References:
 // * https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#authorization-server-location
 // * https://datatracker.ietf.org/doc/html/rfc8414#section-3.2
-func (c *MCPRouteController) buildOAuthAuthServerMetadataJSON(oauth *aigv1b1.MCPRouteOAuth) string {
+func (c *MCPRouteController) buildOAuthAuthServerMetadataJSON(oauth *aigv1b1.MCPRouteOAuth) (string, error) {
 	// For 2025-03-26 compatibility, we return the authorization server metadata.
 
 	// The authorization server's issuer identifier, which is a URL that uses the "https" scheme and has no query or
@@ -536,16 +540,24 @@ func (c *MCPRouteController) buildOAuthAuthServerMetadataJSON(oauth *aigv1b1.MCP
 	// https://datatracker.ietf.org/doc/html/rfc8414#section-2
 	authServer := strings.TrimSuffix(oauth.Issuer, "/")
 
-	// Try to fetch metadata from the well-known endpoint first.
-	if authServer != "" {
-		fetchedMetadata, err := fetchOAuthAuthServerMetadata(authServer, maxRetryElapsedTime)
+	metadataURL := ptr.Deref(oauth.AuthorizationServerMetadataURL, "")
+
+	// Try to fetch the metadata document before falling back to hardcoded values.
+	if authServer != "" || metadataURL != "" {
+		fetchedMetadata, err := fetchOAuthAuthServerMetadata(authServer, metadataURL, maxRetryElapsedTime)
 		if err == nil && fetchedMetadata != nil {
 			// Convert to JSON string and return.
 			jsonBytes, _ := json.Marshal(fetchedMetadata)
-			return string(jsonBytes)
+			return string(jsonBytes), nil
 		}
 		// If there was an error fetching metadata, log it.
 		if err != nil {
+			// An operator who configured an explicit URL asked for that document specifically.
+			// Substituting defaults would hide the misconfiguration behind endpoints that do not
+			// exist, so surface it instead.
+			if metadataURL != "" {
+				return "", fmt.Errorf("failed to fetch OAuth authorization server metadata from %s: %w", metadataURL, err)
+			}
 			c.logger.Error(err, "failed to fetch OAuth authorization server metadata from well-known endpoint", "authServer", authServer)
 		}
 	}
@@ -570,7 +582,7 @@ func (c *MCPRouteController) buildOAuthAuthServerMetadataJSON(oauth *aigv1b1.MCP
 
 	// Convert to JSON string.
 	jsonBytes, _ := json.Marshal(response)
-	return string(jsonBytes)
+	return string(jsonBytes), nil
 }
 
 // cleanupSecurityPolicyResources deletes existing SecurityPolicy-related resources when SecurityPolicy is nil.
@@ -703,7 +715,7 @@ func (e *invalidMetadataError) Unwrap() error { return e.err }
 
 // fetchOAuthAuthServerMetadata fetches OAuth authorization server metadata from the well-known endpoint
 // with exponential backoff retry logic. It returns the fetched metadata or an error if all attempts fail.
-func fetchOAuthAuthServerMetadata(authServer string, maxRetryElapsedTime time.Duration) (*OAuthAuthServerMetadata, error) {
+func fetchOAuthAuthServerMetadata(authServer, metadataURL string, maxRetryElapsedTime time.Duration) (*OAuthAuthServerMetadata, error) {
 	httpClient := &http.Client{Timeout: httpClientTimeout}
 
 	operation := func(wellKnownURL string, metadata *OAuthAuthServerMetadata) error {
@@ -757,6 +769,12 @@ func fetchOAuthAuthServerMetadata(authServer string, maxRetryElapsedTime time.Du
 		return nil
 	}
 
+	// An explicitly configured metadata URL is used verbatim: the whole point of the field is that
+	// the document lives somewhere the issuer does not lead to, so there is nothing to derive.
+	if metadataURL != "" {
+		return fetchFromWellKnownURLs(metadataURL, []string{metadataURL}, operation, maxRetryElapsedTime)
+	}
+
 	authServerURL, err := url.Parse(authServer)
 	if err != nil {
 		return nil, fmt.Errorf("invalid authorization server URL: %w", err)
@@ -793,12 +811,23 @@ func fetchOAuthAuthServerMetadata(authServer string, maxRetryElapsedTime time.Du
 		),
 	}
 
+	return fetchFromWellKnownURLs(authServer, wellKnownURLVariants, operation, maxRetryElapsedTime)
+}
+
+// fetchFromWellKnownURLs tries each URL in order and returns the first usable document.
+// A URL that answers with a 4xx or with a document we cannot use is a miss, and the next URL is tried.
+func fetchFromWellKnownURLs(
+	subject string,
+	wellKnownURLs []string,
+	operation func(string, *OAuthAuthServerMetadata) error,
+	maxRetryElapsedTime time.Duration,
+) (*OAuthAuthServerMetadata, error) {
 	var lastErr error
-	for _, wellKnownURL := range wellKnownURLVariants {
+	for _, wellKnownURL := range wellKnownURLs {
 		var metadata OAuthAuthServerMetadata
 		b := backoff.NewExponentialBackOff()
 		b.MaxElapsedTime = maxRetryElapsedTime
-		err = backoff.Retry(func() error {
+		err := backoff.Retry(func() error {
 			return operation(wellKnownURL, &metadata)
 		}, b)
 		if err == nil { // Success.
@@ -821,9 +850,9 @@ func fetchOAuthAuthServerMetadata(authServer string, maxRetryElapsedTime time.Du
 		}
 	}
 
-	// We can only get here if every variant was a 4xx or returned an unusable document.
+	// We can only get here if every URL was a 4xx or returned an unusable document.
 	// Return the last failure.
-	return nil, fmt.Errorf("no usable authorization server metadata found for %q: %w", authServer, lastErr)
+	return nil, fmt.Errorf("no usable authorization server metadata found for %q: %w", subject, lastErr)
 }
 
 func oauthProtectedResourceMetadataName(mcpRouteName string) string {
@@ -836,9 +865,9 @@ func oauthAuthServerMetadataFilterName(mcpRouteName string) string {
 
 // discoverJWKSURI attempts to discover the JWKS URI from the OAuth authorization server metadata.
 // It fetches the well-known metadata endpoint and extracts the jwks_uri field.
-func (c *MCPRouteController) discoverJWKSURI(issuer string) (string, error) {
+func (c *MCPRouteController) discoverJWKSURI(oauth *aigv1b1.MCPRouteOAuth) (string, error) {
 	// Fetch OAuth authorization server metadata.
-	metadata, err := fetchOAuthAuthServerMetadata(issuer, maxRetryElapsedTime)
+	metadata, err := fetchOAuthAuthServerMetadata(oauth.Issuer, ptr.Deref(oauth.AuthorizationServerMetadataURL, ""), maxRetryElapsedTime)
 	switch {
 	case err != nil:
 		return "", fmt.Errorf("failed to fetch authorization server metadata: %w", err)

--- a/internal/controller/mcp_route_security_policy_test.go
+++ b/internal/controller/mcp_route_security_policy_test.go
@@ -921,7 +921,7 @@ func Test_fetchOAuthServerMetadata(t *testing.T) {
 
 			// Use a small backoff timeout that allows the test to configure a number of attempts
 			// to force failures or self-healing.
-			metadata, err := fetchOAuthAuthServerMetadata(server.URL+tt.issuerPath, 1*time.Second)
+			metadata, err := fetchOAuthAuthServerMetadata(server.URL+tt.issuerPath, "", 1*time.Second)
 
 			if tt.wantStatusCode != http.StatusOK {
 				var httpError *httpError
@@ -976,7 +976,7 @@ func Test_fetchOAuthServerMetadata_unusableDocument(t *testing.T) {
 		t.Cleanup(server.Close)
 		addr := server.Listener.Addr().String()
 
-		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, 1*time.Second)
+		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, "", 1*time.Second)
 		require.NoError(t, err)
 		require.Equal(t, "http://"+addr+issuerPath, metadata.Issuer)
 		require.Equal(t, "http://"+addr+"/auth", metadata.AuthorizationEndpoint)
@@ -994,7 +994,7 @@ func Test_fetchOAuthServerMetadata_unusableDocument(t *testing.T) {
 		server := httptest.NewServer(mux)
 		t.Cleanup(server.Close)
 
-		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, 1*time.Second)
+		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, "", 1*time.Second)
 		require.NoError(t, err)
 		require.Empty(t, metadata.JwksURI, "jwks_uri from a rejected variant must not survive")
 	})
@@ -1006,7 +1006,7 @@ func Test_fetchOAuthServerMetadata_unusableDocument(t *testing.T) {
 		server := httptest.NewServer(mux)
 		t.Cleanup(server.Close)
 
-		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, 1*time.Second)
+		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, "", 1*time.Second)
 		require.Nil(t, metadata)
 		var invalidErr *invalidMetadataError
 		require.ErrorAs(t, err, &invalidErr)
@@ -1026,7 +1026,7 @@ func Test_fetchOAuthServerMetadata_unusableDocument(t *testing.T) {
 		server := httptest.NewServer(mux)
 		t.Cleanup(server.Close)
 
-		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, 1*time.Second)
+		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, "", 1*time.Second)
 		require.NoError(t, err)
 		require.Equal(t, "https://idp.example.com/keys", metadata.JwksURI)
 	})
@@ -1045,8 +1045,123 @@ func Test_fetchOAuthServerMetadata_unusableDocument(t *testing.T) {
 		t.Cleanup(server.Close)
 		addr := server.Listener.Addr().String()
 
-		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, 1*time.Second)
+		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, "", 1*time.Second)
 		require.NoError(t, err)
 		require.Equal(t, "http://"+addr+issuerPath, metadata.Issuer)
+	})
+}
+
+func Test_fetchOAuthServerMetadata_explicitURL(t *testing.T) {
+	const (
+		issuerPath = "/api/idp/authn"
+		// The document lives at a versioned path that cannot be derived from the issuer.
+		versionedPath = "/api/idp/v4/authn/.well-known/openid-configuration"
+	)
+
+	newServer := func(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
+		mux := http.NewServeMux()
+		register(mux)
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	completeDocument := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                 "http://" + r.Host + issuerPath,
+			"authorization_endpoint": "http://" + r.Host + "/authn/v1/oidc/auth",
+			"token_endpoint":         "http://" + r.Host + "/v4/authn/oidc/token",
+			"jwks_uri":               "http://" + r.Host + "/v4/authn/oidc/keys",
+		})
+	}
+
+	t.Run("fetches from the configured URL", func(t *testing.T) {
+		server := newServer(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(versionedPath, completeDocument)
+		})
+		addr := server.Listener.Addr().String()
+
+		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, server.URL+versionedPath, 1*time.Second)
+		require.NoError(t, err)
+		require.Equal(t, "http://"+addr+issuerPath, metadata.Issuer)
+		require.Equal(t, "http://"+addr+"/authn/v1/oidc/auth", metadata.AuthorizationEndpoint)
+		require.Equal(t, "http://"+addr+"/v4/authn/oidc/token", metadata.TokenEndpoint)
+	})
+
+	t.Run("does not probe the URL variants derived from the issuer", func(t *testing.T) {
+		var derivedHits int
+		server := newServer(t, func(mux *http.ServeMux) {
+			mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+				derivedHits++
+				w.WriteHeader(http.StatusNotFound)
+			})
+			mux.HandleFunc(versionedPath, completeDocument)
+		})
+
+		_, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, server.URL+versionedPath, 1*time.Second)
+		require.NoError(t, err)
+		require.Zero(t, derivedHits, "the derived well-known URLs must not be probed")
+	})
+
+	t.Run("fails when the configured URL serves an unusable document", func(t *testing.T) {
+		server := newServer(t, func(mux *http.ServeMux) {
+			// The legacy issuer path serves a usable document, but it is not what was configured.
+			mux.HandleFunc(issuerPath+"/.well-known/openid-configuration", completeDocument)
+			mux.HandleFunc(versionedPath, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("{}"))
+			})
+		})
+
+		metadata, err := fetchOAuthAuthServerMetadata(server.URL+issuerPath, server.URL+versionedPath, 1*time.Second)
+		require.Nil(t, metadata)
+		var invalidErr *invalidMetadataError
+		require.ErrorAs(t, err, &invalidErr)
+	})
+}
+
+func Test_buildOAuthAuthServerMetadataJSON_explicitURL(t *testing.T) {
+	c := &MCPRouteController{logger: logr.Discard()}
+
+	t.Run("serves the document from the configured URL", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/versioned/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":                 "http://" + r.Host + "/legacy",
+				"authorization_endpoint": "http://" + r.Host + "/oidc/auth",
+				"token_endpoint":         "http://" + r.Host + "/oidc/token",
+			})
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		metadataJSON, err := c.buildOAuthAuthServerMetadataJSON(&aigv1b1.MCPRouteOAuth{
+			Issuer:                         server.URL + "/legacy",
+			AuthorizationServerMetadataURL: ptr.To(server.URL + "/versioned/.well-known/openid-configuration"),
+		})
+		require.NoError(t, err)
+		require.Contains(t, metadataJSON, `"authorization_endpoint":"`+server.URL+`/oidc/auth"`)
+		// The Keycloak-shaped defaults must not appear.
+		require.NotContains(t, metadataJSON, "/protocol/openid-connect/")
+	})
+
+	t.Run("fails rather than substituting defaults", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/versioned/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		_, err := c.buildOAuthAuthServerMetadataJSON(&aigv1b1.MCPRouteOAuth{
+			Issuer:                         server.URL + "/legacy",
+			AuthorizationServerMetadataURL: ptr.To(server.URL + "/versioned/.well-known/openid-configuration"),
+		})
+		require.ErrorContains(t, err, "failed to fetch OAuth authorization server metadata")
 	})
 }

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_mcproutes.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_mcproutes.yaml
@@ -4355,6 +4355,22 @@ spec:
                           type: string
                         maxItems: 32
                         type: array
+                      authorizationServerMetadataUrl:
+                        description: |-
+                          AuthorizationServerMetadataURL is the URL the controller fetches the OAuth 2.0 Authorization
+                          Server Metadata document from, as defined in RFC 8414. When set, it replaces the well-known
+                          URIs derived from Issuer.
+
+                          Set this when the metadata lives somewhere the issuer does not lead to, for example an issuer
+                          of "https://example.com/api/idp/authn" whose document is served only at
+                          "https://example.com/api/idp/v4/authn/.well-known/openid-configuration".
+
+                          Issuer is unaffected by this field. It continues to identify the authorization server in the
+                          protected resource metadata the gateway publishes, and to derive the well-known URIs when this
+                          field is unset. When JWKS is not set, the JWKS URI is discovered from the document fetched here.
+                        format: uri
+                        maxLength: 1024
+                        type: string
                       claimToHeaders:
                         description: |-
                           ClaimToHeaders specifies JWT claims to extract and forward as HTTP headers to backend MCP servers.
@@ -10594,6 +10610,22 @@ spec:
                           type: string
                         maxItems: 32
                         type: array
+                      authorizationServerMetadataUrl:
+                        description: |-
+                          AuthorizationServerMetadataURL is the URL the controller fetches the OAuth 2.0 Authorization
+                          Server Metadata document from, as defined in RFC 8414. When set, it replaces the well-known
+                          URIs derived from Issuer.
+
+                          Set this when the metadata lives somewhere the issuer does not lead to, for example an issuer
+                          of "https://example.com/api/idp/authn" whose document is served only at
+                          "https://example.com/api/idp/v4/authn/.well-known/openid-configuration".
+
+                          Issuer is unaffected by this field. It continues to identify the authorization server in the
+                          protected resource metadata the gateway publishes, and to derive the well-known URIs when this
+                          field is unset. When JWKS is not set, the JWKS URI is discovered from the document fetched here.
+                        format: uri
+                        maxLength: 1024
+                        type: string
                       claimToHeaders:
                         description: |-
                           ClaimToHeaders specifies JWT claims to extract and forward as HTTP headers to backend MCP servers.

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -2156,6 +2156,11 @@ Reference: https://modelcontextprotocol.io/specification/2025-06-18/basic/author
   required="false"
   description="JWKS defines how a JSON Web Key Sets (JWKS) can be obtained to verify the access tokens presented by the clients.<br />If not specified, the JWKS URI will be discovered from the OAuth 2.0 Authorization Server Metadata<br />as per RFC 8414 by querying the `/.well-known/oauth-authorization-server` endpoint on the Issuer."
 /><ApiField
+  name="authorizationServerMetadataUrl"
+  type="string"
+  required="false"
+  description="AuthorizationServerMetadataURL is the URL the controller fetches the OAuth 2.0 Authorization<br />Server Metadata document from, as defined in RFC 8414. When set, it replaces the well-known<br />URIs derived from Issuer.<br />Set this when the metadata lives somewhere the issuer does not lead to, for example an issuer<br />of `https://example.com/api/idp/authn` whose document is served only at<br />`https://example.com/api/idp/v4/authn/.well-known/openid-configuration`.<br />Issuer is unaffected by this field. It continues to identify the authorization server in the<br />protected resource metadata the gateway publishes, and to derive the well-known URIs when this<br />field is unset. When JWKS is not set, the JWKS URI is discovered from the document fetched here."
+/><ApiField
   name="protectedResourceMetadata"
   type="[ProtectedResourceMetadata](#github-com-envoyproxy-ai-gateway-api-v1alpha1-protectedresourcemetadata)"
   required="true"
@@ -4938,6 +4943,11 @@ Reference: https://modelcontextprotocol.io/specification/2025-06-18/basic/author
   type="[JWKS](#github-com-envoyproxy-ai-gateway-api-v1beta1-jwks)"
   required="false"
   description="JWKS defines how a JSON Web Key Sets (JWKS) can be obtained to verify the access tokens presented by the clients.<br />If not specified, the JWKS URI will be discovered from the OAuth 2.0 Authorization Server Metadata<br />as per RFC 8414 by querying the `/.well-known/oauth-authorization-server` endpoint on the Issuer."
+/><ApiField
+  name="authorizationServerMetadataUrl"
+  type="string"
+  required="false"
+  description="AuthorizationServerMetadataURL is the URL the controller fetches the OAuth 2.0 Authorization<br />Server Metadata document from, as defined in RFC 8414. When set, it replaces the well-known<br />URIs derived from Issuer.<br />Set this when the metadata lives somewhere the issuer does not lead to, for example an issuer<br />of `https://example.com/api/idp/authn` whose document is served only at<br />`https://example.com/api/idp/v4/authn/.well-known/openid-configuration`.<br />Issuer is unaffected by this field. It continues to identify the authorization server in the<br />protected resource metadata the gateway publishes, and to derive the well-known URIs when this<br />field is unset. When JWKS is not set, the JWKS URI is discovered from the document fetched here."
 /><ApiField
   name="protectedResourceMetadata"
   type="[ProtectedResourceMetadata](#github-com-envoyproxy-ai-gateway-api-v1beta1-protectedresourcemetadata)"

--- a/site/docs/capabilities/mcp/index.md
+++ b/site/docs/capabilities/mcp/index.md
@@ -285,6 +285,25 @@ spec:
           - "email"
 ```
 
+#### Authorization servers with non-standard metadata locations
+
+By default the gateway discovers the authorization server's endpoints by probing the well-known
+URIs derived from `issuer`, as described in [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414#section-3).
+Some authorization servers publish their metadata somewhere the issuer does not lead to, for example
+at a versioned path. Point `authorizationServerMetadataUrl` at the document in that case:
+
+```yaml
+securityPolicy:
+  oauth:
+    issuer: "https://example.com/api/idp/authn"
+    authorizationServerMetadataUrl: "https://example.com/api/idp/v4/authn/.well-known/openid-configuration"
+```
+
+`issuer` is unaffected by this field: it still identifies the authorization server in the protected
+resource metadata the gateway publishes. When `jwks` is not set, the JWKS URI is also discovered from
+the document fetched here. If that document cannot be fetched, the MCPRoute is not accepted and the
+reason appears in its status conditions.
+
 The OAuth flow follows the MCP specification's authorization code flow with PKCE:
 
 ```mermaid

--- a/tests/crdcel/testdata/mcpgatewayroutes/basic.yaml
+++ b/tests/crdcel/testdata/mcpgatewayroutes/basic.yaml
@@ -27,6 +27,7 @@ spec:
   securityPolicy:
     oauth:
       issuer: https://auth.example.com/
+      authorizationServerMetadataUrl: https://auth.example.com/v4/.well-known/openid-configuration
       audiences:
         - example
       jwks:


### PR DESCRIPTION
**Description**
The controller discovers authorization server metadata by probing well-known URIs derived from the issuer. Some authorization servers publish a complete document at a location that cannot be derived that way, such as an issuer of `https://example.com/api/idp/authn` whose metadata is served only at `https://example.com/api/idp/v4/authn/.well-known/openid-configuration`. The issuer cannot be pointed at the versioned path instead, because it is matched against the `iss` claim on every token.

```yaml
securityPolicy:
  oauth:
    issuer: "https://example.com/api/idp/authn"
    authorizationServerMetadataUrl: "https://example.com/api/idp/v4/authn/.well-known/openid-configuration"
```

The controller fetches that URL verbatim, skipping the derived variants, so `issuer` keeps its single meaning and the two concerns are no longer coupled through one field.

Fixes #2049