### PR TITLE
docs: surface standalone install path

### DIFF
--- a/site/docs/getting-started/index.md
+++ b/site/docs/getting-started/index.md
@@ -9,6 +9,7 @@ sidebar_position: 2
 Welcome to the Envoy AI Gateway getting started guide!
 
 This guide will walk you through setting up and using Envoy AI Gateway, a tool for managing GenAI traffic using Envoy.
+The getting started flow uses Kubernetes by default. If you want to run Envoy AI Gateway as a standalone local proxy with Docker Compose or a config file, use the [CLI run guide](../cli/run.md) and the [`cmd/aigw` Docker Compose examples](https://github.com/envoyproxy/ai-gateway/tree/main/cmd/aigw).
 
 ## Guide Structure
 
@@ -33,6 +34,8 @@ This getting started guide is organized into several sections:
    - Setting up OpenAI integration
    - Configuring AWS Bedrock
    - Managing credentials securely
+
+For local Docker or non-Kubernetes deployments, start with the [Envoy AI Gateway CLI](../cli/) instead.
 
 ## Need Help?
 

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -13,7 +13,9 @@ This guide will walk you through installing Envoy AI Gateway and its required co
 
 ## Installing Envoy AI Gateway
 
-The easiest way to install Envoy AI Gateway is using the Helm charts. You need to install the CRDs first, followed by the AI Gateway controller.
+The easiest way to install Envoy AI Gateway on Kubernetes is using the Helm charts. You need to install the CRDs first, followed by the AI Gateway controller.
+
+If you want to run Envoy AI Gateway as a standalone proxy outside Kubernetes, use [`aigw run`](../cli/run.md). The CLI can run directly on Linux and macOS, or from the Docker Compose examples in [`cmd/aigw`](https://github.com/envoyproxy/ai-gateway/tree/main/cmd/aigw). Those examples include an Ollama-backed stack and an OpenTelemetry stack for local traces and metrics.
 
 ### Step 1: Install AI Gateway CRDs
 


### PR DESCRIPTION
**Description**

This commit updates the getting-started docs to make the standalone `aigw run` path visible from the main installation flow. The Kubernetes Helm path remains the default, but users looking for Docker Compose or non-Kubernetes usage now get directed to the maintained CLI run guide and `cmd/aigw` Compose examples.

This keeps the change intentionally small: it links to the existing standalone examples instead of duplicating their setup steps in the Kubernetes getting-started flow.

AI assistance was used to draft and validate this documentation change; I reviewed the linked docs and own the final patch.

**Related Issues/PRs (if applicable)**

Related to #1899

**Special notes for reviewers (if applicable)**

Validated locally with:

- `go tool -modfile=tools/go.mod prettier --check site/docs/getting-started/index.md site/docs/getting-started/installation.md`
- `go tool -modfile=tools/go.mod misspell -error site/docs/getting-started/index.md site/docs/getting-started/installation.md`
- `git diff --check`
- `npm run build` from `site/`

`npm run build` completed successfully. It still reports existing broken-anchor warnings in generated/versioned API docs that are unrelated to this docs patch.
