### PR TITLE
feat: add AWSOpenAI as a supported VersionedAPISchema value for AIServiceBackend

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -15,7 +15,7 @@ package v1alpha1
 type VersionedAPISchema struct {
 	// Name is the name of the API schema of the AIGatewayRoute or AIServiceBackend.
 	//
-	// +kubebuilder:validation:Enum=OpenAI;Cohere;AWSBedrock;AzureOpenAI;GCPVertexAI;GCPAnthropic;Anthropic;AWSAnthropic
+	// +kubebuilder:validation:Enum=OpenAI;Cohere;AWSBedrock;AzureOpenAI;GCPVertexAI;GCPAnthropic;Anthropic;AWSAnthropic;AWSOpenAI
 	Name APISchema `json:"name"`
 
 	// Version is the version of the API schema.
@@ -89,6 +89,8 @@ const (
 	// https://aws.amazon.com/bedrock/anthropic/
 	// https://docs.claude.com/en/api/claude-on-amazon-bedrock
 	APISchemaAWSAnthropic APISchema = "AWSAnthropic"
+	// APISchemaAWSOpenAI is the OpenAI-compatible API schema provided by AWS.
+	APISchemaAWSOpenAI APISchema = "AWSOpenAI"
 )
 
 const (

--- a/api/v1beta1/shared_types.go
+++ b/api/v1beta1/shared_types.go
@@ -19,7 +19,7 @@ import (
 type VersionedAPISchema struct {
 	// Name is the name of the API schema of the AIGatewayRoute or AIServiceBackend.
 	//
-	// +kubebuilder:validation:Enum=OpenAI;Cohere;AWSBedrock;AzureOpenAI;GCPVertexAI;GCPAnthropic;Anthropic;AWSAnthropic
+	// +kubebuilder:validation:Enum=OpenAI;Cohere;AWSBedrock;AzureOpenAI;GCPVertexAI;GCPAnthropic;Anthropic;AWSAnthropic;AWSOpenAI
 	Name APISchema `json:"name"`
 
 	// Version is the version of the API schema.
@@ -93,6 +93,8 @@ const (
 	// https://aws.amazon.com/bedrock/anthropic/
 	// https://docs.claude.com/en/api/claude-on-amazon-bedrock
 	APISchemaAWSAnthropic APISchema = "AWSAnthropic"
+	// APISchemaAWSOpenAI is the OpenAI-compatible API schema provided by AWS.
+	APISchemaAWSOpenAI APISchema = "AWSOpenAI"
 )
 
 const (

--- a/internal/filterapi/filterconfig.go
+++ b/internal/filterapi/filterconfig.go
@@ -178,6 +178,8 @@ const (
 	// Used for Claude models hosted on AWS Bedrock. Supports both OpenAI and Anthropic input formats
 	// depending on the endpoint path, similar to APISchemaGCPAnthropic.
 	APISchemaAWSAnthropic APISchemaName = "AWSAnthropic"
+	// APISchemaAWSOpenAI represents the AWS OpenAI-compatible API schema.
+	APISchemaAWSOpenAI APISchemaName = "AWSOpenAI"
 )
 
 // RouteRuleName is the name of the route rule.

--- a/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aiservicebackends.yaml
+++ b/manifests/charts/ai-gateway-crds-helm/templates/aigateway.envoyproxy.io_aiservicebackends.yaml
@@ -331,6 +331,7 @@ spec:
                     - GCPAnthropic
                     - Anthropic
                     - AWSAnthropic
+                    - AWSOpenAI
                     type: string
                   prefix:
                     description: |-
@@ -799,6 +800,7 @@ spec:
                     - GCPAnthropic
                     - Anthropic
                     - AWSAnthropic
+                    - AWSOpenAI
                     type: string
                   prefix:
                     description: |-

--- a/site/docs/api/api.mdx
+++ b/site/docs/api/api.mdx
@@ -927,6 +927,11 @@ APISchema defines the API schema.
   type="enum"
   required="false"
   description="APISchemaAWSAnthropic is the schema for Anthropic models hosted on AWS Bedrock.<br />Uses the native Anthropic Messages API format for requests and responses.<br />When used with /v1/chat/completions endpoint, translates OpenAI format to Anthropic.<br />When used with /v1/messages endpoint, passes through native Anthropic format.<br />https://aws.amazon.com/bedrock/anthropic/<br />https://docs.claude.com/en/api/claude-on-amazon-bedrock<br />"
+/><ApiField
+  name="AWSOpenAI"
+  type="enum"
+  required="false"
+  description="APISchemaAWSOpenAI is the OpenAI-compatible API schema provided by AWS.<br />"
 />
 #### <a id="github-com-envoyproxy-ai-gateway-api-v1alpha1-awscredentialsfile">AWSCredentialsFile</a>
 
@@ -3455,6 +3460,11 @@ APISchema defines the API schema.
   type="enum"
   required="false"
   description="APISchemaAWSAnthropic is the schema for Anthropic models hosted on AWS Bedrock.<br />Uses the native Anthropic Messages API format for requests and responses.<br />When used with /v1/chat/completions endpoint, translates OpenAI format to Anthropic.<br />When used with /v1/messages endpoint, passes through native Anthropic format.<br />https://aws.amazon.com/bedrock/anthropic/<br />https://docs.claude.com/en/api/claude-on-amazon-bedrock<br />"
+/><ApiField
+  name="AWSOpenAI"
+  type="enum"
+  required="false"
+  description="APISchemaAWSOpenAI is the OpenAI-compatible API schema provided by AWS.<br />"
 />
 #### <a id="github-com-envoyproxy-ai-gateway-api-v1beta1-awscredentialsfile">AWSCredentialsFile</a>
 

--- a/tests/crdcel/main_test.go
+++ b/tests/crdcel/main_test.go
@@ -96,6 +96,7 @@ func TestAIServiceBackends(t *testing.T) {
 		{name: "basic.yaml"},
 		{name: "anthropic-schema.yaml"},
 		{name: "basic-eg-backend-aws.yaml"},
+		{name: "aws-openai-schema.yaml"},
 		{name: "basic-eg-backend-azure.yaml"},
 		{
 			name:   "unknown_schema.yaml",

--- a/tests/crdcel/testdata/aiservicebackends/aws-openai-schema.yaml
+++ b/tests/crdcel/testdata/aiservicebackends/aws-openai-schema.yaml
@@ -1,0 +1,17 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: aws-openai-schema
+  namespace: default
+spec:
+  schema:
+    name: AWSOpenAI
+  backendRef:
+    name: aws-openai-schema
+    kind: Backend
+    group: gateway.envoyproxy.io


### PR DESCRIPTION
**Description**

Add AWSOpenAI as a supported VersionedAPISchema value for AIServiceBackend.

This updates:

  - v1beta1 and v1alpha1 API definitions
  - Internal filter API constants
  - Generated CRD manifests
  - Generated API documentation
  - CRD validation coverage

  This PR only introduces the API schema value. Endpoint translation and prefix behavior are outside its scope.