### PR TITLE
chore(examples): upgrade BackendTLSPolicy from deprecated v1alpha3 to stable v1

### DIFF
--- a/examples/basic/anthropic.yaml
+++ b/examples/basic/anthropic.yaml
@@ -62,7 +62,7 @@ spec:
         hostname: api.anthropic.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-anthropic-tls

--- a/examples/basic/aws-bedrock-openai-anthropic.yaml
+++ b/examples/basic/aws-bedrock-openai-anthropic.yaml
@@ -80,7 +80,7 @@ spec:
         hostname: bedrock-runtime.us-east-1.amazonaws.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-aws-tls

--- a/examples/basic/aws-irsa.yaml
+++ b/examples/basic/aws-irsa.yaml
@@ -156,7 +156,7 @@ spec:
         port: 443
 ---
 # Step 9: Create BackendTLSPolicy for HTTPS
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-aws-tls

--- a/examples/basic/aws-pod-identity.yaml
+++ b/examples/basic/aws-pod-identity.yaml
@@ -152,7 +152,7 @@ spec:
         port: 443
 ---
 # Step 9: Create BackendTLSPolicy for HTTPS
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-aws-tls

--- a/examples/basic/aws.yaml
+++ b/examples/basic/aws.yaml
@@ -99,7 +99,7 @@ spec:
         hostname: bedrock-runtime.us-east-1.amazonaws.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-aws-tls

--- a/examples/basic/azure_openai.yaml
+++ b/examples/basic/azure_openai.yaml
@@ -68,7 +68,7 @@ spec:
         hostname: dummy-azure-resource.openai.azure.com # Replace "dummy-azure-resource" with your Azure OpenAI resource e.g. <azure_resource_name>.openai.azure.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-azure-tls

--- a/examples/basic/cohere.yaml
+++ b/examples/basic/cohere.yaml
@@ -63,7 +63,7 @@ spec:
         hostname: api.cohere.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-cohere-tls

--- a/examples/basic/gcp_vertex.yaml
+++ b/examples/basic/gcp_vertex.yaml
@@ -74,7 +74,7 @@ spec:
         hostname: us-east5-aiplatform.googleapis.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-gcp-tls
@@ -88,7 +88,7 @@ spec:
     wellKnownCACertificates: "System"
     hostname: us-central1-aiplatform.googleapis.com
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-gcp-us-east5-tls

--- a/examples/basic/openai.yaml
+++ b/examples/basic/openai.yaml
@@ -62,7 +62,7 @@ spec:
         hostname: api.openai.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-openai-tls

--- a/examples/basic/tars.yaml
+++ b/examples/basic/tars.yaml
@@ -64,7 +64,7 @@ spec:
         hostname: api.router.tetrate.ai
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: envoy-ai-gateway-basic-tars-tls

--- a/examples/mcp/mcp_example.yaml
+++ b/examples/mcp/mcp_example.yaml
@@ -72,7 +72,7 @@ spec:
         hostname: api.githubcopilot.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: github-tls
@@ -97,7 +97,7 @@ spec:
         hostname: mcp.kiwi.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: kiwi-tls
@@ -122,7 +122,7 @@ spec:
 #         hostname: mcp.context7.com
 #         port: 443
 # ---
-# apiVersion: gateway.networking.k8s.io/v1alpha3
+# apiVersion: gateway.networking.k8s.io/v1
 # kind: BackendTLSPolicy
 # metadata:
 #   name: context7-tls

--- a/examples/mcp/mcp_oauth_example.yaml
+++ b/examples/mcp/mcp_oauth_example.yaml
@@ -83,7 +83,7 @@ spec:
         hostname: mcp.kiwi.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: kiwi-tls

--- a/examples/mcp/mcp_oauth_keycloak.yaml
+++ b/examples/mcp/mcp_oauth_keycloak.yaml
@@ -59,7 +59,7 @@ spec:
         hostname: mcp.kiwi.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: kiwi-tls

--- a/examples/mcp/openai-github.yaml
+++ b/examples/mcp/openai-github.yaml
@@ -176,7 +176,7 @@ spec:
     group: gateway.envoyproxy.io
     namespace: default
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: openai-tls
@@ -267,7 +267,7 @@ spec:
         hostname: api.githubcopilot.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: github-tls

--- a/examples/provider_fallback/base.yaml
+++ b/examples/provider_fallback/base.yaml
@@ -90,7 +90,7 @@ spec:
         hostname: bedrock-runtime.us-east-1.amazonaws.com
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: provider-fallback-aws-tls
@@ -141,7 +141,7 @@ spec:
         hostname: provider-fallback-always-failing-upstream.default.svc.cluster.local
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: provider-fallback-always-failing-upstream-tls


### PR DESCRIPTION
**Description**

Bumps `apiVersion` of `BackendTLSPolicy` in all example manifests from deprecated `gateway.networking.k8s.io/v1alpha3` to stable `gateway.networking.k8s.io/v1`. `BackendTLSPolicy` graduated to the stable v1 API in Gateway API v1.4.0 (released 2025-10-06), and `v1alpha3` now emits a deprecation warning on every `kubectl apply`.

Scope: 15 files under `examples/` (basic, mcp, provider_fallback). No changes to `internal/autoconfig/` or `cmd/aigw/testdata/` in this PR, as those may have tests that exact-match on the `v1alpha3`, happy to send a follow-up PR once this approach is confirmed.

Verified locally:

```
$ kubectl apply -f examples/basic/anthropic.yaml
aigatewayroute.aigateway.envoyproxy.io/envoy-ai-gateway-basic-anthropic created
aiservicebackend.aigateway.envoyproxy.io/envoy-ai-gateway-basic-anthropic created
backendsecuritypolicy.aigateway.envoyproxy.io/envoy-ai-gateway-basic-anthropic-apikey created
backend.gateway.envoyproxy.io/envoy-ai-gateway-basic-anthropic created
backendtlspolicy.gateway.networking.k8s.io/envoy-ai-gateway-basic-anthropic-tls created
secret/envoy-ai-gateway-basic-anthropic-apikey created
```

No more `v1alpha3` deprecation warning, and subsequent chat completion requests through the gateway continue to work.

**Related Issues/PRs (if applicable)**

Closes #2626

**Special notes for reviewers (if applicable)**

First-time contributor. I used Claude Code to help draft and polish this PR.