### PR TITLE
test: bring back gpt-5-nano as it is now enabled in the CI infra

### DIFF
--- a/internal/testing/real_provider_models.go
+++ b/internal/testing/real_provider_models.go
@@ -20,7 +20,7 @@ const (
 	// Chat completion models (one per real provider).
 
 	// OpenAIModelName is the OpenAI chat completion model.
-	OpenAIModelName = "gpt-4o-mini"
+	OpenAIModelName = "gpt-5-nano"
 	// AWSBedrockModelName is the AWS Bedrock chat completion model.
 	AWSBedrockModelName = "us.amazon.nova-micro-v1:0"
 	// AzureOpenAIModelName is the Azure OpenAI chat completion model.

--- a/tests/data-plane/envoy.yaml
+++ b/tests/data-plane/envoy.yaml
@@ -94,7 +94,7 @@ static_resources:
                             headers:
                               - name: x-ai-eg-model
                                 string_match:
-                                  exact: gpt-4o-mini
+                                  exact: gpt-5-nano
                           route:
                             auto_host_rewrite: true
                             cluster: openai


### PR DESCRIPTION
**Description**
Reverts envoyproxy/ai-gateway#2624