### PR TITLE
fix: skip non-HCM filter chains instead of failing translation

### DIFF
--- a/internal/extensionserver/header_to_metadata.go
+++ b/internal/extensionserver/header_to_metadata.go
@@ -40,7 +40,9 @@ func (s *Server) insertRequestHeaderToMetadataFilter(listener *listenerv3.Listen
 	for _, currChain := range filterChains {
 		httpConManager, hcmIndex, err := findHCM(currChain)
 		if err != nil {
-			return err
+			// Chains without an HCM (e.g. TCP/UDP routes) cannot host HTTP filters.
+			s.log.Error(err, "skipping filter chain without an HTTP connection manager", "listener", listener.Name)
+			continue
 		}
 		if filterIndex, filter := findHeaderToMetadataFilter(httpConManager.HttpFilters); filter != nil {
 			typedConfig := filter.GetTypedConfig()

--- a/internal/extensionserver/header_to_metadata_test.go
+++ b/internal/extensionserver/header_to_metadata_test.go
@@ -146,4 +146,32 @@ func TestInsertRequestHeaderToMetadataFilter(t *testing.T) {
 		err = s.insertRequestHeaderToMetadataFilter(listener)
 		require.EqualError(t, err, "header_to_metadata filter missing typed_config")
 	})
+	t.Run("skip-non-hcm-chain", func(t *testing.T) {
+		s := &Server{logRequestHeaderAttributes: map[string]string{"x-tenant-id": "tenant.id"}}
+		hcm := &httpconnectionmanagerv3.HttpConnectionManager{
+			HttpFilters: []*httpconnectionmanagerv3.HttpFilter{{Name: wellknown.Router}},
+		}
+		hcmAny, err := toAny(hcm)
+		require.NoError(t, err)
+		listener := &listenerv3.Listener{
+			FilterChains: []*listenerv3.FilterChain{
+				// TCP proxy chain without an HCM must be skipped, not fail the walk.
+				{Filters: []*listenerv3.Filter{{Name: "envoy.filters.network.tcp_proxy"}}},
+				{
+					Filters: []*listenerv3.Filter{{
+						Name:       wellknown.HTTPConnectionManager,
+						ConfigType: &listenerv3.Filter_TypedConfig{TypedConfig: hcmAny},
+					}},
+				},
+			},
+		}
+		require.NoError(t, s.insertRequestHeaderToMetadataFilter(listener))
+		// The HTTP chain got the filter; the TCP chain is untouched.
+		hcmAfter := &httpconnectionmanagerv3.HttpConnectionManager{}
+		require.NoError(t, listener.FilterChains[1].Filters[0].GetTypedConfig().UnmarshalTo(hcmAfter))
+		require.Len(t, hcmAfter.HttpFilters, 2)
+		require.Equal(t, headerToMetadataFilterName, hcmAfter.HttpFilters[0].Name)
+		require.Len(t, listener.FilterChains[0].Filters, 1)
+		require.Equal(t, "envoy.filters.network.tcp_proxy", listener.FilterChains[0].Filters[0].Name)
+	})
 }

--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -776,7 +776,9 @@ func (s *Server) insertRouterLevelAIGatewayExtProc(listener *listenerv3.Listener
 	for _, currChain := range filterChains {
 		httpConManager, hcmIndex, err := findHCM(currChain)
 		if err != nil {
-			return fmt.Errorf("failed to find HCM in filter chain: %w", err)
+			// Chains without an HCM (e.g. TCP/UDP routes) cannot host the ext_proc filter.
+			s.log.Error(err, "skipping filter chain without an HTTP connection manager", "listener", listener.Name)
+			continue
 		}
 		// Check if the extproc filter is already present.
 		if !shouldAIGatewayExtProcBeInserted(httpConManager.HttpFilters) {


### PR DESCRIPTION
**Description**

This commit skips filter chains without an HTTP connection manager in `insertRequestHeaderToMetadataFilter` and `insertRouterLevelAIGatewayExtProc` instead of returning an error that aborts the whole `PostTranslateModify` hook. Like the existing skip paths (`patchListenerWithInferencePoolFilters`, `findListenerRouteConfigs`, `insertMCPBackendFilters`, `insertQuotaRateLimitFilter`), chains without an HCM are skipped rather than failing the hook. Per review feedback, the skip keys on the `findHCM` sentinel (`hcmIndex == -1`) instead of the returned error, so a future genuine error is not silenced; the error is still logged.

Chains without an HCM (TCPRoute/UDPRoute listeners) cannot host HTTP filters, so finding no HCM in them is normal, not an error. A regression test is added: a listener mixing a TCP-proxy chain with an HCM chain must translate, with the filter injected only into the HTTP chain.

This hits stock installs: `logRequestHeaderAttributes` defaults to `agent-session-id:session.id` when the flag is unset (`internal/requestheaderattrs/resolve.go`), and `insertRequestHeaderToMetadataFilters` walks every listener unconditionally — so any Gateway carrying TCP/UDP listeners makes xDS translation fail for the entire control plane (all Gateways `Programmed=False`, dataplane crash-looping on rejected config).

**Related Issues/PRs (if applicable)**

Fixes #2600

**Special notes for reviewers (if applicable)**

`go test ./internal/extensionserver/`, `go vet`, and `gofmt` pass locally. Tested against a live fleet where this exact topology (HTTP inference Gateway + Syncthing TCP/UDP Gateway on one control plane) reproduced the failure.

