### PR TITLE
extproc: remove legacy config watcher

### DIFF
--- a/cmd/aigw/run.go
+++ b/cmd/aigw/run.go
@@ -387,14 +387,12 @@ func (runCtx *runCmdContext) mustStartExtProc(
 	if err != nil {
 		panic(fmt.Sprintf("BUG: failed to marshal filter config: %v", err))
 	}
-	configPath := filepath.Join(runCtx.tmpdir, "extproc-config.yaml")
-	_ = os.Remove(configPath)
-	err = os.WriteFile(configPath, marshaled, 0o600)
-	if err != nil {
-		panic(fmt.Sprintf("BUG: failed to write extension proc config: %v", err))
+	configBundlePath := filepath.Join(runCtx.tmpdir, "extproc-config-bundle")
+	if err = writeExtProcConfigBundle(configBundlePath, marshaled); err != nil {
+		panic(fmt.Sprintf("BUG: failed to write extension proc config bundle: %v", err))
 	}
 	args := []string{
-		"--configPath", configPath,
+		"--configBundlePath", configBundlePath,
 		"--extProcAddr", fmt.Sprintf("unix://%s", runCtx.udsPath),
 		"--adminPort", fmt.Sprintf("%d", runCtx.adminPort),
 		"--mcpAddr", ":" + strconv.Itoa(internalapi.MCPProxyPort),
@@ -428,6 +426,29 @@ func (runCtx *runCmdContext) mustStartExtProc(
 		close(done)
 	}()
 	return done
+}
+
+func writeExtProcConfigBundle(bundlePath string, raw []byte) error {
+	part := filterapi.ConfigBundlePart{
+		Name:      "extproc-config",
+		Path:      filterapi.ConfigBundlePartPath(0),
+		SizeBytes: len(raw),
+	}
+	partPath := filepath.Join(bundlePath, filepath.FromSlash(part.Path))
+	if err := os.MkdirAll(filepath.Dir(partPath), 0o700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(partPath, raw, 0o600); err != nil {
+		return err
+	}
+	indexRaw, err := filterapi.MarshalConfigBundleIndex(&filterapi.ConfigBundleIndex{
+		Checksum: filterapi.ConfigBundleChecksum(raw),
+		Parts:    []filterapi.ConfigBundlePart{part},
+	})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(bundlePath, filterapi.ConfigBundleIndexFileName), indexRaw, 0o600)
 }
 
 func envOptional(name string) *string {

--- a/cmd/aigw/run_test.go
+++ b/cmd/aigw/run_test.go
@@ -107,15 +107,31 @@ func TestRunCmdContext_writeEnvoyResourcesAndRunExtProc_noListeners(t *testing.T
 
 func Test_mustStartExtProc(t *testing.T) {
 	mockErr := errors.New("mock extproc error")
+	var capturedArgs []string
 	runCtx := &runCmdContext{
-		stderrLogger:    slog.New(slog.DiscardHandler),
-		stderr:          io.Discard,
-		tmpdir:          t.TempDir(),
-		adminPort:       1064,
-		extProcLauncher: func(context.Context, []string, io.Writer) error { return mockErr },
+		stderrLogger: slog.New(slog.DiscardHandler),
+		stderr:       io.Discard,
+		tmpdir:       t.TempDir(),
+		adminPort:    1064,
+		extProcLauncher: func(_ context.Context, args []string, _ io.Writer) error {
+			capturedArgs = args
+			return mockErr
+		},
 	}
 	done := runCtx.mustStartExtProc(t.Context(), &filterapi.Config{Version: version.Parse()})
 	require.ErrorIs(t, <-done, mockErr)
+
+	bundlePath := findFlagValue(capturedArgs, "--configBundlePath")
+	require.NotEmpty(t, bundlePath)
+	indexRaw, err := os.ReadFile(filepath.Join(bundlePath, filterapi.ConfigBundleIndexFileName))
+	require.NoError(t, err)
+	index, err := filterapi.UnmarshalConfigBundleIndex(indexRaw)
+	require.NoError(t, err)
+	cfg, err := filterapi.ReassembleBundleConfig(index, func(part filterapi.ConfigBundlePart) ([]byte, error) {
+		return os.ReadFile(filepath.Join(bundlePath, filepath.FromSlash(part.Path)))
+	})
+	require.NoError(t, err)
+	require.Equal(t, version.Parse(), cfg.Version)
 }
 
 func Test_mustStartExtProc_defaultHeaderAttributes(t *testing.T) {

--- a/cmd/aigw/testdata/translate_basic.out.yaml
+++ b/cmd/aigw/testdata/translate_basic.out.yaml
@@ -210,50 +210,6 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: envoy-ai-gateway-basic-default
-stringData:
-  filter-config.yaml: |
-    backends:
-    - auth:
-        apiKey:
-          key: apiKey
-      modelNameOverride: ""
-      name: default/envoy-ai-gateway-basic-openai/route/envoy-ai-gateway-basic/rule/0/ref/0
-      schema:
-        name: OpenAI
-        prefix: v1
-    - auth:
-        aws:
-          credentialFileLiteral: |
-            [default]
-            aws_access_key_id = AWS_ACCESS_KEY_ID
-            aws_secret_access_key = AWS_SECRET_ACCESS_KEY
-          region: us-east-1
-      modelNameOverride: us.meta.llama3-2-1b-instruct-v1:0
-      name: default/envoy-ai-gateway-basic-aws/route/envoy-ai-gateway-basic/rule/1/ref/0
-      schema:
-        name: AWSBedrock
-    - modelNameOverride: ""
-      name: default/envoy-ai-gateway-basic-testupstream/route/envoy-ai-gateway-basic/rule/2/ref/0
-      schema:
-        name: OpenAI
-        prefix: v1
-    models:
-    - CreatedAt: "2025-05-23T00:00:00Z"
-      Name: gpt-4o-mini
-      OwnedBy: openai
-    - CreatedAt: "2025-05-23T00:00:00Z"
-      Name: llama3-2-1b-instruct-v1
-      OwnedBy: aws
-    - CreatedAt: "2025-05-23T00:00:00Z"
-      Name: some-cool-self-hosted-model
-      OwnedBy: Envoy AI Gateway
-    uuid: aigw-translate
-    version: dev
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: envoy-ai-gateway-basic-openai-apikey
   namespace: default
 stringData:

--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -39,7 +39,6 @@ import (
 
 // extProcFlags is the struct that holds the flags passed to the external processor.
 type extProcFlags struct {
-	configPath                             string        // path to the configuration file.
 	configBundlePath                       string        // path to the sharded configuration bundle directory.
 	extProcAddr                            string        // gRPC address for the external processor.
 	logLevel                               slog.Level    // log level for the external processor.
@@ -89,12 +88,6 @@ func parseAndValidateFlags(args []string) (extProcFlags, error) {
 		fs    = flag.NewFlagSet("AI Gateway External Processor", flag.ContinueOnError)
 	)
 
-	fs.StringVar(&flags.configPath,
-		"configPath",
-		"",
-		"path to the configuration file. The file must be in YAML format specified in filterapi.Config type. "+
-			"The configuration file is watched for changes.",
-	)
 	fs.StringVar(&flags.configBundlePath,
 		"configBundlePath",
 		"",
@@ -165,8 +158,8 @@ func parseAndValidateFlags(args []string) (extProcFlags, error) {
 		return extProcFlags{}, fmt.Errorf("failed to parse extProcFlags: %w", err)
 	}
 
-	if flags.configPath == "" && flags.configBundlePath == "" {
-		errs = append(errs, fmt.Errorf("either configPath or configBundlePath must be provided"))
+	if flags.configBundlePath == "" {
+		errs = append(errs, fmt.Errorf("configBundlePath must be provided"))
 	}
 	if err := flags.logLevel.UnmarshalText([]byte(*logLevelPtr)); err != nil {
 		errs = append(errs, fmt.Errorf("failed to unmarshal log level: %w", err))
@@ -229,7 +222,6 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	l.Info("starting external processor",
 		slog.String("version", version.Parse()),
 		slog.String("address", flags.extProcAddr),
-		slog.String("configPath", flags.configPath),
 		slog.String("configBundlePath", flags.configBundlePath),
 	)
 
@@ -354,7 +346,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 		countTokensMetricsFactory, tracing.CountTokensTracer(), endpointspec.MessagesCountTokensEndpointSpec{}))
 
 	// Create and register gRPC server with ExternalProcessorServer (the service Envoy calls).
-	if err = startConfigWatcher(ctx, &flags, server, l, time.Second*5); err != nil {
+	if err = filterapi.StartConfigBundleWatcher(ctx, flags.configBundlePath, server, l, time.Second*5); err != nil {
 		return fmt.Errorf("failed to start config watcher: %w", err)
 	}
 
@@ -378,7 +370,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to create MCP proxy: %w", err)
 		}
-		if err = startConfigWatcher(ctx, &flags, mcpProxyConfig, l, time.Second*5); err != nil {
+		if err = filterapi.StartConfigBundleWatcher(ctx, flags.configBundlePath, mcpProxyConfig, l, time.Second*5); err != nil {
 			return fmt.Errorf("failed to start config watcher: %w", err)
 		}
 
@@ -442,14 +434,6 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 	// it would be extremely hard to debug issues where the external processor fails to start.
 	fmt.Fprintf(stderr, "AI Gateway External Processor is ready\n")
 	return s.Serve(extProcLis)
-}
-
-func startConfigWatcher(ctx context.Context, flags *extProcFlags, rcv filterapi.ConfigReceiver, l *slog.Logger, tick time.Duration) error {
-	if flags.configBundlePath != "" {
-		return filterapi.StartConfigBundleWatcher(ctx, flags.configBundlePath, rcv, l, tick)
-	}
-	// TODO(huabing): the legacy config watcher can be removed in the next release
-	return filterapi.StartLegacyConfigWatcher(ctx, flags.configPath, rcv, l, tick)
 }
 
 func listen(ctx context.Context, name, network, address string) (net.Listener, error) {

--- a/cmd/extproc/mainlib/main_test.go
+++ b/cmd/extproc/mainlib/main_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 	"github.com/envoyproxy/ai-gateway/internal/json"
 )
@@ -61,7 +62,6 @@ func Test_parseAndValidateFlags(t *testing.T) {
 		for _, tc := range []struct {
 			name             string
 			args             []string
-			configPath       string
 			configBundlePath string
 			addr             string
 			rootPrefix       string
@@ -70,141 +70,141 @@ func Test_parseAndValidateFlags(t *testing.T) {
 			enableRedaction  bool
 		}{
 			{
-				name:            "minimal extProcFlags",
-				args:            []string{"-configPath", "/path/to/config.yaml"},
-				configPath:      "/path/to/config.yaml",
-				addr:            ":1063",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelInfo,
-				logFormat:       "text",
-				enableRedaction: false,
+				name:             "minimal extProcFlags",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             ":1063",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelInfo,
+				logFormat:        "text",
+				enableRedaction:  false,
 			},
 			{
-				name:            "log format json",
-				args:            []string{"-configPath", "/path/to/config.yaml", "-logFormat", "json"},
-				configPath:      "/path/to/config.yaml",
-				addr:            ":1063",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelInfo,
-				logFormat:       "json",
-				enableRedaction: false,
+				name:             "log format json",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle", "-logFormat", "json"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             ":1063",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelInfo,
+				logFormat:        "json",
+				enableRedaction:  false,
 			},
 			{
-				name:            "custom addr",
-				args:            []string{"-configPath", "/path/to/config.yaml", "-extProcAddr", "unix:///tmp/ext_proc.sock"},
-				configPath:      "/path/to/config.yaml",
-				addr:            "unix:///tmp/ext_proc.sock",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelInfo,
-				enableRedaction: false,
+				name:             "custom addr",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle", "-extProcAddr", "unix:///tmp/ext_proc.sock"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             "unix:///tmp/ext_proc.sock",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelInfo,
+				enableRedaction:  false,
 			},
 			{
-				name:            "log level debug",
-				args:            []string{"-configPath", "/path/to/config.yaml", "-logLevel", "debug"},
-				configPath:      "/path/to/config.yaml",
-				addr:            ":1063",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelDebug,
-				enableRedaction: false,
+				name:             "log level debug",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle", "-logLevel", "debug"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             ":1063",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelDebug,
+				enableRedaction:  false,
 			},
 			{
-				name:            "log level debug with redaction enabled",
-				args:            []string{"-configPath", "/path/to/config.yaml", "-logLevel", "debug", "-enableRedaction"},
-				configPath:      "/path/to/config.yaml",
-				addr:            ":1063",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelDebug,
-				enableRedaction: true,
+				name:             "log level debug with redaction enabled",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle", "-logLevel", "debug", "-enableRedaction"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             ":1063",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelDebug,
+				enableRedaction:  true,
 			},
 			{
-				name:            "log level warn",
-				args:            []string{"-configPath", "/path/to/config.yaml", "-logLevel", "warn"},
-				configPath:      "/path/to/config.yaml",
-				addr:            ":1063",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelWarn,
-				enableRedaction: false,
+				name:             "log level warn",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle", "-logLevel", "warn"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             ":1063",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelWarn,
+				enableRedaction:  false,
 			},
 			{
-				name:            "log level error",
-				args:            []string{"-configPath", "/path/to/config.yaml", "-logLevel", "error"},
-				configPath:      "/path/to/config.yaml",
-				addr:            ":1063",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelError,
-				enableRedaction: false,
+				name:             "log level error",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle", "-logLevel", "error"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             ":1063",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelError,
+				enableRedaction:  false,
 			},
 			{
 				name: "all extProcFlags",
 				args: []string{
-					"-configPath", "/path/to/config.yaml",
+					"-configBundlePath", "/path/to/config-bundle",
 					"-extProcAddr", "unix:///tmp/ext_proc.sock",
 					"-logLevel", "debug",
 					"-rootPrefix", "/foo/bar/",
 				},
-				configPath:      "/path/to/config.yaml",
-				addr:            "unix:///tmp/ext_proc.sock",
-				rootPrefix:      "/foo/bar/",
-				logLevel:        slog.LevelDebug,
-				enableRedaction: false,
+				configBundlePath: "/path/to/config-bundle",
+				addr:             "unix:///tmp/ext_proc.sock",
+				rootPrefix:       "/foo/bar/",
+				logLevel:         slog.LevelDebug,
+				enableRedaction:  false,
 			},
 			{
-				name:            "with endpoint prefixes",
-				args:            []string{"-configPath", "/path/to/config.yaml", "-endpointPrefixes", "openai:/,cohere:/cohere,anthropic:/anthropic"},
-				configPath:      "/path/to/config.yaml",
-				addr:            ":1063",
-				rootPrefix:      "/",
-				logLevel:        slog.LevelInfo,
-				enableRedaction: false,
+				name:             "with endpoint prefixes",
+				args:             []string{"-configBundlePath", "/path/to/config-bundle", "-endpointPrefixes", "openai:/,cohere:/cohere,anthropic:/anthropic"},
+				configBundlePath: "/path/to/config-bundle",
+				addr:             ":1063",
+				rootPrefix:       "/",
+				logLevel:         slog.LevelInfo,
+				enableRedaction:  false,
 			},
 			{
 				name: "with metrics header mapping",
 				args: []string{
-					"-configPath", "/path/to/config.yaml",
+					"-configBundlePath", "/path/to/config-bundle",
 					"-metricsRequestHeaderAttributes", "x-tenant-id:tenant.id,x-tenant-id:tenant.id",
 				},
-				configPath:      "/path/to/config.yaml",
-				rootPrefix:      "/",
-				addr:            ":1063",
-				logLevel:        slog.LevelInfo,
-				enableRedaction: false,
+				configBundlePath: "/path/to/config-bundle",
+				rootPrefix:       "/",
+				addr:             ":1063",
+				logLevel:         slog.LevelInfo,
+				enableRedaction:  false,
 			},
 			{
 				name: "with base header mapping",
 				args: []string{
-					"-configPath", "/path/to/config.yaml",
+					"-configBundlePath", "/path/to/config-bundle",
 					"-metricsRequestHeaderAttributes", "x-team-id:team.id,x-user-id:user.id",
 				},
-				configPath:      "/path/to/config.yaml",
-				rootPrefix:      "/",
-				addr:            ":1063",
-				logLevel:        slog.LevelInfo,
-				enableRedaction: false,
+				configBundlePath: "/path/to/config-bundle",
+				rootPrefix:       "/",
+				addr:             ":1063",
+				logLevel:         slog.LevelInfo,
+				enableRedaction:  false,
 			},
 			{
 				name: "with tracing header attributes",
 				args: []string{
-					"-configPath", "/path/to/config.yaml",
+					"-configBundlePath", "/path/to/config-bundle",
 					"-spanRequestHeaderAttributes", "x-session-id:session.id,x-user-id:user.id",
 				},
-				configPath:      "/path/to/config.yaml",
-				rootPrefix:      "/",
-				addr:            ":1063",
-				logLevel:        slog.LevelInfo,
-				enableRedaction: false,
+				configBundlePath: "/path/to/config-bundle",
+				rootPrefix:       "/",
+				addr:             ":1063",
+				logLevel:         slog.LevelInfo,
+				enableRedaction:  false,
 			},
 			{
 				name: "with both metrics and tracing headers",
 				args: []string{
-					"-configPath", "/path/to/config.yaml",
+					"-configBundlePath", "/path/to/config-bundle",
 					"-metricsRequestHeaderAttributes", "x-user-id:user.id",
 					"-spanRequestHeaderAttributes", "x-session-id:session.id",
 				},
-				configPath:      "/path/to/config.yaml",
-				rootPrefix:      "/",
-				addr:            ":1063",
-				logLevel:        slog.LevelInfo,
-				enableRedaction: false,
+				configBundlePath: "/path/to/config-bundle",
+				rootPrefix:       "/",
+				addr:             ":1063",
+				logLevel:         slog.LevelInfo,
+				enableRedaction:  false,
 			},
 			{
 				name:             "bundle path only",
@@ -219,7 +219,6 @@ func Test_parseAndValidateFlags(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				flags, err := parseAndValidateFlags(tc.args)
 				require.NoError(t, err)
-				require.Equal(t, tc.configPath, flags.configPath)
 				require.Equal(t, tc.configBundlePath, flags.configBundlePath)
 				require.Equal(t, tc.addr, flags.extProcAddr)
 				require.Equal(t, tc.logLevel, flags.logLevel)
@@ -244,31 +243,31 @@ func Test_parseAndValidateFlags(t *testing.T) {
 			{
 				name:          "invalid log level",
 				args:          []string{"-logLevel", "invalid"},
-				expectedError: "either configPath or configBundlePath must be provided\nfailed to unmarshal log level: slog: level string \"invalid\": unknown name",
+				expectedError: "configBundlePath must be provided\nfailed to unmarshal log level: slog: level string \"invalid\": unknown name",
 			},
 			{
 				name:          "invalid log format",
-				args:          []string{"-configPath", "/path/to/config.yaml", "-logFormat", "yaml"},
+				args:          []string{"-configBundlePath", "/path/to/config-bundle", "-logFormat", "yaml"},
 				expectedError: `invalid log format: "yaml", must be "text" or "json"`,
 			},
 			{
 				name:          "invalid endpoint prefixes - unknown key",
-				args:          []string{"-configPath", "/path/to/config.yaml", "-endpointPrefixes", "foo:/x"},
+				args:          []string{"-configBundlePath", "/path/to/config-bundle", "-endpointPrefixes", "foo:/x"},
 				expectedError: "failed to parse endpoint prefixes: unknown endpointPrefixes key \"foo\" at position 1 (allowed: openai, cohere, anthropic)",
 			},
 			{
 				name:          "invalid endpoint prefixes - missing colon",
-				args:          []string{"-configPath", "/path/to/config.yaml", "-endpointPrefixes", "openai"},
+				args:          []string{"-configBundlePath", "/path/to/config-bundle", "-endpointPrefixes", "openai"},
 				expectedError: "failed to parse endpoint prefixes: invalid endpointPrefixes pair at position 1: \"openai\" (expected format: key:value)",
 			},
 			{
 				name:          "invalid tracing header attributes - missing colon",
-				args:          []string{"-configPath", "/path/to/config.yaml", "-spanRequestHeaderAttributes", "x-session-id"},
+				args:          []string{"-configBundlePath", "/path/to/config-bundle", "-spanRequestHeaderAttributes", "x-session-id"},
 				expectedError: "failed to parse tracing header mapping: invalid header-attribute pair at position 1: \"x-session-id\" (expected format: header:attribute)",
 			},
 			{
 				name:          "invalid tracing header attributes - empty header",
-				args:          []string{"-configPath", "/path/to/config.yaml", "-spanRequestHeaderAttributes", ":session.id"},
+				args:          []string{"-configBundlePath", "/path/to/config-bundle", "-spanRequestHeaderAttributes", ":session.id"},
 				expectedError: "failed to parse tracing header mapping: empty header or attribute at position 1: \":session.id\"",
 			},
 		}
@@ -279,6 +278,11 @@ func Test_parseAndValidateFlags(t *testing.T) {
 				require.EqualError(t, err, tt.expectedError)
 			})
 		}
+	})
+
+	t.Run("legacy config path is rejected", func(t *testing.T) {
+		_, err := parseAndValidateFlags([]string{"-configPath", "/path/to/config.yaml"})
+		require.EqualError(t, err, "failed to parse extProcFlags: flag provided but not defined: -configPath")
 	})
 }
 
@@ -313,17 +317,27 @@ func TestListenAddress(t *testing.T) {
 
 // TestExtProcStartupMessage ensures other programs can rely on the startup message to STDERR.
 func TestExtProcStartupMessage(t *testing.T) {
-	// Create a temporary config file.
+	// Create a temporary config bundle.
 	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	configRaw := []byte(`
 version: dev
 backends:
 - name: openai
   schema:
     name: OpenAI
     version: v1
-`), 0o600))
+`)
+	configBundlePath := filepath.Join(tmpDir, "config-bundle")
+	part := filterapi.ConfigBundlePart{Name: "config", Path: filterapi.ConfigBundlePartPath(0), SizeBytes: len(configRaw)}
+	partPath := filepath.Join(configBundlePath, filepath.FromSlash(part.Path))
+	require.NoError(t, os.MkdirAll(filepath.Dir(partPath), 0o700))
+	require.NoError(t, os.WriteFile(partPath, configRaw, 0o600))
+	indexRaw, err := filterapi.MarshalConfigBundleIndex(&filterapi.ConfigBundleIndex{
+		Checksum: filterapi.ConfigBundleChecksum(configRaw),
+		Parts:    []filterapi.ConfigBundlePart{part},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configBundlePath, filterapi.ConfigBundleIndexFileName), indexRaw, 0o600))
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -352,7 +366,7 @@ backends:
 	errCh := make(chan error, 1)
 	go func() {
 		args := []string{
-			"-configPath", configPath,
+			"-configBundlePath", configBundlePath,
 			"-extProcAddr", ":0",
 			"-adminPort", "0",
 			"-mcpAddr", "unix://" + socketPath,

--- a/internal/controller/extproc_builder.go
+++ b/internal/controller/extproc_builder.go
@@ -284,7 +284,7 @@ func (b *extProcBuilder) nonDefaultLogFormat() string {
 }
 
 // buildExtProcBaseArgs builds the command line arguments for the extproc
-// container excluding the secret-presence-driven -configPath / -configBundlePath
+// container excluding the secret-presence-driven -configBundlePath
 // flags. The mutating webhook prepends those based on which filter-config
 // secrets exist; they are intentionally kept out of the drift hash.
 func (b *extProcBuilder) buildExtProcBaseArgs(needMCP bool) []string {

--- a/internal/controller/extproc_builder_test.go
+++ b/internal/controller/extproc_builder_test.go
@@ -233,7 +233,7 @@ func TestExtProcContainerHash_Drift(t *testing.T) {
 }
 
 // TestExtProcContainerHash_ExcludesConfigRoutingArgs ensures the secret-
-// presence-driven -configPath / -configBundlePath args are NOT part of the hash
+// presence-driven -configBundlePath args are NOT part of the hash
 // (they are added by the webhook after buildExtProcContainer returns). The base
 // container's Args must contain neither flag, so secret-existence transitions
 // do not spuriously trigger rollouts.
@@ -245,7 +245,6 @@ func TestExtProcContainerHash_ExcludesConfigRoutingArgs(t *testing.T) {
 
 	container := b.buildExtProcContainer(input)
 	for _, a := range container.Args {
-		require.NotEqual(t, "-configPath", a)
 		require.NotEqual(t, "-configBundlePath", a)
 	}
 	require.Equal(t, baseHash, b.extProcContainerHash(input),

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -40,8 +40,6 @@ import (
 )
 
 const (
-	// FilterConfigKeyInSecret is the key to store the filter config in the secret.
-	FilterConfigKeyInSecret = "filter-config.yaml" //nolint: gosec
 	// defaultOwnedBy is the default value for the ModelsOwnedBy field in the filter config.
 	defaultOwnedBy = "Envoy AI Gateway"
 )
@@ -574,48 +572,7 @@ func (c *GatewayController) reconcileFilterConfigSecret(
 	if err = c.writeFilterConfigBundle(ctx, gatewayName, gatewayNamespace, configSecretNamespace, marshaled, uuid); err != nil {
 		return false, err
 	}
-	// TODO(huabing): this can be removed in the next release.
-	if err = c.writeLegacyFilterConfigSecret(ctx, gatewayName, gatewayNamespace, configSecretNamespace, marshaled); err != nil {
-		return false, err
-	}
 	return hasEffectiveRoute, nil
-}
-
-func (c *GatewayController) writeLegacyFilterConfigSecret(
-	ctx context.Context,
-	gatewayName,
-	gatewayNamespace,
-	configSecretNamespace string,
-	marshaled []byte,
-) error {
-	legacySecretName := legacyFilterConfigSecretName(gatewayName, gatewayNamespace)
-
-	// Create legacy secret only if the secret name and content still fit Kubernetes limits.
-	if len(legacySecretName) > k8sObjectNameMaxLen || len(marshaled) > corev1.MaxSecretSize {
-		return nil
-	}
-
-	data := map[string]string{FilterConfigKeyInSecret: string(marshaled)}
-	secret, err := c.kube.CoreV1().Secrets(configSecretNamespace).Get(ctx, legacySecretName, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: legacySecretName, Namespace: configSecretNamespace},
-				StringData: data,
-			}
-			if _, err = c.kube.CoreV1().Secrets(configSecretNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-				return fmt.Errorf("failed to create secret %s: %w", legacySecretName, err)
-			}
-			return nil
-		}
-		return fmt.Errorf("failed to get secret %s: %w", legacySecretName, err)
-	}
-
-	secret.StringData = data
-	if _, err := c.kube.CoreV1().Secrets(configSecretNamespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("failed to update secret %s: %w", secret.Name, err)
-	}
-	return nil
 }
 
 // reconcileFilterConfigSecretForMCPGateway updates the filter config secret for the external processor.

--- a/internal/controller/gateway_mutator.go
+++ b/internal/controller/gateway_mutator.go
@@ -244,26 +244,21 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 
 	podspec := &pod.Spec
 
-	// Resolve config secret sources.
-	// Prefer bundled config when available/valid, and fall back to legacy config for compatibility.
-	// If neither exists, skip mutation to avoid blocking Envoy pod creation.
+	// Resolve the config bundle.
+	// If it does not exist, skip mutation to avoid blocking Envoy pod creation.
 	// The controller will later trigger new pod mutations by updating pod/deployment annotations when the config secrets are created.
-	legacyConfigSecretName := legacyFilterConfigSecretName(gatewayName, gatewayNamespace)
 	bundleConfigIndexSecretName := FilterConfigBundleIndexSecretName(gatewayName, gatewayNamespace)
 
 	bundleConfigIndexSecret, err := g.kube.CoreV1().Secrets(pod.Namespace).Get(ctx, bundleConfigIndexSecretName, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
+		g.logger.Info("no filter config secret found, skipping mutation",
+			"gateway_name", gatewayName, "gateway_namespace", gatewayNamespace)
+		return nil
+	}
+	if err != nil {
 		return fmt.Errorf("failed to get bundled filter config secret %s: %w", bundleConfigIndexSecretName, err)
 	}
-	hasBundleConfig := err == nil && bundleConfigIndexSecret != nil
-
-	legacyConfigSecret, err := g.kube.CoreV1().Secrets(pod.Namespace).Get(ctx, legacyConfigSecretName, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get legacy filter config secret %s: %w", legacyConfigSecretName, err)
-	}
-	hasLegacyConfig := err == nil && legacyConfigSecret != nil
-
-	if !hasBundleConfig && !hasLegacyConfig {
+	if bundleConfigIndexSecret == nil {
 		g.logger.Info("no filter config secret found, skipping mutation",
 			"gateway_name", gatewayName, "gateway_namespace", gatewayNamespace)
 		return nil
@@ -275,7 +270,6 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 	}
 
 	// Now we construct the AI Gateway managed containers and volumes.
-	filterConfigVolumeName := legacyFilterConfigVolumeName(gatewayName, gatewayNamespace)
 	filterConfigBundleVolumeName := filterConfigBundleVolumeName(gatewayName, gatewayNamespace)
 	volumes := []corev1.Volume{
 		{
@@ -285,54 +279,42 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 			},
 		},
 	}
-	if hasLegacyConfig {
-		volumes = append(volumes, corev1.Volume{
-			Name: filterConfigVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: legacyConfigSecretName},
-			},
-		})
-	}
-
-	// Mount the shared config secrets if bundled config exists.
-	if hasBundleConfig {
-		projections := []corev1.VolumeProjection{
-			{
-				Secret: &corev1.SecretProjection{
-					LocalObjectReference: corev1.LocalObjectReference{Name: bundleConfigIndexSecretName},
-					Items: []corev1.KeyToPath{
-						{
-							Key:  FilterConfigBundleIndexKey,
-							Path: filterapi.ConfigBundleIndexFileName,
-						},
+	projections := []corev1.VolumeProjection{
+		{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{Name: bundleConfigIndexSecretName},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  FilterConfigBundleIndexKey,
+						Path: filterapi.ConfigBundleIndexFileName,
 					},
 				},
 			},
-		}
-		optional := true
-		for i := range maxFilterConfigBundleSlots {
-			projections = append(projections, corev1.VolumeProjection{
-				Secret: &corev1.SecretProjection{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: filterConfigBundlePartSecretName(gatewayName, gatewayNamespace, i),
-					},
-					Optional: &optional,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  FilterConfigBundlePartKey,
-							Path: filterapi.ConfigBundlePartPath(i),
-						},
+		},
+	}
+	optional := true
+	for i := range maxFilterConfigBundleSlots {
+		projections = append(projections, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: filterConfigBundlePartSecretName(gatewayName, gatewayNamespace, i),
+				},
+				Optional: &optional,
+				Items: []corev1.KeyToPath{
+					{
+						Key:  FilterConfigBundlePartKey,
+						Path: filterapi.ConfigBundlePartPath(i),
 					},
 				},
-			})
-		}
-		volumes = append(volumes, corev1.Volume{
-			Name: filterConfigBundleVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Projected: &corev1.ProjectedVolumeSource{Sources: projections},
 			},
 		})
 	}
+	volumes = append(volumes, corev1.Volume{
+		Name: filterConfigBundleVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{Sources: projections},
+		},
+	})
 	podspec.Volumes = append(podspec.Volumes, volumes...)
 
 	// Add imagePullSecrets for extProc if configured
@@ -340,50 +322,24 @@ func (g *gatewayMutator) mutatePod(ctx context.Context, pod *corev1.Pod, gateway
 		podspec.ImagePullSecrets = append(podspec.ImagePullSecrets, g.imagePullSecrets...)
 	}
 
-	const (
-		filterConfigMountPath       = "/etc/filter-config"
-		filterConfigFullPath        = filterConfigMountPath + "/" + FilterConfigKeyInSecret
-		filterConfigBundleMountPath = "/etc/filter-config-bundle"
-	)
+	const filterConfigBundleMountPath = "/etc/filter-config-bundle"
 	udsMountPath := filepath.Dir(g.udsPath)
 
 	// Build the extproc container via the shared builder. The builder produces the
 	// base container (image, env, base args, UDS mount, resources, securityContext,
 	// GatewayConfig volumeMounts, readiness probe); the secret-presence-driven parts
-	// (-configPath / -configBundlePath args and the legacy/bundle volumeMounts) are
+	// (-configBundlePath and its volumeMount) are
 	// added below, since they depend on which filter-config secrets exist at pod
 	// creation time and must stay out of the drift hash.
 	input := extProcContainerInput{gatewayConfig: gatewayConfig, needMCP: len(mcpRoutes.Items) > 0}
 	container := g.buildExtProcContainer(input)
 
-	// Prepend the config-routing flags so the arg order matches what extproc
-	// expects (configPath/bundlePath first, then base args).
-	configArgs := []string{}
-	if !hasBundleConfig { // for backward compatibility when upgrading from the previous version and the secret is created by the previous version
-		configArgs = append(configArgs, "-configPath", filterConfigFullPath)
-	}
-	if hasBundleConfig {
-		configArgs = append(configArgs, "-configBundlePath", filterConfigBundleMountPath)
-	}
-	if len(configArgs) > 0 {
-		container.Args = append(configArgs, container.Args...)
-	}
-
-	if hasLegacyConfig {
-		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-			Name:      filterConfigVolumeName,
-			MountPath: filterConfigMountPath,
-			ReadOnly:  true,
-		})
-	}
-
-	if hasBundleConfig {
-		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-			Name:      filterConfigBundleVolumeName,
-			MountPath: filterConfigBundleMountPath,
-			ReadOnly:  true,
-		})
-	}
+	container.Args = append([]string{"-configBundlePath", filterConfigBundleMountPath}, container.Args...)
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      filterConfigBundleVolumeName,
+		MountPath: filterConfigBundleMountPath,
+		ReadOnly:  true,
+	})
 
 	if g.extProcAsSideCar {
 		// RestartPolicy is set by the builder for the sidecar case.

--- a/internal/controller/gateway_mutator_test.go
+++ b/internal/controller/gateway_mutator_test.go
@@ -424,16 +424,6 @@ func TestGatewayMutator_mutatePod(t *testing.T) {
 					require.NoError(t, idxErr)
 					_, err = g.kube.CoreV1().Secrets("test-namespace").Create(t.Context(),
 						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Name: legacyFilterConfigSecretName(
-								gwName, gwNamespace,
-							), Namespace: "test-namespace"},
-							Data: map[string][]byte{
-								FilterConfigKeyInSecret: []byte("version: dev\n"),
-							},
-						}, metav1.CreateOptions{})
-					require.NoError(t, err)
-					_, err = g.kube.CoreV1().Secrets("test-namespace").Create(t.Context(),
-						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{Name: FilterConfigBundleIndexSecretName(
 								gwName, gwNamespace,
 							), Namespace: "test-namespace"},
@@ -468,7 +458,6 @@ func TestGatewayMutator_mutatePod(t *testing.T) {
 
 					require.Equal(t, "ai-gateway-extproc", extProcContainer.Name)
 					require.Contains(t, extProcContainer.Args, "-configBundlePath")
-					require.NotContains(t, extProcContainer.Args, "-configPath")
 					tt.extprocTest(t, extProcContainer)
 					if tt.podTest != nil {
 						tt.podTest(t, *pod)
@@ -531,56 +520,6 @@ func TestGatewayMutator_mutatePod_BundleOnly(t *testing.T) {
 
 	extProcContainer := pod.Spec.Containers[1]
 	require.Contains(t, extProcContainer.Args, "-configBundlePath")
-	require.NotContains(t, extProcContainer.Args, "-configPath")
-
-	legacySecretName := legacyFilterConfigSecretName(gwName, gwNamespace)
-	for i := range pod.Spec.Volumes {
-		v := pod.Spec.Volumes[i]
-		if v.Secret != nil {
-			require.NotEqual(t, legacySecretName, v.Secret.SecretName)
-		}
-	}
-}
-
-func TestGatewayMutator_mutatePod_LegacyOnly(t *testing.T) {
-	fakeClient := requireNewFakeClientWithIndexes(t)
-	fakeKube := fake2.NewClientset()
-	g := newTestGatewayMutator(fakeClient, fakeKube, nil, nil, nil, nil, "", "", "", false)
-
-	const gwName, gwNamespace = "test-gateway", "test-namespace"
-	err := fakeClient.Create(t.Context(), &aigv1b1.AIGatewayRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNamespace},
-		Spec: aigv1b1.AIGatewayRouteSpec{
-			ParentRefs: []gwapiv1a2.ParentReference{
-				{
-					Name:  gwName,
-					Kind:  ptr.To(gwapiv1a2.Kind("Gateway")),
-					Group: ptr.To(gwapiv1a2.Group("gateway.networking.k8s.io")),
-				},
-			},
-			Rules: []aigv1b1.AIGatewayRouteRule{{BackendRefs: []aigv1b1.AIGatewayRouteRuleBackendRef{{Name: "apple"}}}},
-		},
-	})
-	require.NoError(t, err)
-
-	_, err = g.kube.CoreV1().Secrets(gwNamespace).Create(t.Context(),
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: legacyFilterConfigSecretName(gwName, gwNamespace), Namespace: gwNamespace},
-			Data:       map[string][]byte{FilterConfigKeyInSecret: []byte("version: dev\n")},
-		}, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: gwNamespace},
-		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "envoy"}}},
-	}
-	err = g.mutatePod(t.Context(), pod, gwName, gwNamespace)
-	require.NoError(t, err)
-	require.Len(t, pod.Spec.Containers, 2)
-
-	extProcContainer := pod.Spec.Containers[1]
-	require.Contains(t, extProcContainer.Args, "-configPath")
-	require.NotContains(t, extProcContainer.Args, "-configBundlePath")
 }
 
 func strPtr(value string) *string {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/yaml"
 
 	aigv1b1 "github.com/envoyproxy/ai-gateway/api/v1beta1"
 	"github.com/envoyproxy/ai-gateway/internal/controller/rotators"
@@ -1712,11 +1711,7 @@ func TestGatewayController_reconcileFilterConfigSecret_ReadsCredentialsFromCache
 	require.True(t, effective)
 	require.Zero(t, credentialGets, "the credential must come from the cache, not the API server")
 
-	legacy, err := kube.CoreV1().Secrets(configNamespace).Get(t.Context(),
-		legacyFilterConfigSecretName("gw", gwNamespace), metav1.GetOptions{})
-	require.NoError(t, err)
-	var cfg filterapi.Config
-	require.NoError(t, yaml.Unmarshal([]byte(legacy.StringData[FilterConfigKeyInSecret]), &cfg))
+	cfg := requireFilterConfigFromBundle(t, kube, configNamespace, "gw", gwNamespace)
 	require.Len(t, cfg.Backends, len(backendNames))
 	for _, b := range cfg.Backends {
 		require.NotNil(t, b.Auth, b.Name)
@@ -3242,8 +3237,6 @@ func TestGatewayController_writeFilterConfigBundleShards(t *testing.T) {
 	_, err = kube.CoreV1().Secrets(namespace).Get(t.Context(),
 		filterConfigBundlePartSecretName(gatewayName, gatewayNamespace, maxFilterConfigBundleSlots-1), metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err))
-	_, legacyOK := indexSecret.StringData[FilterConfigKeyInSecret]
-	require.False(t, legacyOK)
 }
 
 func TestGatewayController_writeFilterConfigBundleShards_Overflow(t *testing.T) {

--- a/internal/controller/secret_name.go
+++ b/internal/controller/secret_name.go
@@ -47,7 +47,7 @@ func truncateAndAppendHash(base, hash string, maxLen int) string {
 // example: gateway-ns1-c6d39be275c7
 func FilterConfigBundleIndexSecretName(gwName, gwNamespace string) string {
 	rawIdentity := fmt.Sprintf("%s/%s", gwNamespace, gwName)
-	return truncateAndAppendHash(legacyFilterConfigSecretName(gwName, gwNamespace), shortStableHash(rawIdentity), k8sObjectNameMaxLen)
+	return truncateAndAppendHash(fmt.Sprintf("%s-%s", gwName, gwNamespace), shortStableHash(rawIdentity), k8sObjectNameMaxLen)
 }
 
 // example: gateway-ns1-c6d39be275c7-part-000
@@ -71,16 +71,4 @@ func filterConfigBundleVolumeName(gwName, gwNamespace string) string {
 	volumeBase := fmt.Sprintf("%s%s-%s", mutationNamePrefix, gwName, gwNamespace)
 	base := truncateAndAppendHash(volumeBase, shortStableHash(rawIdentity), k8sVolumeNameMaxLen-len(suffix))
 	return base + suffix
-}
-
-// example: gateway-ns1
-func legacyFilterConfigSecretName(gwName, gwNamespace string) string {
-	return fmt.Sprintf("%s-%s", gwName, gwNamespace)
-}
-
-// example: ai-gateway-gw-default-3d45476e8d68
-func legacyFilterConfigVolumeName(gwName, gwNamespace string) string {
-	rawIdentity := fmt.Sprintf("%s/%s", gwNamespace, gwName)
-	volumeBase := fmt.Sprintf("%s%s-%s", mutationNamePrefix, gwName, gwNamespace)
-	return truncateAndAppendHash(volumeBase, shortStableHash(rawIdentity), k8sVolumeNameMaxLen)
 }

--- a/internal/controller/secret_name_test.go
+++ b/internal/controller/secret_name_test.go
@@ -180,39 +180,3 @@ func TestFilterConfigBundleVolumeName(t *testing.T) {
 		})
 	}
 }
-
-func TestLegacyFilterConfigVolumeName(t *testing.T) {
-	tests := []struct {
-		name        string
-		gwName      string
-		gwNamespace string
-		expect      string
-	}{
-		{
-			name:        "short gateway name",
-			gwName:      "gw",
-			gwNamespace: "default",
-			expect:      "ai-gateway-gw-default-3d45476e8d68",
-		},
-		{
-			name:        "another identity",
-			gwName:      "gateway",
-			gwNamespace: "ns1",
-			expect:      "ai-gateway-gateway-ns1-c6d39be275c7",
-		},
-		{
-			name:        "long gateway name bounded with hash",
-			gwName:      strings.Repeat("gw", 50),
-			gwNamespace: "default",
-			expect:      "ai-gateway-gwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwg-aa314d0b5069",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := legacyFilterConfigVolumeName(tt.gwName, tt.gwNamespace)
-			require.Equal(t, tt.expect, got)
-			require.LessOrEqual(t, len(got), k8sVolumeNameMaxLen)
-		})
-	}
-}

--- a/internal/filterapi/watcher.go
+++ b/internal/filterapi/watcher.go
@@ -26,35 +26,12 @@ type ConfigReceiver interface {
 	LoadConfig(ctx context.Context, config *Config) error
 }
 
-// TODO(huabing): the legacy config watcher can be removed in the next release
-type configWatcher struct {
-	lastMod    time.Time
-	path       string
-	rcv        ConfigReceiver
-	l          *slog.Logger
-	versionStr string
-}
-
 type bundleConfigWatcher struct {
 	lastMod    time.Time
 	path       string
 	rcv        ConfigReceiver
 	l          *slog.Logger
 	versionStr string
-}
-
-// StartLegacyConfigWatcher starts a watcher for the given path and Receiver.
-// Periodically checks the file for changes and calls the Receiver's UpdateConfig method.
-func StartLegacyConfigWatcher(ctx context.Context, path string, rcv ConfigReceiver, l *slog.Logger, tick time.Duration) error {
-	cw := &configWatcher{rcv: rcv, l: l, path: path, versionStr: version.Parse()}
-
-	if err := cw.loadConfig(ctx); err != nil {
-		return fmt.Errorf("failed to load initial config: %w", err)
-	}
-
-	l.Info("start watching the config file", slog.String("path", path), slog.String("interval", tick.String()))
-	go cw.watch(ctx, tick)
-	return nil
 }
 
 // StartConfigBundleWatcher starts a watcher for the sharded bundle directory.
@@ -75,25 +52,6 @@ func StartConfigBundleWatcher(ctx context.Context, bundlePath string, rcv Config
 	return nil
 }
 
-// watch periodically checks the file for changes and calls the update method.
-func (cw *configWatcher) watch(ctx context.Context, tick time.Duration) {
-	ticker := time.NewTicker(tick)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			cw.l.Info("stop watching the config file", slog.String("path", cw.path))
-			return
-		case <-ticker.C:
-			perTickCtx, cancel := context.WithTimeout(ctx, tick)
-			if err := cw.loadConfig(perTickCtx); err != nil {
-				cw.l.Error("failed to update config", slog.String("error", err.Error()))
-			}
-			cancel()
-		}
-	}
-}
-
 func (cw *bundleConfigWatcher) watch(ctx context.Context, tick time.Duration) {
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
@@ -110,36 +68,6 @@ func (cw *bundleConfigWatcher) watch(ctx context.Context, tick time.Duration) {
 			cancel()
 		}
 	}
-}
-
-// loadConfig loads a new config from the given path and updates the ConfigReceiver by
-// calling the [ConfigReceiver.Load].
-func (cw *configWatcher) loadConfig(ctx context.Context) error {
-	var cfg *Config
-	stat, err := os.Stat(cw.path)
-	if err != nil {
-		return err
-	}
-
-	if stat.ModTime().Sub(cw.lastMod) <= 0 {
-		return nil
-	}
-	cw.l.Info("loading a new config", slog.String("path", cw.path))
-	cw.lastMod = stat.ModTime()
-	cfg, err = UnmarshalConfigYaml(cw.path)
-	if err != nil {
-		return err
-	}
-
-	if cfg.Version != cw.versionStr {
-		return fmt.Errorf(`config version mismatch: expected %q, got %q. Likely in the middle of rolling update`,
-			cw.versionStr, cfg.Version)
-	}
-
-	if err = cw.rcv.LoadConfig(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-	return nil
 }
 
 func (cw *bundleConfigWatcher) loadConfig(ctx context.Context) error {

--- a/internal/filterapi/watcher_test.go
+++ b/internal/filterapi/watcher_test.go
@@ -16,7 +16,6 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
@@ -51,11 +50,6 @@ func newTestLoggerWithBuffer() (*slog.Logger, internaltesting.OutBuffer) {
 	return logger, buf
 }
 
-func TestStartConfigWatcher(t *testing.T) {
-	// Virtualize time so sleeps take no time!
-	synctest.Test(t, testStartConfigWatcher)
-}
-
 func TestStartConfigBundleWatcher(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		tmpdir := t.TempDir()
@@ -79,7 +73,7 @@ func TestStartConfigBundleWatcher(t *testing.T) {
 		}
 
 		writeBundle("version: dev\nbackends:\n- name: first\n")
-		logger, _ := newTestLoggerWithBuffer()
+		logger, buf := newTestLoggerWithBuffer()
 		err := StartConfigBundleWatcher(t.Context(), bundleDir, rcv, logger, tickInterval)
 		require.NoError(t, err)
 
@@ -93,90 +87,15 @@ func TestStartConfigBundleWatcher(t *testing.T) {
 			cfg := rcv.getConfig()
 			return cfg != nil && len(cfg.Backends) == 1 && cfg.Backends[0].Name == "second"
 		}, time.Second, tickInterval)
+		secondCfg := rcv.getConfig()
+
+		writeBundle("version: some-new-version\nbackends:\n- name: rejected\n")
+		time.Sleep(2 * tickInterval)
+		require.Equal(t, secondCfg, rcv.getConfig(), "config should not change after a version mismatch")
+		require.Eventually(t, func() bool {
+			return strings.Contains(buf.String(), "failed to update bundled config")
+		}, time.Second, tickInterval, buf.String())
 	})
-}
-
-func testStartConfigWatcher(t *testing.T) {
-	t.Helper()
-
-	tmpdir := t.TempDir()
-	path := tmpdir + "/config.yaml"
-	rcv := &mockReceiver{}
-
-	// Create the initial config file.
-	const tickInterval = time.Millisecond
-	cfg := `
-version: dev
-schema:
-  name: OpenAI
-backends:
-- name: kserve
-  weight: 1
-  schema:
-    name: OpenAI
-- name: awsbedrock
-  weight: 10
-  schema:
-    name: AWSBedrock
-- name: openai
-  schema:
-    name: OpenAI
-`
-	requireAtomicWriteFile(t, tickInterval, path, []byte(cfg), 0o600)
-
-	logger, buf := newTestLoggerWithBuffer()
-	err := StartLegacyConfigWatcher(t.Context(), path, rcv, logger, tickInterval)
-	require.NoError(t, err)
-
-	// Initial loading should have happened.
-	require.Eventually(t, func() bool {
-		return !cmp.Equal(rcv.getConfig(), nil)
-	}, 1*time.Second, tickInterval)
-	firstCfg := rcv.getConfig()
-	require.NotNil(t, firstCfg)
-	require.Len(t, firstCfg.Backends, 3, buf.String())
-	require.Equal(t, "kserve", firstCfg.Backends[0].Name)
-	require.Equal(t, "awsbedrock", firstCfg.Backends[1].Name)
-	require.Equal(t, "openai", firstCfg.Backends[2].Name)
-
-	// Update the config file.
-	cfg = `
-version: dev
-schema:
-  name: OpenAI
-backends:
-- name: openai
-  schema:
-    name: OpenAI
-`
-
-	requireAtomicWriteFile(t, tickInterval, path, []byte(cfg), 0o600)
-
-	// Verify the config has been updated.
-	require.Eventually(t, func() bool {
-		return !cmp.Equal(rcv.getConfig(), firstCfg)
-	}, 1*time.Second, tickInterval)
-	secondCfg := rcv.getConfig()
-	require.NotNil(t, secondCfg)
-	require.Len(t, secondCfg.Backends, 1, buf.String())
-	require.Equal(t, "openai", secondCfg.Backends[0].Name)
-
-	// Update the config file with the different version, which shouldn't be loaded.
-	cfg = `
-version: some-new-version
-foo: bar
-`
-	requireAtomicWriteFile(t, tickInterval, path, []byte(cfg), 0o600)
-
-	// Verify the config has NOT been updated due to the error.
-	time.Sleep(2 * tickInterval)
-	thirdCfg := rcv.getConfig()
-	require.Equal(t, secondCfg, thirdCfg, "config should not have changed on invalid update")
-
-	// Verify the buffer contains the error message.
-	require.Eventually(t, func() bool {
-		return strings.Contains(buf.String(), "failed to update config")
-	}, 1*time.Second, tickInterval, buf.String())
 }
 
 // requireAtomicWriteFile creates a temporary file, writes the data to it, and then renames it to the final filename.

--- a/tests/data-plane/vcr/docker-compose-otel.yaml
+++ b/tests/data-plane/vcr/docker-compose-otel.yaml
@@ -41,6 +41,7 @@ services:
     volumes:
       - extproc-target:/app
       - ./extproc.yaml:/etc/extproc/config.yaml:ro
+      - ./extproc-index.yaml:/etc/extproc/index.yaml:ro
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:4317
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
@@ -50,7 +51,7 @@ services:
     # - 1063: gRPC service
     # - 1064: admin server (/metrics and /health endpoints)
     working_dir: /app
-    command: ["./extproc", "-configPath", "/etc/extproc/config.yaml"]
+    command: ["./extproc", "-configBundlePath", "/etc/extproc"]
 
   ollama-pull:
     image: alpine/ollama

--- a/tests/data-plane/vcr/docker-compose.yaml
+++ b/tests/data-plane/vcr/docker-compose.yaml
@@ -31,11 +31,12 @@ services:
     volumes:
       - extproc-target:/app
       - ./extproc.yaml:/etc/extproc/config.yaml:ro
+      - ./extproc-index.yaml:/etc/extproc/index.yaml:ro
     # ExtProc ports (internal to Docker network, consumed by Envoy):
     # - 1063: gRPC service
     # - 1064: admin server (/metrics and /health endpoints)
     working_dir: /app
-    command: ["./extproc", "-configPath", "/etc/extproc/config.yaml"]
+    command: ["./extproc", "-configBundlePath", "/etc/extproc"]
 
   ollama-pull:
     image: alpine/ollama

--- a/tests/data-plane/vcr/extproc-index.yaml
+++ b/tests/data-plane/vcr/extproc-index.yaml
@@ -1,0 +1,10 @@
+# Copyright Envoy AI Gateway Authors
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+checksum: b2aaa5fcd4a305b33fccd23d56b57b5272aedb7ef6cd062112e48ee4c36b4ddb
+parts:
+  - name: config
+    path: config.yaml
+    sizeBytes: 1000

--- a/tests/e2e-upgrade/upgrade_test.go
+++ b/tests/e2e-upgrade/upgrade_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/envoyproxy/ai-gateway/internal/controller"
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/tests/internal/e2elib"
 	"github.com/envoyproxy/ai-gateway/tests/internal/testupstreamlib"
 )
@@ -304,18 +306,31 @@ func makeRequest(t *testing.T, ipAddress string, phase string) error {
 	return nil
 }
 
-// breakFilterConfig modifies the filter config secret to contain an invalid configuration, which should be
+// breakFilterConfig modifies a filter config bundle part to contain an invalid configuration, which should be
 // ignored by the running pods.
 func breakFilterConfig(t *testing.T) {
+	indexSecretName := controller.FilterConfigBundleIndexSecretName("upgrade-test", "default")
+	getIndexCmd := e2elib.Kubectl(t.Context(), "get", "secret", indexSecretName,
+		"-n", e2elib.EnvoyGatewayNamespace, "-o", "jsonpath={.data.index\\.yaml}")
+	getIndexCmd.Stdout = nil
+	getIndexCmd.Stderr = nil
+	indexEncoded, err := getIndexCmd.Output()
+	require.NoError(t, err, "failed to get filter config bundle index")
+	indexRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(indexEncoded)))
+	require.NoError(t, err, "failed to decode filter config bundle index")
+	index, err := filterapi.UnmarshalConfigBundleIndex(indexRaw)
+	require.NoError(t, err, "failed to unmarshal filter config bundle index")
+	require.NotEmpty(t, index.Parts, "filter config bundle has no parts")
+
 	newEncodedConfig := base64.StdEncoding.EncodeToString([]byte(`
 version: some-nonexistent-version # The version mismatch should cause the filter to ignore this config.
 foo: bar
 `))
 
-	// Patch the secret with the broken config.
-	patch := fmt.Sprintf(`{"data":{"filter-config.yaml":"%s"}}`, newEncodedConfig)
+	// Patch the first part without changing the index checksum. The watcher must reject the corrupt bundle.
+	patch := fmt.Sprintf(`{"data":{"chunk":"%s"}}`, newEncodedConfig)
 	patchCmd := e2elib.Kubectl(t.Context(), "patch", "secret",
-		"upgrade-test-default", // The name and namespace of the Gateway in testdata/manifest.yaml.
+		index.Parts[0].Name,
 		"-n", e2elib.EnvoyGatewayNamespace, "--type=merge", "-p", patch)
 	patchCmd.Stdout = nil
 	patchCmd.Stderr = nil

--- a/tests/e2e/large_config_test.go
+++ b/tests/e2e/large_config_test.go
@@ -7,9 +7,7 @@ package e2e
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -20,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
+	"github.com/envoyproxy/ai-gateway/internal/controller"
 	"github.com/envoyproxy/ai-gateway/tests/internal/e2elib"
 )
 
@@ -53,8 +52,7 @@ func TestLargeConfigIsSharded(t *testing.T) {
 	fwd := e2elib.RequireNewHTTPPortForwarder(t, e2elib.EnvoyGatewayNamespace, egSelector, e2elib.EnvoyGatewayDefaultServicePort)
 	defer fwd.Kill()
 
-	baseLegacyName := fmt.Sprintf("%s-%s", gatewayName, namespace)
-	indexSecretName := fmt.Sprintf("%s-%s", baseLegacyName, shortStableHash(fmt.Sprintf("%s/%s", namespace, gatewayName)))
+	indexSecretName := controller.FilterConfigBundleIndexSecretName(gatewayName, namespace)
 	require.Eventually(t, func() bool {
 		partCount, err := readIndexPartCount(t.Context(), indexSecretName)
 		if err != nil {
@@ -75,14 +73,6 @@ func TestLargeConfigIsSharded(t *testing.T) {
 		t.Logf("config bundle successfully split into %d secrets", partCount)
 		return true
 	}, 90*time.Second, 2*time.Second, "bundle did not split into multiple secrets")
-
-	require.Eventually(t, func() bool {
-		if err := requireSecretExists(t.Context(), baseLegacyName); err != nil {
-			t.Logf("legacy secret %s missing: %v", baseLegacyName, err)
-			return false
-		}
-		return true
-	}, 90*time.Second, 2*time.Second, "legacy filter config secret was not created")
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "large-config-mcp-client", Version: "0.1.0"}, nil)
 	testMCPRouteTools(
@@ -237,11 +227,6 @@ spec:
 	}
 
 	return strings.TrimSpace(b.String())
-}
-
-func shortStableHash(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:6])
 }
 
 func readIndexPartCount(ctx context.Context, secretName string) (int, error) {

--- a/tests/e2e/testupstream_test.go
+++ b/tests/e2e/testupstream_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/openai/openai-go/option"
 	"github.com/stretchr/testify/require"
 
+	"github.com/envoyproxy/ai-gateway/internal/controller"
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
 	"github.com/envoyproxy/ai-gateway/tests/internal/e2elib"
 	"github.com/envoyproxy/ai-gateway/tests/internal/testupstreamlib"
@@ -254,18 +256,18 @@ func TestWithTestUpstream(t *testing.T) {
 	})
 
 	t.Run("secret update propagation", func(t *testing.T) {
-		const secretName = "translation-testupstream-default"
-		// Verify that the apiKey still exists in the filter-config.yaml secret with the existing value.
+		indexSecretName := controller.FilterConfigBundleIndexSecretName("translation-testupstream", "default")
+		// Verify that the apiKey still exists in the filter config bundle with the existing value.
 		internaltesting.RequireEventuallyNoError(t, func() error {
-			secret, err := extractFilterConfigFromSecret(t.Context(), secretName)
+			config, err := extractFilterConfigFromBundle(t.Context(), indexSecretName)
 			if err != nil {
 				return err
 			}
-			if !strings.Contains(secret, dummyToken) {
-				return fmt.Errorf("filter-config.yaml does not contain %s", dummyToken)
+			if !strings.Contains(config, dummyToken) {
+				return fmt.Errorf("filter config bundle does not contain %s", dummyToken)
 			}
 			return nil
-		}, 10*time.Second, 1*time.Second, "initial secret not found in filter-config.yaml")
+		}, 10*time.Second, 1*time.Second, "initial filter config bundle not found")
 
 		// Update the secret used by the BackendSecurityPolicy to have a new apiKey value.
 		const updatedKey = "pikachu"
@@ -279,36 +281,59 @@ stringData:
   apiKey: "%s"`, updatedKey)
 		require.NoError(t, e2elib.KubectlApplyManifestStdin(t.Context(), secretUpdated))
 
-		// Verify that the new apiKey is propagated to the filter-config.yaml secret.
+		// Verify that the new apiKey is propagated to the filter config bundle.
 		internaltesting.RequireEventuallyNoError(t, func() error {
-			secret, err := extractFilterConfigFromSecret(t.Context(), secretName)
+			config, err := extractFilterConfigFromBundle(t.Context(), indexSecretName)
 			if err != nil {
 				return err
 			}
-			if !strings.Contains(secret, updatedKey) {
-				return fmt.Errorf("filter-config.yaml does not contain %s", updatedKey)
+			if !strings.Contains(config, updatedKey) {
+				return fmt.Errorf("filter config bundle does not contain %s", updatedKey)
 			}
 			return nil
-		}, 20*time.Second, 1*time.Second, "updated secret not propagated to filter-config.yaml")
+		}, 20*time.Second, 1*time.Second, "updated secret not propagated to filter config bundle")
 	})
 }
 
-// extractFilterConfigFromSecret extracts the filter-config.yaml content from the given secret name.
-func extractFilterConfigFromSecret(ctx context.Context, name string) (string, error) {
+// extractFilterConfigFromBundle reassembles the filter config from its Kubernetes Secrets.
+func extractFilterConfigFromBundle(ctx context.Context, indexSecretName string) (string, error) {
 	ctrl := e2elib.Kubectl(ctx, "get", "secrets", "-n", e2elib.EnvoyGatewayNamespace,
-		name, "-o",
-		`jsonpath='{.data.filter-config\.yaml}'`)
+		indexSecretName, "-o", `jsonpath='{.data.index\.yaml}'`)
 	ctrl.Stderr = nil
 	ctrl.Stdout = nil
 	output, err := ctrl.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get filter-config.yaml from secret: %w", err)
+		return "", fmt.Errorf("failed to get filter config bundle index: %w", err)
 	}
-	decoded, err := base64.StdEncoding.DecodeString(strings.Trim(string(output), "'"))
+	indexRaw, err := base64.StdEncoding.DecodeString(strings.Trim(string(output), "'"))
 	if err != nil {
-		return "", fmt.Errorf("failed to base64 decode filter-config.yaml: %w", err)
+		return "", fmt.Errorf("failed to decode filter config bundle index: %w", err)
 	}
-	return string(decoded), nil
+	index, err := filterapi.UnmarshalConfigBundleIndex(indexRaw)
+	if err != nil {
+		return "", err
+	}
+
+	var raw []byte
+	for _, part := range index.Parts {
+		ctrl = e2elib.Kubectl(ctx, "get", "secrets", "-n", e2elib.EnvoyGatewayNamespace,
+			part.Name, "-o", "jsonpath='{.data.chunk}'")
+		ctrl.Stderr = nil
+		ctrl.Stdout = nil
+		output, err = ctrl.Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to get filter config bundle part %s: %w", part.Name, err)
+		}
+		partRaw, decodeErr := base64.StdEncoding.DecodeString(strings.Trim(string(output), "'"))
+		if decodeErr != nil {
+			return "", fmt.Errorf("failed to decode filter config bundle part %s: %w", part.Name, decodeErr)
+		}
+		raw = append(raw, partRaw...)
+	}
+	if got := filterapi.ConfigBundleChecksum(raw); got != index.Checksum {
+		return "", fmt.Errorf("filter config bundle checksum mismatch: expected %s, got %s", index.Checksum, got)
+	}
+	return string(raw), nil
 }
 
 // TestPromptCacheTranslationMatrix proves OpenAI-shim cache_control markers survive

--- a/tests/internal/dataplaneenv/dataplaneenv.go
+++ b/tests/internal/dataplaneenv/dataplaneenv.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/envoyproxy/ai-gateway/cmd/extproc/mainlib"
+	"github.com/envoyproxy/ai-gateway/internal/filterapi"
 	"github.com/envoyproxy/ai-gateway/internal/pprof"
 	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
 	testsinternal "github.com/envoyproxy/ai-gateway/tests/internal"
@@ -289,11 +290,21 @@ func requireEnvoy(t testing.TB,
 
 // requireExtProc starts the external processor with the given configuration.
 func requireExtProc(t testing.TB, out io.Writer, config string, env []string, extraArgs []string, port, adminPort, mcpPort int, mcpWriteTimeout time.Duration, inProcess bool) {
-	configPath := t.TempDir() + "/extproc-config.yaml"
-	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+	configRaw := []byte(config)
+	configBundlePath := filepath.Join(t.TempDir(), "extproc-config-bundle")
+	part := filterapi.ConfigBundlePart{Name: "config", Path: filterapi.ConfigBundlePartPath(0), SizeBytes: len(configRaw)}
+	partPath := filepath.Join(configBundlePath, filepath.FromSlash(part.Path))
+	require.NoError(t, os.MkdirAll(filepath.Dir(partPath), 0o700))
+	require.NoError(t, os.WriteFile(partPath, configRaw, 0o600))
+	indexRaw, err := filterapi.MarshalConfigBundleIndex(&filterapi.ConfigBundleIndex{
+		Checksum: filterapi.ConfigBundleChecksum(configRaw),
+		Parts:    []filterapi.ConfigBundlePart{part},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configBundlePath, filterapi.ConfigBundleIndexFileName), indexRaw, 0o600))
 
 	args := []string{
-		"-configPath", configPath,
+		"-configBundlePath", configBundlePath,
 		"-extProcAddr", fmt.Sprintf(":%d", port),
 		"-adminPort", strconv.Itoa(adminPort),
 		"-mcpAddr", ":" + strconv.Itoa(mcpPort),


### PR DESCRIPTION
**Description**

This removes the legacy single-file extproc config watcher now that the config-bundle path has shipped for a release. The controller no longer creates or mounts legacy filter-config Secrets, and extproc now requires `-configBundlePath`.

Standalone `aigw`, data-plane helpers, Docker Compose VCR configs, snapshots, and end-to-end coverage now use bundles. Tests also verify that `-configPath` is rejected and bundle version or checksum failures do not replace the active config.

AI assistance was used to implement, review, and validate this change; I reviewed the patch and own the final result.

**Related Issues/PRs (if applicable)**

Related PR: #1865

**Special notes for reviewers (if applicable)**

This removes the deprecated `-configPath` flag. Deployments invoking extproc directly must provide `-configBundlePath`.

Validated with:

- `golangci-lint run --modules-download-mode=mod --build-tags=test_crdcel,test_controller,test_extproc,test_e2e ./...`
- `make test` package sweep, followed by successful isolated reruns of the proxy-sensitive Azure token-provider tests and a timing-sensitive loopback streaming test
- e2e and e2e-upgrade package compilation
- `git diff --check`