### PR TITLE
fix(anthropic): ignore negative stream delta indices

### DIFF
--- a/internal/apischema/anthropic/stream_fold.go
+++ b/internal/apischema/anthropic/stream_fold.go
@@ -61,7 +61,7 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 
 		case event.ContentBlockDelta != nil:
 			idx := event.ContentBlockDelta.Index
-			if idx < len(response.Content) {
+			if idx >= 0 && idx < len(response.Content) {
 				block := &response.Content[idx]
 				delta := event.ContentBlockDelta.Delta
 

--- a/internal/apischema/anthropic/stream_fold_test.go
+++ b/internal/apischema/anthropic/stream_fold_test.go
@@ -102,6 +102,14 @@ func TestMessagesResponseFromStream_boundaries(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: "delta for a negative index is ignored",
+			chunks: []*MessagesStreamChunk{{
+				ContentBlockDelta: &MessagesStreamChunkContentBlockDelta{
+					Index: -1, Delta: ContentBlockDelta{Text: "orphan"},
+				},
+			}},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
**Description**

`MessagesResponseFromStream` previously checked only the upper bound of a `content_block_delta` index before indexing the folded response. Because a negative index is still less than the response length, a malformed upstream Anthropic stream could trigger an `index out of range [-1]` panic while the response was being recorded.

This change requires delta indices to be non-negative before accessing the content slice. Negative delta indices are now ignored, matching the existing handling for negative block-start indices and unknown positive delta indices. A boundary regression test covers the malformed event.

**Related Issues/PRs (if applicable)**

Fixes #2627

**Special notes for reviewers (if applicable)**

Validation:
- `go test ./internal/apischema/anthropic -count=1`
- `go test ./internal/apischema/... -count=1`
- `go vet ./internal/apischema/anthropic`
- `git diff --check`

This change was developed with assistance from OpenAI Codex. I understand the change and take responsibility for the submitted code.