### PR TITLE
fix: prevent index out of range panic in maybeModifyCluster's combined-cluster path

### DIFF
--- a/internal/extensionserver/extensionserver_test.go
+++ b/internal/extensionserver/extensionserver_test.go
@@ -455,6 +455,145 @@ func Test_maybeModifyCluster(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test: httpRouteRule.BackendRefs (read fresh from
+			// the AIGatewayRoute) and cluster.LoadAssignment (translated by
+			// Envoy Gateway) can be a revision apart, so LoadAssignment.
+			// Endpoints can be shorter than the rule's non-zero-weight
+			// BackendRefs. maybeModifyCluster must log and stop, not index
+			// out of range - this reproduces the "index out of range"
+			// panic the guard prevents.
+			name: "fewer LoadAssignment endpoints than non-zero-weight backendRefs logs and stops",
+			cluster: &clusterv3.Cluster{
+				Name: "httproute/ns/myroute/rule/0",
+				LoadAssignment: &endpointv3.ClusterLoadAssignment{
+					Endpoints: []*endpointv3.LocalityLbEndpoints{
+						{
+							LbEndpoints: []*endpointv3.LbEndpoint{
+								{HostIdentifier: &endpointv3.LbEndpoint_Endpoint{Endpoint: &endpointv3.Endpoint{
+									Address: &corev3.Address{Address: &corev3.Address_SocketAddress{
+										SocketAddress: &corev3.SocketAddress{Address: "aaa.bedrock-runtime.us-east-1.amazonaws.com"},
+									}},
+								}}},
+							},
+						},
+						// Only one LocalityLbEndpoints entry, even though the rule
+						// has two non-zero-weight backendRefs ("aaa", "bbb") -
+						// "bbb" has no entry here, as when the cluster was
+						// translated from an earlier revision of the rule that
+						// had one backendRef.
+					},
+				},
+			},
+			expectedLog: "msg=\"cluster LoadAssignment has fewer endpoint groups than non-zero-weight backendRefs\" logger=envoy-gateway-extension-server cluster_name=httproute/ns/myroute/rule/0 backend_index=2 load_assignment_endpoints=1\n",
+			expected: &clusterv3.Cluster{
+				Name: "httproute/ns/myroute/rule/0",
+				LoadAssignment: &endpointv3.ClusterLoadAssignment{
+					Endpoints: []*endpointv3.LocalityLbEndpoints{
+						{
+							// "aaa" still gets its metadata stamped - only the
+							// backend(s) past the LoadAssignment's length are
+							// skipped, not the whole cluster.
+							Priority: 0,
+							LbEndpoints: []*endpointv3.LbEndpoint{
+								{
+									HostIdentifier: &endpointv3.LbEndpoint_Endpoint{Endpoint: &endpointv3.Endpoint{
+										Address: &corev3.Address{Address: &corev3.Address_SocketAddress{
+											SocketAddress: &corev3.SocketAddress{Address: "aaa.bedrock-runtime.us-east-1.amazonaws.com"},
+										}},
+									}},
+									Metadata: &corev3.Metadata{
+										FilterMetadata: map[string]*structpb.Struct{
+											internalapi.InternalEndpointMetadataNamespace: {
+												Fields: map[string]*structpb.Value{
+													internalapi.InternalMetadataBackendNameKey: structpb.NewStringValue(
+														internalapi.PerRouteRuleRefBackendName("ns", "aaa", "myroute", 0, 0),
+													),
+													internalapi.InternalMetadataUpstreamHostKey: structpb.NewStringValue(
+														"aaa.bedrock-runtime.us-east-1.amazonaws.com",
+													),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TypedExtensionProtocolOptions: map[string]*anypb.Any{
+					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustToAny(t, &httpv3.HttpProtocolOptions{
+						UpstreamProtocolOptions: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_{ExplicitHttpConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig{
+							ProtocolConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+						}},
+						HttpFilters: []*httpconnectionmanagerv3.HttpFilter{
+							{
+								Name: aiGatewayExtProcName,
+								ConfigType: &httpconnectionmanagerv3.HttpFilter_TypedConfig{
+									TypedConfig: mustToAny(t, &extprocv3.ExternalProcessor{
+										MetadataOptions: &extprocv3.MetadataOptions{
+											ReceivingNamespaces: &extprocv3.MetadataOptions_MetadataNamespaces{
+												Untyped: []string{aigv1b1.AIGatewayFilterMetadataNamespace},
+											},
+										},
+										AllowModeOverride: true,
+										RequestAttributes: []string{
+											internalapi.XDSUpstreamHostMetadataBackendNamePath,
+											internalapi.XDSClusterMetadataBackendNamePath,
+											internalapi.XDSUpstreamHostMetadataUpstreamHostPath,
+											internalapi.XDSRouteMetadataRouteNamePath,
+										},
+										ProcessingMode: &extprocv3.ProcessingMode{
+											RequestHeaderMode:  extprocv3.ProcessingMode_SEND,
+											RequestBodyMode:    extprocv3.ProcessingMode_NONE,
+											ResponseHeaderMode: extprocv3.ProcessingMode_SKIP,
+											ResponseBodyMode:   extprocv3.ProcessingMode_NONE,
+										},
+										MessageTimeout: durationpb.New(10 * time.Second),
+										GrpcService: &corev3.GrpcService{
+											TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+												EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{
+													ClusterName: extProcUDSClusterName,
+												},
+											},
+											Timeout: durationpb.New(30 * time.Second),
+										},
+									}),
+								},
+							},
+							{
+								Name: "envoy.filters.http.header_mutation",
+								ConfigType: &httpconnectionmanagerv3.HttpFilter_TypedConfig{
+									TypedConfig: mustToAny(t, &header_mutationv3.HeaderMutation{
+										Mutations: &header_mutationv3.Mutations{
+											RequestMutations: []*mutation_rulesv3.HeaderMutation{
+												{
+													Action: &mutation_rulesv3.HeaderMutation_Append{
+														Append: &corev3.HeaderValueOption{
+															AppendAction: corev3.HeaderValueOption_ADD_IF_ABSENT,
+															Header: &corev3.HeaderValue{
+																Key:   "content-length",
+																Value: `%DYNAMIC_METADATA(` + aigv1b1.AIGatewayFilterMetadataNamespace + `:content_length)%`,
+															},
+														},
+													},
+												},
+											},
+										},
+									}),
+								},
+							},
+							{
+								Name: "envoy.filters.http.upstream_codec",
+								ConfigType: &httpconnectionmanagerv3.HttpFilter_TypedConfig{
+									TypedConfig: mustToAny(t, &upstream_codecv3.UpstreamCodec{}),
+								},
+							},
+						},
+					}),
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer

--- a/internal/extensionserver/post_translate_modify.go
+++ b/internal/extensionserver/post_translate_modify.go
@@ -378,6 +378,26 @@ func (s *Server) maybeModifyCluster(ctx context.Context, cluster *clusterv3.Clus
 				if backendRef.Weight != nil && *backendRef.Weight == 0 {
 					continue
 				}
+				// httpRouteRule.BackendRefs comes from a fresh
+				// s.k8sClient.Get(&aigwRoute); cluster.LoadAssignment is
+				// whatever Envoy Gateway translated for this cluster. The two
+				// can be a revision apart, so the rule can carry more
+				// non-zero-weight BackendRefs than the cluster has endpoint
+				// groups (e.g. an AIGatewayRoute gained a BackendRef whose
+				// AIServiceBackend does not resolve yet, so the generated
+				// HTTPRoute - and the cluster - stay a revision behind).
+				// lbEndpointIndex only increases, so once it is out of range
+				// every remaining backendRef is too; stop rather than index out
+				// of bounds. The rule and backendRef indices are already
+				// guarded the same way earlier in this function. The unmatched
+				// backend(s) get their endpoint metadata stamped on a later
+				// reconcile once the counts agree.
+				if lbEndpointIndex >= len(cluster.LoadAssignment.Endpoints) {
+					s.log.Info("cluster LoadAssignment has fewer endpoint groups than non-zero-weight backendRefs",
+						"cluster_name", cluster.Name, "backend_index", i,
+						"load_assignment_endpoints", len(cluster.LoadAssignment.Endpoints))
+					break
+				}
 				endpoints := cluster.LoadAssignment.Endpoints[lbEndpointIndex]
 				lbEndpointIndex++
 				name := backendRef.Name


### PR DESCRIPTION
**Description**

We run a multi-tenant LLM gateway with Envoy AI Gateway as the inference data
plane. Each model is served through a priority-failover pool of upstream
providers (Bedrock, Vertex, OpenRouter, direct OpenAI/Anthropic), and our
control plane syncs those pools from a database into `AIGatewayRoute` /
`AIServiceBackend` CRDs. A race in that sync briefly left an `AIGatewayRoute`
with a `backendRef` whose `AIServiceBackend` had not been created yet, and
`ai-gateway-controller` crash-looped on it for 4+ days (84 restarts) before we
caught it - while it was down no config change propagated to any Gateway using
the extension, and the data plane served intermittent `unknown backend` on live
traffic as routes went stale. We fixed our sync, but a single-replica
leader-elected controller should not be put into a permanent crash loop by a
transiently-inconsistent-but-schema-valid `AIGatewayRoute`.

`maybeModifyCluster`'s `default:` branch - the path for a rule whose
priority-ranked `backendRefs` share one combined cluster - loops
`httpRouteRule.BackendRefs` and indexes
`cluster.LoadAssignment.Endpoints[lbEndpointIndex]` with no bounds check.
`httpRouteRule.BackendRefs` is read from a fresh `s.k8sClient.Get(&aigwRoute)`;
`cluster.LoadAssignment` is whatever Envoy Gateway translated for the cluster.
The two can be a revision apart, so the rule can carry more non-zero-weight
`backendRefs` than the cluster has endpoint groups - for example when the
`AIGatewayRoute` gains a `backendRef` whose `AIServiceBackend` does not resolve,
so `newHTTPRoute` fails and the generated `HTTPRoute` (and the translated
cluster) stay a revision behind. When the counts disagree the loop reads past
the end and panics:

```
panic: runtime error: index out of range [2] with length 2
    internal/extensionserver/post_translate_modify.go   maybeModifyCluster
    internal/extensionserver/post_translate_modify.go   PostTranslateModify
    github.com/envoyproxy/gateway  proto/extension/service_grpc.pb.go
```

There is no gRPC recovery interceptor and the extension server runs in the
controller process, so the panic crashes `ai-gateway-controller`; the input is
stable, so it is `CrashLoopBackOff`.

This same function already guards this exact class of skew twice, at the top -
`httpRouteRuleIndex >= len(aigwRoute.Spec.Rules)` and
`clusterName.backendRefIndex >= len(httpRouteRule.BackendRefs)`, both
`s.log.Info(...)` then `return nil`. The `default:` branch's endpoint index is
the third occurrence of the same pattern, without the check.

**Fix**

When `lbEndpointIndex` reaches `len(cluster.LoadAssignment.Endpoints)`, log at
Info and `break` out of the `backendRef` loop instead of indexing past the end.
`lbEndpointIndex` only increases, so every remaining `backendRef` is out of
range too. `break` rather than `return nil` so the endpoint groups that do line
up still get stamped and the ext_proc filter wiring after the switch still
runs. The unmatched backends get their endpoint metadata stamped on a later
reconcile once Envoy Gateway has re-translated and the counts agree.

**Testing**

Added a regression case to `Test_maybeModifyCluster`: a combined cluster
(`httproute/ns/myroute/rule/0`) with one `LocalityLbEndpoints` entry for a rule
with two non-zero-weight `backendRefs`. Against the unpatched code it reproduces
the panic (`index out of range [1] with length 1` at `post_translate_modify.go`);
with the fix it passes. `go test`, `go vet`, and `golangci-lint run` are clean
on `internal/extensionserver`.

Also reproduced end to end on kind (ai-gateway-controller v1.1.0, Envoy Gateway
v1.8.1): two plain `fqdn:` `AIServiceBackends` in one rule produce one combined
cluster with two endpoint groups; adding a third `backendRef` whose
`AIServiceBackend` is not created leaves the generated `HTTPRoute` frozen at two
`backendRefs` while the `AIGatewayRoute` has three; the next translation panics
at `post_translate_modify.go` and the controller goes to `CrashLoopBackOff`
(exit code 2) within seconds. Removing the dangling `backendRef` recovers it.

**Special notes for reviewers (if applicable)**

There is no purely-static manifest that reproduces this: anything that makes a
backend contribute zero endpoints (a mixed `ip:`/`fqdn:` rule, an invalid
backend, a zero-endpoint backend) trips `RouteDestination.NeedsClusterPerSetting`
and is split into per-`backend/N` clusters, which take the already-guarded
`case` branch. The `default:` branch only runs on an internally consistent
combined cluster, so the shortfall is always the revision skew between the two
reads. The regression test constructs that state directly.

An earlier revision of this PR attributed the mismatch to an unreachable
static-IP `Backend` alongside FQDN siblings in one rule; that configuration is
split per-backend by `NeedsClusterPerSetting` before this branch runs, so it is
not the trigger. The revision-skew description above is the accurate one.

**Related Issues/PRs (if applicable)**

Fixes #2610

**AI Usage**

Root-caused and fixed with the assistance of Claude Code: analysis of the live
crash-loop, reading `main` and `v1.1.0` to confirm the bug and locate the line,
writing the guard and the regression test (reproduces the panic against the
unpatched code, passes with the fix), an end-to-end kind reproduction, and
running `go build` / `go vet` / `go test` / `golangci-lint` on the changed
package. I have reviewed the change and take ownership of it.
