### PR TITLE
revert: resolve backend credentials from the informer cache (#2494)

### DIFF
--- a/cmd/aigw/translate.go
+++ b/cmd/aigw/translate.go
@@ -224,14 +224,13 @@ func translateCustomResourceObjects(
 	fakeClient = builder.Build()
 	fakeClientSet = fake2.NewClientset()
 
-	// Store the user-defined secrets in both fakes so that the controllers can read them.
+	// Store the user-defined secrets in the fake client set so that Gateway controller can read them.
 	userDefinedSecretKeys := map[string]struct{}{}
 	for _, s := range usedDefinedSecrets {
 		if _, err = fakeClientSet.CoreV1().Secrets(s.Namespace).Create(ctx, s, metav1.CreateOptions{}); err != nil {
 			err = fmt.Errorf("error creating secret: %w", err)
 			return
 		}
-		mustCreate(ctx, fakeClient, s.DeepCopy(), logger)
 		userDefinedSecretKeys[fmt.Sprintf("%s/%s", s.Namespace, s.Name)] = struct{}{}
 	}
 

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -938,8 +938,8 @@ func (c *GatewayController) bspToFilterAPIBackendAuth(ctx context.Context, backe
 }
 
 func (c *GatewayController) getSecretData(ctx context.Context, namespace, name, dataKey string) (string, error) {
-	secret := &corev1.Secret{}
-	if err := c.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {
+	secret, err := c.kube.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
 		return "", fmt.Errorf("failed to get secret %s: %w", name, err)
 	}
 	if secret.Data != nil {

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -1086,7 +1086,8 @@ func TestGatewayController_bspToFilterAPIBackendAuth(t *testing.T) {
 			StringData: map[string]string{rotators.GCPAccessTokenKey: "thisisgcpcredentials"},
 		},
 	} {
-		require.NoError(t, fakeClient.Create(t.Context(), s))
+		_, err := kube.CoreV1().Secrets(namespace).Create(t.Context(), s, metav1.CreateOptions{})
+		require.NoError(t, err)
 	}
 
 	for _, tc := range []struct {
@@ -1407,10 +1408,11 @@ func TestGatewayController_bspToFilterAPIBackendAuth_WithOverride(t *testing.T) 
 			},
 		},
 	}))
-	require.NoError(t, fakeClient.Create(t.Context(), &corev1.Secret{
+	_, err := kube.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "api-key-secret", Namespace: namespace},
 		StringData: map[string]string{apiKeyInSecret: "thisisapikey"},
-	}))
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	bsp := &aigv1b1.BackendSecurityPolicy{}
 	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: "bsp-with-override", Namespace: namespace}, bsp))
@@ -1562,18 +1564,16 @@ func TestGatewayController_GetSecretData_ErrorCases(t *testing.T) {
 // but silently strip auth from live traffic until something triggers another reconcile.
 func TestGatewayController_reconcileFilterConfigSecret_BailsOnContextCanceled(t *testing.T) {
 	const gwNamespace, configNamespace = "ns", "some-namespace"
-	inner, ok := requireNewFakeClientWithIndexes(t).(client.WithWatch)
-	require.True(t, ok)
-	// Fail only the credential read; failing every read makes the test pass vacuously.
-	fakeClient := interceptor.NewClient(inner, interceptor.Funcs{
-		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-			if _, isSecret := obj.(*corev1.Secret); isSecret && key.Name == "api-key" {
-				return context.Canceled
-			}
-			return cl.Get(ctx, key, obj, opts...)
-		},
-	})
+	fakeClient := requireNewFakeClientWithIndexes(t)
 	kube := fake2.NewClientset()
+	// Fail only the credential read. Failing every Secret Get would also break the config-bundle
+	// write and the reconcile would error regardless, which would make this test pass vacuously.
+	kube.PrependReactor("get", "secrets", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if get, ok := a.(k8stesting.GetAction); ok && get.GetName() == "api-key" {
+			return true, nil, context.Canceled
+		}
+		return false, nil, nil
+	})
 	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
 		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
 
@@ -1649,75 +1649,6 @@ func TestGatewayController_reconcileFilterConfigSecret_BailsOnContextDeadlineRea
 	_, getErr := kube.CoreV1().Secrets(configNamespace).Get(t.Context(),
 		FilterConfigBundleIndexSecretName("gw", gwNamespace), metav1.GetOptions{})
 	require.Error(t, getErr, "no filter config may be published when the backend could not be read")
-}
-
-// TestGatewayController_reconcileFilterConfigSecret_ReadsCredentialsFromCache pins that credentials
-// come from the cache. The config assertions matter: a lookup that silently failed also reads zero.
-func TestGatewayController_reconcileFilterConfigSecret_ReadsCredentialsFromCache(t *testing.T) {
-	const gwNamespace, configNamespace, secretName = "ns", "some-namespace", "shared-api-key"
-	backendNames := []string{"apple", "banana", "cherry"}
-
-	kube := fake2.NewClientset()
-	var credentialGets int
-	kube.PrependReactor("get", "secrets", func(a k8stesting.Action) (bool, runtime.Object, error) {
-		if get, ok := a.(k8stesting.GetAction); ok && get.GetName() == secretName {
-			credentialGets++
-		}
-		return false, nil, nil
-	})
-	fakeClient := requireNewFakeClientWithIndexes(t)
-	c := newTestGatewayController(fakeClient, kube, ctrl.Log, "envoy-gateway-system",
-		"docker.io/envoyproxy/ai-gateway-extproc:latest", "info", false, nil, true)
-
-	require.NoError(t, fakeClient.Create(t.Context(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: gwNamespace},
-		StringData: map[string]string{apiKeyInSecret: "secret-value"},
-	}))
-
-	var (
-		targetRefs []gwapiv1a2.LocalPolicyTargetReference
-		rule       aigv1b1.AIGatewayRouteRule
-	)
-	for _, name := range backendNames {
-		require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.AIServiceBackend{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: gwNamespace},
-			Spec: aigv1b1.AIServiceBackendSpec{
-				BackendRef: gwapiv1.BackendObjectReference{
-					Name: gwapiv1.ObjectName(name), Namespace: ptr.To[gwapiv1.Namespace](gwNamespace),
-				},
-			},
-		}))
-		targetRefs = append(targetRefs, gwapiv1a2.LocalPolicyTargetReference{
-			Kind: "AIServiceBackend", Group: "aigateway.envoyproxy.io", Name: gwapiv1.ObjectName(name),
-		})
-		rule.BackendRefs = append(rule.BackendRefs, aigv1b1.AIGatewayRouteRuleBackendRef{Name: name})
-	}
-	require.NoError(t, fakeClient.Create(t.Context(), &aigv1b1.BackendSecurityPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "bsp", Namespace: gwNamespace},
-		Spec: aigv1b1.BackendSecurityPolicySpec{
-			Type:       aigv1b1.BackendSecurityPolicyTypeAPIKey,
-			APIKey:     &aigv1b1.BackendSecurityPolicyAPIKey{SecretRef: &gwapiv1.SecretObjectReference{Name: secretName}},
-			TargetRefs: targetRefs,
-		},
-	}))
-
-	routes := []aigv1b1.AIGatewayRoute{{
-		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: gwNamespace},
-		Spec:       aigv1b1.AIGatewayRouteSpec{Rules: []aigv1b1.AIGatewayRouteRule{rule}},
-	}}
-
-	effective, err := c.reconcileFilterConfigSecret(t.Context(), "gw", gwNamespace, configNamespace, routes, nil, "uuid", nil)
-	require.NoError(t, err)
-	require.True(t, effective)
-	require.Zero(t, credentialGets, "the credential must come from the cache, not the API server")
-
-	cfg := requireFilterConfigFromBundle(t, kube, configNamespace, "gw", gwNamespace)
-	require.Len(t, cfg.Backends, len(backendNames))
-	for _, b := range cfg.Backends {
-		require.NotNil(t, b.Auth, b.Name)
-		require.NotNil(t, b.Auth.APIKey, b.Name)
-		require.Equal(t, "secret-value", b.Auth.APIKey.Key, b.Name)
-	}
 }
 
 func TestGatewayController_annotateGatewayPods(t *testing.T) {


### PR DESCRIPTION
**Description**

Fixes #2603 

Reverts #2494

There is a race between rotated credentials getting created and them being used in reconcile using informer. The bsp is created and reconcile is triggered at the same time. BSP has not yet updated in api server and the cache returns stale tokens.

Ideally we should depend on either reconcile triggering through BSP changes. Or pass credentials during reconcile invocation.

The PR for the same is raised in #2604 and #2605, but this revert to fix a reproducible race.