### PR TITLE
fix(anthropic): avoid mutating stream chunk usage

### DIFF
--- a/internal/apischema/anthropic/stream_fold.go
+++ b/internal/apischema/anthropic/stream_fold.go
@@ -24,6 +24,11 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 		switch {
 		case event.MessageStart != nil:
 			response = *(*MessagesResponse)(event.MessageStart)
+			// Subsequent deltas must not update the originating chunk's usage.
+			if response.Usage != nil {
+				usage := *response.Usage
+				response.Usage = &usage
+			}
 			// Ensure Content is initialized if nil.
 			if response.Content == nil {
 				response.Content = []MessagesContentBlock{}
@@ -32,7 +37,8 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 		case event.MessageDelta != nil:
 			delta := event.MessageDelta
 			if response.Usage == nil {
-				response.Usage = &delta.Usage
+				usage := delta.Usage
+				response.Usage = &usage
 			} else {
 				// Usage is cumulative for output tokens in message_delta.
 				// Input tokens are usually in message_start.

--- a/internal/apischema/anthropic/stream_fold_test.go
+++ b/internal/apischema/anthropic/stream_fold_test.go
@@ -67,6 +67,37 @@ func TestMessagesResponseFromStream_doesNotMutateInput(t *testing.T) {
 	require.Empty(t, chunks[1].ContentBlockStart.ContentBlock.Text.Text)
 }
 
+func TestMessagesResponseFromStream_usageDoesNotMutateInput(t *testing.T) {
+	for _, withStart := range []bool{false, true} {
+		name := "without message start"
+		if withStart {
+			name = "with message start"
+		}
+		t.Run(name, func(t *testing.T) {
+			chunks := []*MessagesStreamChunk{}
+			startUsage := &Usage{InputTokens: 10, OutputTokens: 1}
+			if withStart {
+				chunks = append(chunks, &MessagesStreamChunk{
+					MessageStart: (*MessagesStreamChunkMessageStart)(&MessagesResponse{Usage: startUsage}),
+				})
+			}
+			chunks = append(chunks,
+				&MessagesStreamChunk{MessageDelta: &MessagesStreamChunkMessageDelta{Usage: Usage{OutputTokens: 4}}},
+				&MessagesStreamChunk{MessageDelta: &MessagesStreamChunkMessageDelta{Usage: Usage{OutputTokens: 7}}},
+			)
+
+			complete := MessagesResponseFromStream(chunks)
+			require.Equal(t, float64(7), complete.Usage.OutputTokens)
+			require.Equal(t, float64(1), startUsage.OutputTokens)
+			require.Equal(t, float64(4), chunks[len(chunks)-2].MessageDelta.Usage.OutputTokens)
+
+			prefix := MessagesResponseFromStream(chunks[:len(chunks)-1])
+			require.Equal(t, float64(4), prefix.Usage.OutputTokens)
+			require.Equal(t, float64(7), complete.Usage.OutputTokens)
+		})
+	}
+}
+
 func TestMessagesResponseFromStream_boundaries(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
**Description**

Folding Anthropic stream chunks currently aliases usage from `message_start` (or the first `message_delta` when start usage is absent). Later deltas overwrite the original chunk's output token count. Folding a prefix of the same stream can also change the usage in an already returned response.

Copy usage before accumulating output tokens so each folded response owns its mutable usage. Regression tests cover streams with and without a message start: the original token counts stay unchanged, a complete stream reports 7 output tokens, and folding its prefix reports 4 without modifying the complete result.

**Related Issues/PRs (if applicable)**

Independently discovered while inspecting the stream folding used by tracing.

**Special notes for reviewers (if applicable)**

Validation: the new regression test fails on the base commit for both cases. After the fix, `go test ./internal/apischema/anthropic -count=1`, `go vet ./internal/apischema/anthropic`, and `git diff --check` pass.

Developed with assistance from OpenAI Codex.
