### PR TITLE
fix: treat an empty translator header value as a header removal

### DIFF
--- a/internal/extproc/util.go
+++ b/internal/extproc/util.go
@@ -101,6 +101,16 @@ func mutationsFromTranslationResult(newHeaders []internalapi.Header, newBody []b
 ) {
 	header = &extprocv3.HeaderMutation{}
 	for _, h := range newHeaders {
+		if h.Value() == "" {
+			// An empty value means "remove this header". A translator emits this when a
+			// header the client sent has no valid value left for the selected backend
+			// (e.g. an allowlist filter strips every anthropic-beta flag, so
+			// filterHeaderValues returns changed==true with an empty result). Setting the
+			// header to the empty string would forward a present-but-empty header instead
+			// of removing it, which is not what the translator asked for.
+			header.RemoveHeaders = append(header.RemoveHeaders, h.Key())
+			continue
+		}
 		header.SetHeaders = append(header.SetHeaders, &corev3.HeaderValueOption{
 			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 			Header: &corev3.HeaderValue{

--- a/internal/extproc/util_test.go
+++ b/internal/extproc/util_test.go
@@ -14,6 +14,8 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
 )
 
 func TestIsGoodStatusCode(t *testing.T) {
@@ -256,5 +258,54 @@ func TestHeaderMutationCarrier(t *testing.T) {
 				},
 			},
 		}, mutation)
+	})
+}
+
+func TestMutationsFromTranslationResult(t *testing.T) {
+	t.Run("a non-empty header is set with its raw value", func(t *testing.T) {
+		header, body := mutationsFromTranslationResult([]internalapi.Header{
+			{":path", "/v1/models/x:rawPredict"},
+		}, nil)
+		require.NotNil(t, header)
+		require.Len(t, header.SetHeaders, 1)
+		require.Equal(t, ":path", header.SetHeaders[0].Header.Key)
+		require.Equal(t, []byte("/v1/models/x:rawPredict"), header.SetHeaders[0].Header.RawValue)
+		require.Equal(t, corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD, header.SetHeaders[0].AppendAction)
+		require.Empty(t, header.RemoveHeaders)
+		require.Nil(t, body, "a nil body must not produce a body mutation")
+	})
+
+	t.Run("an empty-valued header is removed, not set", func(t *testing.T) {
+		// A translator emits Header{name, ""} to request removal, e.g. when an allowlist
+		// filter strips every value of a multi-valued header (filterHeaderValues returns
+		// changed==true with an empty result). It must become a RemoveHeaders entry, never
+		// a present-but-empty SetHeaders entry.
+		header, _ := mutationsFromTranslationResult([]internalapi.Header{
+			{"anthropic-beta", ""},
+		}, nil)
+		require.NotNil(t, header)
+		require.Empty(t, header.SetHeaders, "an empty value must never be forwarded as a set header")
+		require.Equal(t, []string{"anthropic-beta"}, header.RemoveHeaders)
+	})
+
+	t.Run("set and remove are split within one result", func(t *testing.T) {
+		header, _ := mutationsFromTranslationResult([]internalapi.Header{
+			{"content-length", "42"},
+			{"anthropic-beta", ""},
+			{":path", "/v1/x"},
+		}, nil)
+		require.NotNil(t, header)
+		setKeys := make([]string, 0, len(header.SetHeaders))
+		for _, h := range header.SetHeaders {
+			setKeys = append(setKeys, h.Header.Key)
+		}
+		require.ElementsMatch(t, []string{"content-length", ":path"}, setKeys)
+		require.Equal(t, []string{"anthropic-beta"}, header.RemoveHeaders)
+	})
+
+	t.Run("an empty but non-nil body is a body mutation", func(t *testing.T) {
+		_, body := mutationsFromTranslationResult(nil, []byte{})
+		require.NotNil(t, body, "an empty (non-nil) body clears the body")
+		require.Equal(t, []byte{}, body.GetBody())
 	})
 }


### PR DESCRIPTION
**Description**

`mutationsFromTranslationResult` (`internal/extproc/util.go`) turns every `internalapi.Header` a translator returns into a `SetHeaders` entry, including ones whose value is the empty string. That forwards a present-but-empty header to the upstream instead of removing it.

This is reachable today through the `anthropic-beta` allowlist/denylist filter. In `anthropic_gcpanthropic.go` (and `anthropic_awsanthropic.go`):

```go
if betas, changed := filterHeaderValues(a.anthropicBetas, a.betaFilterMode, a.betaFilterValues); changed {
    newHeaders = append(newHeaders, internalapi.Header{anthropicBetaHeaderName, strings.Join(betas, ",")})
}
```

When the filter strips **every** value the client sent, `filterHeaderValues` returns an empty slice with `changed == true`, so `strings.Join(betas, ",")` is `""` and the translator appends `Header{"anthropic-beta", ""}`. `mutationsFromTranslationResult` then emits `anthropic-beta:` with an empty value rather than dropping it — the opposite of what the "overwrite the forwarded header with the filtered set" comment intends when the filtered set is empty. A backend that 400s on an unsupported `anthropic-beta` value can just as easily 400 on an empty one, and forwarding an empty header is never the intended outcome.

**Fix**: in `mutationsFromTranslationResult`, an empty header value becomes a `RemoveHeaders` entry instead of a `SetHeaders` entry. This is the shared sink for every translator's header output (request and response paths), so the fix covers all of them in one place rather than at each `filterHeaderValues` call site.

An explicit `Remove` flag on `internalapi.Header` was considered, but the empty-value convention keeps the change confined to `util.go` and is pinned by the test below; no translator emits an empty value it wants forwarded (the only empty-value producers are the `strings.Join` sites above, which mean "removed"). Happy to switch to an explicit field if maintainers prefer it encoded in the type.

**Related Issues/PRs (if applicable)**

None — standalone bug fix.

**Special notes for reviewers (if applicable)**

Testing: `TestMutationsFromTranslationResult` in `internal/extproc/util_test.go` covers a non-empty header set with its raw value; an empty value becoming a removal, never a forwarded empty header; set and remove split correctly within one result; and a nil body vs. an empty-but-non-nil body distinguished. Verified red-capable — reverting the `util.go` guard turns the removal and split cases red.
