### PR TITLE
docs(examples): correct Anthropic endpoint prefix

### DIFF
--- a/examples/basic/anthropic-openai-local.yaml
+++ b/examples/basic/anthropic-openai-local.yaml
@@ -3,10 +3,11 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-# This example routes /v1/messages (Anthropic Messages API) requests to a
-# local vLLM backend.
-# The AIServiceBackend schema is set to OpenAI so the gateway passes through
-# the Anthropic request format with translation.
+# This example routes Anthropic Messages API requests sent to the default
+# /anthropic/v1/messages endpoint to a local vLLM backend. The /anthropic
+# provider prefix is configurable through endpointConfig.anthropic.
+# The AIServiceBackend schema is set to OpenAI, so the gateway translates
+# Anthropic Messages API requests and responses to and from OpenAI Chat Completions.
 
 apiVersion: aigateway.envoyproxy.io/v1beta1
 kind: AIGatewayRoute


### PR DESCRIPTION
**Description**

Correct the default Anthropic request path documented in `anthropic-openai-local.yaml`.

- Document `/anthropic/v1/messages` instead of `/v1/messages`.
- Explain that the `/anthropic` provider prefix is configurable through `endpointConfig.anthropic`.
- Clarify that the gateway translates between Anthropic Messages API and OpenAI Chat Completions request and response formats.

Fixes #2631

**Testing**

`make precommit`

**AI assistance**

This documentation change was prepared with AI assistance. I reviewed the change, reproduced the documented endpoint behavior, and will take responsibility for follow-up review feedback.
