### PR TITLE
chore(site): redirect aigateway.envoyproxy.io to theagentrouter.ai

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,3 +20,13 @@ command = "npm run build"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+
+# Redirect the whole aigateway.envoyproxy.io domain to theagentrouter.ai.
+# Matching on the full host means deploy previews (*.netlify.app) are unaffected.
+# force = true is required because Docusaurus publishes real files at these paths,
+# and Netlify would otherwise serve them instead of applying the redirect.
+[[redirects]]
+  from = "https://aigateway.envoyproxy.io/*"
+  to = "https://theagentrouter.ai/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
**Description**

This commit adds a domain-level Netlify redirect so that every request to
`aigateway.envoyproxy.io`, on any path, is permanently (301) redirected to the
same path on `https://theagentrouter.ai/`. The new site mirrors the existing
deep links, so `:splat` carries the path through.

The rule matches on the full host rather than `/*`, so deploy previews on
`*.netlify.app` keep serving the built site and PRs remain reviewable.
`force = true` is required because Docusaurus publishes real files at these
paths, and Netlify would otherwise serve them instead of applying the redirect.

**Related Issues/PRs (if applicable)**

**Special notes for reviewers (if applicable)**

theagentrouter.ai is ready to take traffic
