### PR TITLE
fix: keep rotated credentials fresh in the filter config

### DIFF
--- a/internal/controller/backend_security_policy.go
+++ b/internal/controller/backend_security_policy.go
@@ -118,9 +118,17 @@ func (c *BackendSecurityPolicyController) reconcile(ctx context.Context, bsp *ai
 	}
 
 	if requiresRotation {
-		res, err = c.rotateCredential(ctx, bsp)
+		var rotated bool
+		res, rotated, err = c.rotateCredential(ctx, bsp)
 		if err != nil {
 			return res, err
+		}
+		if rotated {
+			// The rotator wrote a new credential. Its watch event drives the rebuild from
+			// secretController, where the informer has already observed the write. Fanning out here
+			// as well would rebuild once from a cache that has not, publishing the previous
+			// credential until the second rebuild replaced it.
+			return res, nil
 		}
 	}
 	err = c.syncBackendSecurityPolicy(ctx, bsp)
@@ -128,7 +136,7 @@ func (c *BackendSecurityPolicyController) reconcile(ctx context.Context, bsp *ai
 }
 
 // rotateCredential rotates the credentials using the access token from OIDC provider and return the requeue time for next rotation.
-func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, bsp *aigv1b1.BackendSecurityPolicy) (res ctrl.Result, err error) {
+func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, bsp *aigv1b1.BackendSecurityPolicy) (res ctrl.Result, rotated bool, err error) {
 	var rotator rotators.Rotator
 
 	switch bsp.Spec.Type {
@@ -139,10 +147,10 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 			roleArn := bsp.Spec.AWSCredentials.OIDCExchangeToken.AwsRoleArn
 			rotator, err = rotators.NewAWSOIDCRotator(ctx, c.client, nil, c.kube, c.logger, bsp.Namespace, bsp.Name, preRotationWindow, oidc, roleArn, region)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 		} else {
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, false, nil
 		}
 	case aigv1b1.BackendSecurityPolicyTypeAzureCredentials:
 		clientID := bsp.Spec.AzureCredentials.ClientID
@@ -155,11 +163,11 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 			var oidcProvider tokenprovider.TokenProvider
 			oidcProvider, err = tokenprovider.NewOidcTokenProvider(ctx, c.client, oidc)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 			provider, err = tokenprovider.NewAzureTokenProvider(ctx, tenantID, clientID, oidcProvider, options)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 		} else if secretRef := bsp.Spec.AzureCredentials.ClientSecretRef; secretRef != nil {
 			secretNamespace := bsp.Namespace
@@ -171,28 +179,28 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 			secret, err = rotators.LookupSecret(ctx, c.client, secretNamespace, secretName)
 			if err != nil {
 				c.logger.Error(err, "failed to lookup azure client secret", "namespace", secretNamespace, "name", secretName)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 			secretValue, exists := secret.Data[clientSecretKey]
 			if !exists {
-				return ctrl.Result{}, fmt.Errorf("missing azure client secret key %s", clientSecretKey)
+				return ctrl.Result{}, false, fmt.Errorf("missing azure client secret key %s", clientSecretKey)
 			}
 			clientSecret := string(secretValue)
 			provider, err = tokenprovider.NewAzureClientSecretTokenProvider(tenantID, clientID, clientSecret, options)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 		} else {
-			return ctrl.Result{}, fmt.Errorf("one of secret ref or oidc must be defined, namespace %s name %s", bsp.Namespace, bsp.Name)
+			return ctrl.Result{}, false, fmt.Errorf("one of secret ref or oidc must be defined, namespace %s name %s", bsp.Namespace, bsp.Name)
 		}
 
 		rotator, err = rotators.NewAzureTokenRotator(c.client, c.kube, c.logger, bsp.Namespace, bsp.Name, preRotationWindow, provider)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, false, err
 		}
 	case aigv1b1.BackendSecurityPolicyTypeGCPCredentials:
 		if err = validateGCPCredentialsParams(bsp.Spec.GCPCredentials); err != nil {
-			return ctrl.Result{}, fmt.Errorf("invalid GCP credentials configuration: %w", err)
+			return ctrl.Result{}, false, fmt.Errorf("invalid GCP credentials configuration: %w", err)
 		}
 		oidc := getBackendSecurityPolicyAuthOIDC(&bsp.Spec)
 		if oidc != nil {
@@ -200,11 +208,11 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 			var oidcProvider tokenprovider.TokenProvider
 			oidcProvider, err = tokenprovider.NewOidcTokenProvider(ctx, c.client, oidc)
 			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to initialize OIDC provider: %w", err)
+				return ctrl.Result{}, false, fmt.Errorf("failed to initialize OIDC provider: %w", err)
 			}
 			rotator, err = rotators.NewGCPOIDCTokenRotator(c.client, c.logger, bsp, preRotationWindow, oidcProvider)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 		} else if credentialFile := bsp.Spec.GCPCredentials.CredentialsFile; credentialFile != nil {
 			secretNamespace := bsp.Namespace
@@ -216,63 +224,72 @@ func (c *BackendSecurityPolicyController) rotateCredential(ctx context.Context, 
 			secret, err = rotators.LookupSecret(ctx, c.client, secretNamespace, secretName)
 			if err != nil {
 				c.logger.Error(err, "failed to lookup gcp service account key secret", "namespace", secretNamespace, "name", secretName)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 			serviceAccountKeyJSON, exists := secret.Data[rotators.GCPServiceAccountJSON]
 			if !exists {
-				return ctrl.Result{}, fmt.Errorf("missing gcp service account key %s", rotators.GCPServiceAccountJSON)
+				return ctrl.Result{}, false, fmt.Errorf("missing gcp service account key %s", rotators.GCPServiceAccountJSON)
 			}
 			var tokenProvider tokenprovider.TokenProvider
 			tokenProvider, err = tokenprovider.NewGCPTokenProvider(ctx, serviceAccountKeyJSON)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 
 			rotator, err = rotators.NewGCPTokenRotator(c.client, c.kube, c.logger, bsp.Namespace, bsp.Name, preRotationWindow, tokenProvider)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
 		} else {
 			// Use Application Default Credentials (ADC) - handled by extproc, skip rotation
 			c.logger.Info("Using GCP Application Default Credentials (ADC), skipping rotation",
 				"namespace", bsp.Namespace, "name", bsp.Name)
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, false, nil
 		}
 
 	default:
 		err = fmt.Errorf("backend security type %s does not support OIDC token exchange", bsp.Spec.Type)
 		c.logger.Error(err, "unsupported backend security type", "namespace", bsp.Namespace, "name", bsp.Name)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, false, err
 	}
-	res, err = c.executeRotation(ctx, rotator, bsp)
+	res, rotated, err = c.executeRotation(ctx, rotator, bsp)
 	if err != nil {
 		c.logger.Error(err, "failed to execute rotation", "namespace", bsp.Namespace, "name", bsp.Name)
-		return res, fmt.Errorf("failed to execute rotation for backend security policy %s/%s: %w", bsp.Namespace, bsp.Name, err)
+		return res, rotated, fmt.Errorf("failed to execute rotation for backend security policy %s/%s: %w", bsp.Namespace, bsp.Name, err)
 	}
 
-	if secretName := getBSPGeneratedSecretName(bsp); secretName != "" {
-		var secret *corev1.Secret
-		secret, err = rotators.LookupSecret(ctx, c.client, bsp.Namespace, secretName)
-		if err != nil {
-			return res, fmt.Errorf("failed to lookup backend security policy secret %s/%s: %w",
-				bsp.Namespace, secretName, err)
+	// A rotator ran, so the secret exists. If the name helper disagrees, it ends up unindexed and
+	// unowned.
+	secretName := getBSPGeneratedSecretName(bsp)
+	if secretName == "" {
+		return res, rotated, fmt.Errorf("BUG: no generated secret name defined for rotating type %s", bsp.Spec.Type)
+	}
+	secret, err := rotators.LookupSecret(ctx, c.client, bsp.Namespace, secretName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// The rotator created the secret moments ago and the cache has not caught up. That
+			// write is indexed to this policy, so its watch event brings the reconcile back.
+			return res, rotated, nil
 		}
-		ok, _ := ctrlutil.HasOwnerReference(secret.OwnerReferences, bsp, c.client.Scheme())
-		if !ok {
-			updated := secret.DeepCopy()
-			if err = ctrlutil.SetControllerReference(bsp, updated, c.client.Scheme()); err != nil {
-				panic(fmt.Errorf("BUG: failed to set controller reference for secret %s/%s: %w", bsp.Namespace, bsp.Name, err))
-			}
-			if err = c.client.Update(ctx, updated); err != nil {
-				return res, fmt.Errorf("failed to update secret %s/%s with owner reference: %w",
-					updated.Namespace, updated.Name, err)
-			}
+		return res, rotated, fmt.Errorf("failed to lookup backend security policy secret %s/%s: %w",
+			bsp.Namespace, secretName, err)
+	}
+	if ok, _ := ctrlutil.HasOwnerReference(secret.OwnerReferences, bsp, c.client.Scheme()); !ok {
+		updated := secret.DeepCopy()
+		if err = ctrlutil.SetControllerReference(bsp, updated, c.client.Scheme()); err != nil {
+			panic(fmt.Errorf("BUG: failed to set controller reference for secret %s/%s: %w", bsp.Namespace, bsp.Name, err))
+		}
+		// Patch rather than Update: the cached read carries the resourceVersion from before the
+		// rotator's write, and Update would reject that as a conflict.
+		if err = c.client.Patch(ctx, updated, client.MergeFrom(secret)); err != nil {
+			return res, rotated, fmt.Errorf("failed to set owner reference on secret %s/%s: %w",
+				updated.Namespace, updated.Name, err)
 		}
 	}
-	return res, nil
+	return res, rotated, nil
 }
 
-func (c *BackendSecurityPolicyController) executeRotation(ctx context.Context, rotator rotators.Rotator, bsp *aigv1b1.BackendSecurityPolicy) (res ctrl.Result, err error) {
+func (c *BackendSecurityPolicyController) executeRotation(ctx context.Context, rotator rotators.Rotator, bsp *aigv1b1.BackendSecurityPolicy) (res ctrl.Result, rotated bool, err error) {
 	requeue := time.Minute
 	var rotationTime time.Time
 	rotationTime, err = rotator.GetPreRotationTime(ctx)
@@ -285,6 +302,7 @@ func (c *BackendSecurityPolicyController) executeRotation(ctx context.Context, r
 			if err != nil {
 				c.logger.Error(err, "failed to rotate token, retry in one minute")
 			} else {
+				rotated = true
 				rotationTime = expirationTime.Add(-preRotationWindow)
 				if r := time.Until(rotationTime); r > 0 {
 					requeue = r
@@ -302,7 +320,7 @@ func (c *BackendSecurityPolicyController) executeRotation(ctx context.Context, r
 				bsp.Name, bsp.Namespace, bsp.Spec.Type, requeue.Minutes()))
 		}
 	}
-	return ctrl.Result{RequeueAfter: requeue}, err
+	return ctrl.Result{RequeueAfter: requeue}, rotated, err
 }
 
 // getBackendSecurityPolicyAuthOIDC returns the backendSecurityPolicy's OIDC pointer or nil.
@@ -331,11 +349,23 @@ func backendSecurityPolicyKey(namespace, name string) string {
 }
 
 func (c *BackendSecurityPolicyController) syncBackendSecurityPolicy(ctx context.Context, bsp *aigv1b1.BackendSecurityPolicy) error {
+	return syncBackendSecurityPolicyTargets(ctx, c.client, c.logger, bsp, c.aiServiceBackendEventChan, c.inferencePoolEventChan)
+}
+
+// syncBackendSecurityPolicyTargets rebuilds the filter config of everything bsp targets, by sending
+// each target to its own controller.
+func syncBackendSecurityPolicyTargets(
+	ctx context.Context,
+	cl client.Client,
+	logger logr.Logger,
+	bsp *aigv1b1.BackendSecurityPolicy,
+	aiServiceBackendEventChan, inferencePoolEventChan chan event.GenericEvent,
+) error {
 	for _, targetRef := range bsp.Spec.TargetRefs {
 		switch {
 		case targetRef.Group == aiServiceBackendGroup && targetRef.Kind == aiServiceBackendKind:
 			var aiBackend aigv1b1.AIServiceBackend
-			err := c.client.Get(ctx, client.ObjectKey{
+			err := cl.Get(ctx, client.ObjectKey{
 				Name:      string(targetRef.Name),
 				Namespace: bsp.Namespace, // targetRefs are local to the policy's namespace.
 			}, &aiBackend)
@@ -343,14 +373,14 @@ func (c *BackendSecurityPolicyController) syncBackendSecurityPolicy(ctx context.
 				if client.IgnoreNotFound(err) != nil {
 					return fmt.Errorf("failed to get targeted AIServiceBackend %s: %w", targetRef.Name, err)
 				}
-				c.logger.Info("Targeted AIServiceBackend not found", "name", string(targetRef.Name), "namespace", bsp.Namespace)
+				logger.Info("Targeted AIServiceBackend not found", "name", string(targetRef.Name), "namespace", bsp.Namespace)
 				continue
 			}
-			c.logger.Info("Syncing AIServiceBackend", "namespace", aiBackend.Namespace, "name", aiBackend.Name)
-			c.aiServiceBackendEventChan <- event.GenericEvent{Object: &aiBackend}
+			logger.Info("Syncing AIServiceBackend", "namespace", aiBackend.Namespace, "name", aiBackend.Name)
+			aiServiceBackendEventChan <- event.GenericEvent{Object: &aiBackend}
 		case targetRef.Group == inferencePoolGroup && targetRef.Kind == inferencePoolKind:
 			var inferencePool gwaiev1.InferencePool
-			err := c.client.Get(ctx, client.ObjectKey{
+			err := cl.Get(ctx, client.ObjectKey{
 				Name:      string(targetRef.Name),
 				Namespace: bsp.Namespace, // targetRefs are local to the policy's namespace.
 			}, &inferencePool)
@@ -358,11 +388,11 @@ func (c *BackendSecurityPolicyController) syncBackendSecurityPolicy(ctx context.
 				if client.IgnoreNotFound(err) != nil {
 					return fmt.Errorf("failed to get targeted InferencePool %s: %w", targetRef.Name, err)
 				}
-				c.logger.Info("Targeted InferencePool not found", "name", string(targetRef.Name), "namespace", bsp.Namespace)
+				logger.Info("Targeted InferencePool not found", "name", string(targetRef.Name), "namespace", bsp.Namespace)
 				continue
 			}
-			c.logger.Info("Syncing InferencePool", "namespace", inferencePool.Namespace, "name", inferencePool.Name)
-			c.inferencePoolEventChan <- event.GenericEvent{Object: &inferencePool}
+			logger.Info("Syncing InferencePool", "namespace", inferencePool.Namespace, "name", inferencePool.Name)
+			inferencePoolEventChan <- event.GenericEvent{Object: &inferencePool}
 		}
 	}
 
@@ -414,28 +444,33 @@ func validateGCPCredentialsParams(gcpCreds *aigv1b1.BackendSecurityPolicyGCPCred
 	return nil
 }
 
-// getBSPGeneratedSecretName returns a secret's name generated by the input bsp
-// if there's any. This returns an empty string if there's no generated secret.
+// getBSPGeneratedSecretName returns the secret a rotator writes for bsp, or "" if nothing rotates.
+// The filter config and backendSecurityPolicyIndexFunc must derive the same name. Unknown types
+// return "" instead of panicking: indexers run outside panic recovery.
 func getBSPGeneratedSecretName(bsp *aigv1b1.BackendSecurityPolicy) string {
 	switch bsp.Spec.Type {
 	case aigv1b1.BackendSecurityPolicyTypeAWSCredentials:
-		if bsp.Spec.AWSCredentials.OIDCExchangeToken == nil {
+		if bsp.Spec.AWSCredentials == nil || bsp.Spec.AWSCredentials.OIDCExchangeToken == nil {
 			return ""
 		}
 	case aigv1b1.BackendSecurityPolicyTypeAzureCredentials:
-		if bsp.Spec.AzureCredentials.OIDCExchangeToken == nil {
+		// A client secret and an OIDC exchange are both traded for an access token.
+		azure := bsp.Spec.AzureCredentials
+		if azure == nil || (azure.ClientSecretRef == nil && azure.OIDCExchangeToken == nil) {
 			return ""
 		}
 	case aigv1b1.BackendSecurityPolicyTypeGCPCredentials:
-		if bsp.Spec.GCPCredentials.WorkloadIdentityFederationConfig == nil {
+		// A service account key and WIF are both traded for an access token; ADC resolves in extproc.
+		gcp := bsp.Spec.GCPCredentials
+		if gcp == nil || (gcp.CredentialsFile == nil && gcp.WorkloadIdentityFederationConfig == nil) {
 			return ""
 		}
 	case aigv1b1.BackendSecurityPolicyTypeAPIKey,
 		aigv1b1.BackendSecurityPolicyTypeAzureAPIKey,
 		aigv1b1.BackendSecurityPolicyTypeAnthropicAPIKey:
-		return "" // APIKey does not require rotation.
+		return "" // The credential is read straight from the referenced secret.
 	default:
-		panic("BUG: unsupported backend security policy type: " + string(bsp.Spec.Type))
+		return "" // Unrecognized type.
 	}
 	return rotators.GetBSPSecretName(bsp.Name)
 }

--- a/internal/controller/backend_security_policy_test.go
+++ b/internal/controller/backend_security_policy_test.go
@@ -7,6 +7,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -299,7 +300,7 @@ func TestBackendSecurityPolicyController_RotateCredential(t *testing.T) {
 	}
 	err = cl.Create(ctx, secret)
 	require.NoError(t, err)
-	_, err = c.rotateCredential(ctx, bsp)
+	_, _, err = c.rotateCredential(ctx, bsp)
 	require.NoError(t, err)
 
 	// Check the generated secret contains the owner reference to the BackendSecurityPolicy.
@@ -308,6 +309,169 @@ func TestBackendSecurityPolicyController_RotateCredential(t *testing.T) {
 	require.NoError(t, err)
 	ok, _ := ctrlutil.HasOwnerReference(awsSecret.OwnerReferences, bsp, c.client.Scheme())
 	require.True(t, ok, "expected secret to have owner reference to BackendSecurityPolicy")
+}
+
+// TestBackendSecurityPolicyController_RotateCredential_OwnsGeneratedSecret checks that a policy
+// rotating without an OIDC exchange owns its generated secret, so GC removes it with the policy.
+func TestBackendSecurityPolicyController_RotateCredential_OwnsGeneratedSecret(t *testing.T) {
+	const bspNamespace, clientSecretName = "default", "azure-client-secret"
+
+	eventCh := internaltesting.NewControllerEventChan[*aigv1b1.AIServiceBackend]()
+	cl := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	c := NewBackendSecurityPolicyController(cl, fake2.NewClientset(), ctrl.Log, eventCh.Ch, nil)
+
+	require.NoError(t, cl.Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: clientSecretName, Namespace: bspNamespace},
+		Data:       map[string][]byte{clientSecretKey: []byte("client-secret")},
+	}))
+
+	bsp := &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "azure-client-secret-bsp", Namespace: bspNamespace},
+		Spec: aigv1b1.BackendSecurityPolicySpec{
+			Type: aigv1b1.BackendSecurityPolicyTypeAzureCredentials,
+			AzureCredentials: &aigv1b1.BackendSecurityPolicyAzureCredentials{
+				ClientID: "some-client-id",
+				TenantID: "some-tenant-id",
+				ClientSecretRef: &gwapiv1.SecretObjectReference{
+					Name: gwapiv1.ObjectName(clientSecretName),
+				},
+			},
+		},
+	}
+	require.NoError(t, cl.Create(t.Context(), bsp))
+
+	// A future expiry makes executeRotation skip Rotate, so no token endpoint is contacted.
+	generatedName := rotators.GetBSPSecretName(bsp.Name)
+	require.NoError(t, cl.Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generatedName,
+			Namespace: bspNamespace,
+			Annotations: map[string]string{
+				rotators.ExpirationTimeAnnotationKey: time.Now().Add(60 * time.Minute).Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{rotators.AzureAccessTokenKey: []byte("some-access-token")},
+	}))
+
+	_, _, err := c.rotateCredential(t.Context(), bsp)
+	require.NoError(t, err)
+
+	generated, err := rotators.LookupSecret(t.Context(), cl, bspNamespace, generatedName)
+	require.NoError(t, err)
+	ok, _ := ctrlutil.HasOwnerReference(generated.OwnerReferences, bsp, c.client.Scheme())
+	require.True(t, ok, "expected the generated secret to be owned by the BackendSecurityPolicy")
+}
+
+type stubRotator struct {
+	expired    bool
+	expiration time.Time
+	rotateErr  error
+	rotated    bool
+}
+
+func (s *stubRotator) IsExpired(time.Time) bool                              { return s.expired }
+func (s *stubRotator) GetPreRotationTime(context.Context) (time.Time, error) { return time.Time{}, nil }
+func (s *stubRotator) Rotate(context.Context) (time.Time, error) {
+	s.rotated = true
+	return s.expiration, s.rotateErr
+}
+
+// TestBackendSecurityPolicyController_ExecuteRotationReportsWrites covers the signal reconcile uses
+// to decide whether to fan out. Only a pass that wrote a credential has a watch event coming that
+// will rebuild the filter config.
+func TestBackendSecurityPolicyController_ExecuteRotationReportsWrites(t *testing.T) {
+	c := NewBackendSecurityPolicyController(fake.NewClientBuilder().WithScheme(Scheme).Build(),
+		fake2.NewClientset(), ctrl.Log, nil, nil)
+	bsp := &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "bsp", Namespace: "default"},
+		Spec:       aigv1b1.BackendSecurityPolicySpec{Type: aigv1b1.BackendSecurityPolicyTypeAWSCredentials},
+	}
+
+	t.Run("wrote a credential", func(t *testing.T) {
+		r := &stubRotator{expired: true, expiration: time.Now().Add(time.Hour)}
+		_, rotated, err := c.executeRotation(t.Context(), r, bsp)
+		require.NoError(t, err)
+		require.True(t, r.rotated)
+		require.True(t, rotated)
+	})
+
+	t.Run("credential still valid", func(t *testing.T) {
+		r := &stubRotator{expired: false}
+		_, rotated, err := c.executeRotation(t.Context(), r, bsp)
+		require.NoError(t, err)
+		require.False(t, r.rotated)
+		require.False(t, rotated)
+	})
+
+	t.Run("rotation failed", func(t *testing.T) {
+		r := &stubRotator{expired: true, rotateErr: errors.New("sts unreachable")}
+		_, rotated, err := c.executeRotation(t.Context(), r, bsp)
+		require.Error(t, err)
+		require.False(t, rotated, "a failed write leaves nothing for a watch event to rebuild from")
+	})
+}
+
+// TestBackendSecurityPolicyController_ReconcileFansOutWithoutRotation covers a reconcile that did
+// not rotate. There is no watch event coming, so this pass has to rebuild the targets itself.
+func TestBackendSecurityPolicyController_ReconcileFansOutWithoutRotation(t *testing.T) {
+	const bspNamespace, backendName, bspName = "default", "backend", "still-valid"
+
+	discoveryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"issuer": "issuer", "token_endpoint": "token_endpoint", "authorization_endpoint": "authorization_endpoint", "jwks_uri": "jwks_uri", "scopes_supported": []}`))
+		require.NoError(t, err)
+	}))
+	defer discoveryServer.Close()
+	tokenURL := discoveryServer.URL
+
+	cl := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	eventCh := internaltesting.NewControllerEventChan[*aigv1b1.AIServiceBackend]()
+	c := NewBackendSecurityPolicyController(cl, fake2.NewClientset(), ctrl.Log, eventCh.Ch, nil)
+
+	require.NoError(t, cl.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: bspNamespace},
+	}))
+	require.NoError(t, cl.Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "oidc-client-secret", Namespace: bspNamespace},
+		Data:       map[string][]byte{"client-secret": []byte("client-secret")},
+	}))
+	// A future expiry keeps executeRotation from calling Rotate.
+	require.NoError(t, cl.Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rotators.GetBSPSecretName(bspName), Namespace: bspNamespace,
+			Annotations: map[string]string{
+				rotators.ExpirationTimeAnnotationKey: time.Now().Add(time.Hour).Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{rotators.AwsCredentialsKey: []byte("creds")},
+	}))
+
+	bsp := &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: bspName, Namespace: bspNamespace},
+		Spec: aigv1b1.BackendSecurityPolicySpec{
+			Type: aigv1b1.BackendSecurityPolicyTypeAWSCredentials,
+			AWSCredentials: &aigv1b1.BackendSecurityPolicyAWSCredentials{
+				Region: "us-east-1",
+				OIDCExchangeToken: &aigv1b1.AWSOIDCExchangeToken{
+					BackendSecurityPolicyOIDC: aigv1b1.BackendSecurityPolicyOIDC{OIDC: egv1a1.OIDC{
+						Provider: egv1a1.OIDCProvider{Issuer: discoveryServer.URL, TokenEndpoint: &tokenURL},
+						ClientID: ptr.To("some-client-id"),
+						ClientSecret: gwapiv1.SecretObjectReference{
+							Name: "oidc-client-secret", Namespace: ptr.To[gwapiv1.Namespace](bspNamespace),
+						},
+					}},
+				},
+			},
+			TargetRefs: []gwapiv1a2.LocalPolicyTargetReference{{
+				Group: aiServiceBackendGroup, Kind: aiServiceBackendKind, Name: backendName,
+			}},
+		},
+	}
+	require.NoError(t, cl.Create(t.Context(), bsp))
+
+	_, err := c.reconcile(oidcv3.InsecureIssuerURLContext(t.Context(), discoveryServer.URL), bsp)
+	require.NoError(t, err)
+	backends := eventCh.RequireItemsEventually(t, 1)
+	require.Equal(t, backendName, backends[0].Name)
 }
 
 func TestBackendSecurityPolicyController_RotateExpiredCredential(t *testing.T) {
@@ -671,7 +835,7 @@ func TestNewBackendSecurityPolicyController_RotateCredentialAzureIncorrectSecret
 	err = cl.Create(t.Context(), bsp)
 	require.NoError(t, err)
 
-	res, err := c.rotateCredential(t.Context(), bsp)
+	res, _, err := c.rotateCredential(t.Context(), bsp)
 	require.Error(t, err)
 	require.Equal(t, time.Duration(0), res.RequeueAfter)
 }
@@ -766,7 +930,7 @@ func TestBackendSecurityPolicyController_ExecutionRotation(t *testing.T) {
 		"us-east-1",
 	)
 	require.NoError(t, err)
-	res, err := c.executeRotation(ctx, rotator, bsp)
+	res, _, err := c.executeRotation(ctx, rotator, bsp)
 	require.NoError(t, err)
 	require.Less(t, res.RequeueAfter, time.Hour)
 }
@@ -927,7 +1091,7 @@ func TestBackendSecurityPolicyController_RotateCredential_GCPCredentials(t *test
 			Spec: *tt.bsp,
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := c.rotateCredential(context.Background(), bsp)
+			res, _, err := c.rotateCredential(context.Background(), bsp)
 
 			switch {
 			case tt.expectedErrMsg != "" && err == nil:
@@ -960,7 +1124,7 @@ func TestBackendSecurityPolicyController_RotateCredential_GCPCredentials_ADC(t *
 		},
 	}
 
-	res, err := c.rotateCredential(context.Background(), bsp)
+	res, _, err := c.rotateCredential(context.Background(), bsp)
 	require.NoError(t, err)
 	require.Zero(t, res.RequeueAfter)
 }
@@ -1020,7 +1184,7 @@ func TestBackendSecurityPolicyController_RotateCredential_GCPCredentials_OIDC(t 
 
 	// Test that the OIDC path validation passes and the method attempts to create OIDC provider
 	// (which will fail due to network issues, but that confirms the OIDC path logic is working).
-	res, err := c.rotateCredential(t.Context(), bsp)
+	res, _, err := c.rotateCredential(t.Context(), bsp)
 
 	// We expect an error due to network calls in the OIDC provider initialization.
 	require.Error(t, err)
@@ -1079,7 +1243,7 @@ func TestBackendSecurityPolicyController_RotateCredential_GCPCredentials_Credent
 	require.NoError(t, err)
 
 	// Test that credentials file path is correctly selected and reaches token provider creation.
-	res, err := c.rotateCredential(t.Context(), bsp)
+	res, _, err := c.rotateCredential(t.Context(), bsp)
 
 	// The test behavior varies depending on environment mocking, but both outcomes are valid:
 	// 1. Error at token provider creation confirms the credentials file path worked
@@ -1118,7 +1282,7 @@ func TestBackendSecurityPolicyController_RotateCredential_GCPCredentials_Missing
 	require.NoError(t, err)
 
 	// Test that rotation fails when the referenced secret doesn't exist.
-	res, err := c.rotateCredential(t.Context(), bsp)
+	res, _, err := c.rotateCredential(t.Context(), bsp)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "secrets \"non-existent-secret\" not found")
 	require.Equal(t, ctrl.Result{}, res)
@@ -1164,7 +1328,7 @@ func TestBackendSecurityPolicyController_RotateCredential_GCPCredentials_Missing
 	require.NoError(t, err)
 
 	// Test that rotation fails when the secret doesn't contain the required key.
-	res, err := c.rotateCredential(t.Context(), bsp)
+	res, _, err := c.rotateCredential(t.Context(), bsp)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing gcp service account key service_account.json")
 	require.Equal(t, ctrl.Result{}, res)
@@ -1253,7 +1417,8 @@ func TestGetBSPGeneratedSecretName(t *testing.T) {
 			expectedName: "ai-eg-bsp-azure-oidc-bsp",
 		},
 		{
-			name: "GCP type",
+			// Invalid per the CRD, but the generated name derives from the policy name regardless.
+			name: "GCP with credentials file missing its secret ref",
 			bsp: &aigv1b1.BackendSecurityPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "gcp-bsp",
@@ -1267,7 +1432,7 @@ func TestGetBSPGeneratedSecretName(t *testing.T) {
 					},
 				},
 			},
-			expectedName: "",
+			expectedName: "ai-eg-bsp-gcp-bsp",
 		},
 		{
 			name: "GCP with service account credential file",
@@ -1285,6 +1450,58 @@ func TestGetBSPGeneratedSecretName(t *testing.T) {
 						},
 					},
 				},
+			},
+			expectedName: "ai-eg-bsp-gcp-bsp-sa",
+		},
+		{
+			name: "Azure with ClientSecretRef",
+			bsp: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "azure-secret-bsp",
+				},
+				Spec: aigv1b1.BackendSecurityPolicySpec{
+					Type: aigv1b1.BackendSecurityPolicyTypeAzureCredentials,
+					AzureCredentials: &aigv1b1.BackendSecurityPolicyAzureCredentials{
+						ClientSecretRef: &gwapiv1.SecretObjectReference{Name: "azure-client-secret"},
+					},
+				},
+			},
+			expectedName: "ai-eg-bsp-azure-secret-bsp",
+		},
+		{
+			name: "GCP with workload identity federation",
+			bsp: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcp-wif-bsp",
+				},
+				Spec: aigv1b1.BackendSecurityPolicySpec{
+					Type: aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+					GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{
+						WorkloadIdentityFederationConfig: &aigv1b1.GCPWorkloadIdentityFederationConfig{},
+					},
+				},
+			},
+			expectedName: "ai-eg-bsp-gcp-wif-bsp",
+		},
+		{
+			name: "GCP with application default credentials",
+			bsp: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcp-adc-bsp",
+				},
+				Spec: aigv1b1.BackendSecurityPolicySpec{
+					Type:           aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+					GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{},
+				},
+			},
+			expectedName: "",
+		},
+		{
+			// This runs inside a field indexer, where a panic takes down the controller.
+			name: "unrecognized type",
+			bsp: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "mystery-bsp"},
+				Spec:       aigv1b1.BackendSecurityPolicySpec{Type: "SomethingNewAndUnhandled"},
 			},
 			expectedName: "",
 		},
@@ -1304,10 +1521,7 @@ func TestGetBSPGeneratedSecretName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resultName := getBSPGeneratedSecretName(tt.bsp)
-			if resultName != "" {
-				require.Equal(t, tt.expectedName, resultName)
-			}
+			require.Equal(t, tt.expectedName, getBSPGeneratedSecretName(tt.bsp))
 		})
 	}
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -220,7 +220,8 @@ func StartControllers(ctx context.Context, mgr manager.Manager, config *rest.Con
 	}
 	mcpRouteEventChan := make(chan event.GenericEvent, 100)
 	secretC := NewSecretController(c, kubernetes.NewForConfigOrDie(config), logger.
-		WithName("secret"), backendSecurityPolicyEventChan, mcpRouteEventChan)
+		WithName("secret"), backendSecurityPolicyEventChan, mcpRouteEventChan,
+		aiServiceBackendEventChan, inferencePoolEventChan)
 	// Do not use TypedControllerBuilderForCRD for secret, as changing a secret content doesn't change the generation.
 	if err = ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
@@ -469,40 +470,59 @@ func aiGatewayRouteIndexFunc(o client.Object) []string {
 	return ret
 }
 
+// backendSecurityPolicyIndexFunc indexes a policy under both secrets it consumes, so a write to
+// either reconciles it: the referenced one feeds rotation, the generated one feeds the config.
 func backendSecurityPolicyIndexFunc(o client.Object) []string {
 	backendSecurityPolicy := o.(*aigv1b1.BackendSecurityPolicy)
-	var key string
-	switch backendSecurityPolicy.Spec.Type {
+	var keys []string
+	if referenced := backendSecurityPolicyReferencedSecret(backendSecurityPolicy); referenced != "" {
+		keys = append(keys, referenced)
+	}
+	if generated := getBSPGeneratedSecretName(backendSecurityPolicy); generated != "" {
+		keys = append(keys, backendSecurityPolicyKey(backendSecurityPolicy.Namespace, generated))
+	}
+	return keys
+}
+
+// backendSecurityPolicyReferencedSecret returns the index key for the secret the policy references.
+func backendSecurityPolicyReferencedSecret(bsp *aigv1b1.BackendSecurityPolicy) string {
+	ns := bsp.Namespace
+	switch bsp.Spec.Type {
 	case aigv1b1.BackendSecurityPolicyTypeAPIKey:
-		apiKey := backendSecurityPolicy.Spec.APIKey
-		key = getSecretNameAndNamespace(apiKey.SecretRef, backendSecurityPolicy.Namespace)
-	case aigv1b1.BackendSecurityPolicyTypeAWSCredentials:
-		awsCreds := backendSecurityPolicy.Spec.AWSCredentials
-		if awsCreds.CredentialsFile != nil {
-			key = getSecretNameAndNamespace(awsCreds.CredentialsFile.SecretRef, backendSecurityPolicy.Namespace)
-		} else if awsCreds.OIDCExchangeToken != nil {
-			key = backendSecurityPolicyKey(backendSecurityPolicy.Namespace, backendSecurityPolicy.Name)
-		}
-	case aigv1b1.BackendSecurityPolicyTypeGCPCredentials:
-		gcpCreds := backendSecurityPolicy.Spec.GCPCredentials
-		if gcpCreds.CredentialsFile != nil {
-			key = getSecretNameAndNamespace(gcpCreds.CredentialsFile.SecretRef, backendSecurityPolicy.Namespace)
+		if k := bsp.Spec.APIKey; k != nil {
+			return secretRefKey(k.SecretRef, ns)
 		}
 	case aigv1b1.BackendSecurityPolicyTypeAzureAPIKey:
-		apiKey := backendSecurityPolicy.Spec.AzureAPIKey
-		key = getSecretNameAndNamespace(apiKey.SecretRef, backendSecurityPolicy.Namespace)
+		if k := bsp.Spec.AzureAPIKey; k != nil {
+			return secretRefKey(k.SecretRef, ns)
+		}
 	case aigv1b1.BackendSecurityPolicyTypeAnthropicAPIKey:
-		apiKey := backendSecurityPolicy.Spec.AnthropicAPIKey
-		key = getSecretNameAndNamespace(apiKey.SecretRef, backendSecurityPolicy.Namespace)
+		if k := bsp.Spec.AnthropicAPIKey; k != nil {
+			return secretRefKey(k.SecretRef, ns)
+		}
+	case aigv1b1.BackendSecurityPolicyTypeAWSCredentials:
+		if aws := bsp.Spec.AWSCredentials; aws != nil && aws.CredentialsFile != nil {
+			return secretRefKey(aws.CredentialsFile.SecretRef, ns)
+		}
 	case aigv1b1.BackendSecurityPolicyTypeAzureCredentials:
-		azureCreds := backendSecurityPolicy.Spec.AzureCredentials
-		if azureCreds.ClientSecretRef != nil {
-			key = getSecretNameAndNamespace(azureCreds.ClientSecretRef, backendSecurityPolicy.Namespace)
-		} else if azureCreds.OIDCExchangeToken != nil {
-			key = backendSecurityPolicyKey(backendSecurityPolicy.Namespace, backendSecurityPolicy.Name)
+		if azure := bsp.Spec.AzureCredentials; azure != nil {
+			return secretRefKey(azure.ClientSecretRef, ns)
+		}
+	case aigv1b1.BackendSecurityPolicyTypeGCPCredentials:
+		if gcp := bsp.Spec.GCPCredentials; gcp != nil && gcp.CredentialsFile != nil {
+			return secretRefKey(gcp.CredentialsFile.SecretRef, ns)
 		}
 	}
-	return []string{key}
+	return ""
+}
+
+// secretRefKey returns "" for a nil ref. Indexers run outside panic recovery, so a nil dereference
+// kills the process.
+func secretRefKey(secretRef *gwapiv1.SecretObjectReference, namespace string) string {
+	if secretRef == nil {
+		return ""
+	}
+	return getSecretNameAndNamespace(secretRef, namespace)
 }
 
 func backendSecurityPolicyTargetRefsIndexFunc(o client.Object) []string {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -74,7 +74,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 	for _, bsp := range []struct {
 		name                  string
 		backendSecurityPolicy *aigv1b1.BackendSecurityPolicy
-		expKey                string
+		expKeys               []string
 	}{
 		{
 			name: "api key with namespace",
@@ -90,7 +90,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret1.foo",
+			expKeys: []string{"some-secret1.foo"},
 		},
 		{
 			name: "api key without namespace",
@@ -103,7 +103,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret2.ns",
+			expKeys: []string{"some-secret2.ns"},
 		},
 		{
 			name: "aws credentials with namespace",
@@ -120,7 +120,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret3.foo",
+			expKeys: []string{"some-secret3.foo"},
 		},
 		{
 			name: "aws credentials without namespace",
@@ -135,7 +135,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret4.ns",
+			expKeys: []string{"some-secret4.ns"},
 		},
 		{
 			name: "Azure api key with namespace",
@@ -151,7 +151,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret5.foo",
+			expKeys: []string{"some-secret5.foo"},
 		},
 		{
 			name: "Azure api key without namespace",
@@ -164,7 +164,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret6.ns",
+			expKeys: []string{"some-secret6.ns"},
 		},
 		{
 			name: "Azure credentials with namespace",
@@ -180,7 +180,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret7.foo",
+			expKeys: []string{"some-secret7.foo", "ai-eg-bsp-some-backend-security-policy-7.ns"},
 		},
 		{
 			name: "Azure credentials without namespace",
@@ -195,7 +195,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-secret8.ns",
+			expKeys: []string{"some-secret8.ns", "ai-eg-bsp-some-backend-security-policy-8.ns"},
 		},
 		{
 			name: "AWS OIDC exchange token",
@@ -208,7 +208,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-backend-security-policy-9.foo",
+			expKeys: []string{"ai-eg-bsp-some-backend-security-policy-9.foo"},
 		},
 		{
 			name: "Azure OIDC exchange token",
@@ -221,7 +221,7 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-backend-security-policy-10.foo",
+			expKeys: []string{"ai-eg-bsp-some-backend-security-policy-10.foo"},
 		},
 		{
 			name: "anthropic api key",
@@ -234,7 +234,60 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 					},
 				},
 			},
-			expKey: "some-aaaa.ns",
+			expKeys: []string{"some-aaaa.ns"},
+		},
+		{
+			name: "GCP credentials file",
+			backendSecurityPolicy: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-backend-security-policy-11", Namespace: "ns"},
+				Spec: aigv1b1.BackendSecurityPolicySpec{
+					Type: aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+					GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{
+						CredentialsFile: &aigv1b1.GCPCredentialsFile{
+							SecretRef: &gwapiv1.SecretObjectReference{Name: "some-secret11"},
+						},
+					},
+				},
+			},
+			expKeys: []string{"some-secret11.ns", "ai-eg-bsp-some-backend-security-policy-11.ns"},
+		},
+		{
+			name: "GCP workload identity federation",
+			backendSecurityPolicy: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-backend-security-policy-12", Namespace: "ns"},
+				Spec: aigv1b1.BackendSecurityPolicySpec{
+					Type: aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+					GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{
+						WorkloadIdentityFederationConfig: &aigv1b1.GCPWorkloadIdentityFederationConfig{},
+					},
+				},
+			},
+			expKeys: []string{"ai-eg-bsp-some-backend-security-policy-12.ns"},
+		},
+		{
+			// A panic in the indexer crash-loops the controller for every policy, not just this one.
+			name: "malformed specs do not panic the indexer",
+			backendSecurityPolicy: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-backend-security-policy-14", Namespace: "ns"},
+				Spec: aigv1b1.BackendSecurityPolicySpec{
+					Type: aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+					GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{
+						CredentialsFile: &aigv1b1.GCPCredentialsFile{SecretRef: nil},
+					},
+				},
+			},
+			expKeys: []string{"ai-eg-bsp-some-backend-security-policy-14.ns"},
+		},
+		{
+			name: "GCP application default credentials",
+			backendSecurityPolicy: &aigv1b1.BackendSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-backend-security-policy-13", Namespace: "ns"},
+				Spec: aigv1b1.BackendSecurityPolicySpec{
+					Type:           aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+					GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{},
+				},
+			},
+			expKeys: nil, // ADC resolves in extproc, so no secret feeds this policy.
 		},
 	} {
 		t.Run(bsp.name, func(t *testing.T) {
@@ -245,14 +298,18 @@ func Test_backendSecurityPolicyIndexFunc(t *testing.T) {
 
 			require.NoError(t, c.Create(t.Context(), bsp.backendSecurityPolicy))
 
-			var backendSecurityPolicies aigv1b1.BackendSecurityPolicyList
-			err := c.List(t.Context(), &backendSecurityPolicies,
-				client.MatchingFields{k8sClientIndexSecretToReferencingBackendSecurityPolicy: bsp.expKey})
-			require.NoError(t, err)
+			// A stray key syncs unrelated policies; a missing one leaves a secret write unobserved.
+			require.ElementsMatch(t, bsp.expKeys, backendSecurityPolicyIndexFunc(bsp.backendSecurityPolicy))
 
-			require.Len(t, backendSecurityPolicies.Items, 1)
-			require.Equal(t, bsp.backendSecurityPolicy.Name, backendSecurityPolicies.Items[0].Name)
-			require.Equal(t, bsp.backendSecurityPolicy.Namespace, backendSecurityPolicies.Items[0].Namespace)
+			for _, key := range bsp.expKeys {
+				var backendSecurityPolicies aigv1b1.BackendSecurityPolicyList
+				err := c.List(t.Context(), &backendSecurityPolicies,
+					client.MatchingFields{k8sClientIndexSecretToReferencingBackendSecurityPolicy: key})
+				require.NoError(t, err)
+				require.Len(t, backendSecurityPolicies.Items, 1, key)
+				require.Equal(t, bsp.backendSecurityPolicy.Name, backendSecurityPolicies.Items[0].Name)
+				require.Equal(t, bsp.backendSecurityPolicy.Namespace, backendSecurityPolicies.Items[0].Namespace)
+			}
 		})
 	}
 }

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -937,6 +937,12 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 	return auth, nil
 }
 
+// getSecretData reads dataKey from the named secret, resolving it from the informer cache.
+//
+// A credential only changes by a write this controller observes as a watch event, and the informer
+// updates its store before dispatching handlers, so the rebuild that event triggers reads the new
+// value. That covers a rotated credential too: secretController fans out to the targets of the
+// policy owning the secret, so the rebuild is driven by the secret's own event.
 func (c *GatewayController) getSecretData(ctx context.Context, namespace, name, dataKey string) (string, error) {
 	secret := &corev1.Secret{}
 	if err := c.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -1564,7 +1564,8 @@ func TestGatewayController_reconcileFilterConfigSecret_BailsOnContextCanceled(t 
 	const gwNamespace, configNamespace = "ns", "some-namespace"
 	inner, ok := requireNewFakeClientWithIndexes(t).(client.WithWatch)
 	require.True(t, ok)
-	// Fail only the credential read; failing every read makes the test pass vacuously.
+	// Fail only the credential read. Failing every Secret Get would also break the config-bundle
+	// write and the reconcile would error regardless, which would make this test pass vacuously.
 	fakeClient := interceptor.NewClient(inner, interceptor.Funcs{
 		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, isSecret := obj.(*corev1.Secret); isSecret && key.Name == "api-key" {

--- a/internal/controller/secret.go
+++ b/internal/controller/secret.go
@@ -27,6 +27,7 @@ type secretController struct {
 	kubeClient                                        kubernetes.Interface
 	logger                                            logr.Logger
 	backendSecurityPolicyEventChan, mcpRouteEventChan chan event.GenericEvent
+	aiServiceBackendEventChan, inferencePoolEventChan chan event.GenericEvent
 }
 
 // NewSecretController creates a new reconcile.TypedReconciler[reconcile.Request] for corev1.Secret.
@@ -34,6 +35,8 @@ func NewSecretController(client client.Client, kubeClient kubernetes.Interface,
 	logger logr.Logger,
 	backendSecurityPolicyEventChan chan event.GenericEvent,
 	mcpRouteEventChan chan event.GenericEvent,
+	aiServiceBackendEventChan chan event.GenericEvent,
+	inferencePoolEventChan chan event.GenericEvent,
 ) reconcile.TypedReconciler[reconcile.Request] {
 	return &secretController{
 		client:                         client,
@@ -41,6 +44,8 @@ func NewSecretController(client client.Client, kubeClient kubernetes.Interface,
 		logger:                         logger,
 		backendSecurityPolicyEventChan: backendSecurityPolicyEventChan,
 		mcpRouteEventChan:              mcpRouteEventChan,
+		aiServiceBackendEventChan:      aiServiceBackendEventChan,
+		inferencePoolEventChan:         inferencePoolEventChan,
 	}
 }
 
@@ -76,6 +81,18 @@ func (c *secretController) syncSecret(ctx context.Context, namespace, name strin
 		c.logger.Info("Syncing BackendSecurityPolicy",
 			"namespace", backendSecurityPolicy.Namespace, "name", backendSecurityPolicy.Name)
 		c.backendSecurityPolicyEventChan <- event.GenericEvent{Object: backendSecurityPolicy}
+
+		// A rotator wrote this secret, so the credential in the filter config is now behind. Rebuild
+		// the targets from here: this reconcile was woken by the secret's own watch event, so the
+		// informer store already holds the new value. Routing it through the policy controller
+		// instead would make the rebuild depend on its OIDC discovery call succeeding.
+		if backendSecurityPolicy.Namespace == namespace && getBSPGeneratedSecretName(backendSecurityPolicy) == name {
+			if err = syncBackendSecurityPolicyTargets(ctx, c.client, c.logger, backendSecurityPolicy,
+				c.aiServiceBackendEventChan, c.inferencePoolEventChan); err != nil {
+				return fmt.Errorf("failed to sync targets of BackendSecurityPolicy %s: %w",
+					backendSecurityPolicy.Name, err)
+			}
+		}
 	}
 
 	var mcpRoutes aigv1b1.MCPRouteList

--- a/internal/controller/secret_test.go
+++ b/internal/controller/secret_test.go
@@ -20,15 +20,65 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	gwaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
 	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
+	"github.com/envoyproxy/ai-gateway/internal/controller/rotators"
 	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
 )
+
+// TestSecretController_RotatedSecretSyncsTargets covers a write to a rotator-generated secret. The
+// targets are synced from here rather than through the policy controller, so the rebuild runs off
+// this reconcile, whose informer store already holds the new value.
+func TestSecretController_RotatedSecretSyncsTargets(t *testing.T) {
+	const ns, bspName, backendName = "default", "rotating", "backend"
+
+	bspCh := internaltesting.NewControllerEventChan[*aigv1b1.BackendSecurityPolicy]()
+	mcpRouteCh := internaltesting.NewControllerEventChan[*aigv1b1.MCPRoute]()
+	backendCh := internaltesting.NewControllerEventChan[*aigv1b1.AIServiceBackend]()
+	poolCh := internaltesting.NewControllerEventChan[*gwaiev1.InferencePool]()
+	fakeClient := requireNewFakeClientWithIndexes(t)
+	c := NewSecretController(fakeClient, fake2.NewClientset(), ctrl.Log, bspCh.Ch, mcpRouteCh.Ch, backendCh.Ch, poolCh.Ch)
+
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: ns},
+	}))
+	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: bspName, Namespace: ns},
+		Spec: aigv1b1.BackendSecurityPolicySpec{
+			Type: aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+			GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{
+				ProjectName:                      "p",
+				Region:                           "r",
+				WorkloadIdentityFederationConfig: &aigv1b1.GCPWorkloadIdentityFederationConfig{},
+			},
+			TargetRefs: []gwapiv1a2.LocalPolicyTargetReference{{
+				Group: aiServiceBackendGroup, Kind: aiServiceBackendKind, Name: backendName,
+			}},
+		},
+	}))
+
+	generated := rotators.GetBSPSecretName(bspName)
+	require.NoError(t, fakeClient.Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: generated, Namespace: ns},
+		StringData: map[string]string{rotators.GCPAccessTokenKey: "token"},
+	}))
+
+	_, err := c.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: generated}})
+	require.NoError(t, err)
+
+	backends := backendCh.RequireItemsEventually(t, 1)
+	require.Equal(t, backendName, backends[0].Name)
+}
 
 func TestSecretController_Reconcile(t *testing.T) {
 	bspCh := internaltesting.NewControllerEventChan[*aigv1b1.BackendSecurityPolicy]()
 	mcpRouteCh := internaltesting.NewControllerEventChan[*aigv1b1.MCPRoute]()
+	backendCh := internaltesting.NewControllerEventChan[*aigv1b1.AIServiceBackend]()
+	poolCh := internaltesting.NewControllerEventChan[*gwaiev1.InferencePool]()
 	fakeClient := requireNewFakeClientWithIndexes(t)
-	c := NewSecretController(fakeClient, fake2.NewClientset(), ctrl.Log, bspCh.Ch, mcpRouteCh.Ch)
+	c := NewSecretController(fakeClient, fake2.NewClientset(), ctrl.Log, bspCh.Ch, mcpRouteCh.Ch, backendCh.Ch, poolCh.Ch)
 
 	err := fakeClient.Create(t.Context(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "mysecret", Namespace: "default"},

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -757,7 +757,9 @@ func TestSecretController(t *testing.T) {
 
 	bspCh := internaltesting.NewControllerEventChan[*aigv1b1.BackendSecurityPolicy]()
 	mcpRouteCh := internaltesting.NewControllerEventChan[*aigv1b1.MCPRoute]()
-	sc := controller.NewSecretController(mgr.GetClient(), k, defaultLogger(), bspCh.Ch, mcpRouteCh.Ch)
+	backendCh := internaltesting.NewControllerEventChan[*aigv1b1.AIServiceBackend]()
+	poolCh := internaltesting.NewControllerEventChan[*gwaiev1.InferencePool]()
+	sc := controller.NewSecretController(mgr.GetClient(), k, defaultLogger(), bspCh.Ch, mcpRouteCh.Ch, backendCh.Ch, poolCh.Ch)
 	const secretName, secretNamespace = "mysecret", "default"
 
 	err = ctrl.NewControllerManagedBy(mgr).For(&corev1.Secret{}).Complete(sc)
@@ -790,6 +792,48 @@ func TestSecretController(t *testing.T) {
 	slices.SortFunc(originals, func(a, b *aigv1b1.BackendSecurityPolicy) int {
 		return cmp.Compare(a.Name, b.Name)
 	})
+
+	// WIF references no secret of its own. Kept out of originals: those assertions cover only
+	// policies referencing secretName.
+	require.NoError(t, c.Create(t.Context(), &aigv1b1.AIServiceBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "rotated-backend", Namespace: "default"},
+		Spec: aigv1b1.AIServiceBackendSpec{
+			APISchema: defaultSchema,
+			BackendRef: gwapiv1.BackendObjectReference{
+				Name:  "rotated-backend",
+				Kind:  ptr.To(gwapiv1.Kind("Backend")),
+				Group: ptr.To(gwapiv1.Group("gateway.envoyproxy.io")),
+			},
+		},
+	}))
+	rotated := &aigv1b1.BackendSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "mybsp3", Namespace: "default"},
+		Spec: aigv1b1.BackendSecurityPolicySpec{
+			TargetRefs: []gwapiv1a2.LocalPolicyTargetReference{{
+				Group: "aigateway.envoyproxy.io", Kind: "AIServiceBackend", Name: "rotated-backend",
+			}},
+			Type: aigv1b1.BackendSecurityPolicyTypeGCPCredentials,
+			GCPCredentials: &aigv1b1.BackendSecurityPolicyGCPCredentials{
+				ProjectName: "some-project",
+				Region:      "us-central1",
+				WorkloadIdentityFederationConfig: &aigv1b1.GCPWorkloadIdentityFederationConfig{
+					ProjectID:                    "some-project-id",
+					WorkloadIdentityPoolName:     "some-pool",
+					WorkloadIdentityProviderName: "some-provider",
+					OIDCExchangeToken: aigv1b1.GCPOIDCExchangeToken{
+						BackendSecurityPolicyOIDC: aigv1b1.BackendSecurityPolicyOIDC{
+							OIDC: egv1a1.OIDC{
+								Provider:     egv1a1.OIDCProvider{Issuer: "https://issuer.example.com"},
+								ClientID:     ptr.To("some-client-id"),
+								ClientSecret: gwapiv1.SecretObjectReference{Name: "some-oidc-client-secret"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(t.Context(), rotated))
 
 	// Start the manager and wait for bsps to be cached before trigger a reconciler.
 	go func() { require.NoError(t, mgr.Start(t.Context())) }()
@@ -827,6 +871,32 @@ func TestSecretController(t *testing.T) {
 			return cmp.Compare(a.Name, b.Name)
 		})
 		require.Equal(t, originals, bsps)
+	})
+
+	// The rotator derives its secret name from the policy. That name must be indexed for the secret
+	// to reach the policy.
+	t.Run("generated secret syncs its policy", func(t *testing.T) {
+		generated := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "ai-eg-bsp-mybsp3", Namespace: secretNamespace},
+			StringData: map[string]string{"gcpAccessToken": "token-1"},
+		}
+		require.NoError(t, c.Create(t.Context(), generated))
+		bsps := bspCh.RequireItemsEventually(t, 1)
+		require.Len(t, bsps, 1)
+		require.Equal(t, "mybsp3", bsps[0].Name)
+		// The targets are synced from this reconcile, so the rebuild does not wait on the policy
+		// controller.
+		backends := backendCh.RequireItemsEventually(t, 1)
+		require.Equal(t, "rotated-backend", backends[0].Name)
+
+		// Rotation updates the secret in place rather than recreating it.
+		generated.StringData = map[string]string{"gcpAccessToken": "token-2"}
+		require.NoError(t, c.Update(t.Context(), generated))
+		bsps = bspCh.RequireItemsEventually(t, 1)
+		require.Len(t, bsps, 1)
+		require.Equal(t, "mybsp3", bsps[0].Name)
+		backends = backendCh.RequireItemsEventually(t, 1)
+		require.Equal(t, "rotated-backend", backends[0].Name)
 	})
 }
 


### PR DESCRIPTION
**Description**

After #2494 a rotated credential can sit one generation behind in the filter config, permanently.

What happens:
- `BackendSecurityPolicyController.reconcile` rotates a credential, then rebuilds the filter config in the same pass.
- The rebuild read the secret from the informer cache. The fan-out to it is in-process; the cache update needs a watch round trip.
- The fan-out wins, so the config gets the pre-rotation token. That token is valid for `preRotationWindow`, so requests fail about five minutes after a rotation, not at it.

Why nothing corrects it:
- The Secret watch fires. `secretController.syncSecret` looks policies up by `<secretName>.<namespace>`.
- `backendSecurityPolicyIndexFunc` never emitted the generated secret's name. AWS and Azure OIDC emitted `<policyName>.<namespace>`, which matches nothing; GCP WIF, Azure ClientSecretRef and GCP CredentialsFile emitted nothing for it.
- No policy is found, no rebuild runs, and the next rotation loses the same race. All five rotating configurations were affected, not just the reported GCP WIF one.

Fix:
- `backendSecurityPolicyIndexFunc` emits both keys, the referenced secret and the generated one, with the generated name from `getBSPGeneratedSecretName`.
- When the changed secret is a policy's generated one, `secretController` syncs that policy's targets directly. That reconcile was woken by the secret's own watch event, so its informer store already holds the new credential.
- A reconcile that rotated no longer fans out itself, so the config is never built from a stale read.

Credential reads are unchanged: `getSecretData` still resolves from the informer cache.

Also fixed:
- `getBSPGeneratedSecretName` returned `""` for Azure ClientSecretRef and GCP CredentialsFile, which do rotate. The owner-reference block is gated on that name, so their generated secrets were orphaned on policy delete.
- It also panicked on an unrecognised type, and now runs inside a field indexer, which is outside reconcile panic recovery. It returns `""`, and `rotateCredential` asserts the name exists.
- The owner reference is applied with a merge patch. `Update` from a cached read taken right after the rotator's write could conflict on `resourceVersion`.
- A `NotFound` on that read is no longer an error. The rotator's create is indexed to the policy, so its watch event brings the reconcile back.
- The index emitted a stray `""` key for policies that reference no secret.

**Related Issues/PRs (if applicable)**

Fixes #2603
Caused by #2494
Related: #2605

**Special notes for reviewers (if applicable)**

- Upgrade note: generated secrets for Azure ClientSecretRef and GCP CredentialsFile policies gain an owner reference on the first reconcile after upgrade, so they are garbage collected with the policy instead of being left behind.
- The targetRefs fan-out moved into `syncBackendSecurityPolicyTargets` so both controllers share it. Mechanical.
- The watch event is now the only route to a post-rotation rebuild, where before two paths reached it. The surviving one reads a cache that has observed the write.
- This covers most of #2605. What remains is `rotateCredential` returning early on rotation failure, and the missing AWS mutual exclusion between `credentialsFile` and `oidcExchangeToken`.
