### PR TITLE
fix: charge per-tenant token cost for Distinct bucket rules

### DIFF
--- a/internal/extensionserver/quota_ratelimit.go
+++ b/internal/extensionserver/quota_ratelimit.go
@@ -826,8 +826,7 @@ func buildClientSelectorActions(
 }
 
 // buildClientSelectorStreamDoneActions is like buildClientSelectorActions but
-// always uses ExpectMatch=true on HeaderValueMatch actions. Distinct headers fall
-// back to GenericKey because per-value bucketing is not applicable at stream-done time.
+// always uses ExpectMatch=true on HeaderValueMatch actions.
 func buildClientSelectorStreamDoneActions(
 	ruleIndex int, selectors []egv1a1.RateLimitSelectCondition,
 ) []*routev3.RateLimit_Action {
@@ -869,18 +868,21 @@ func flattenAndSortClientSelectorHeaders(selectors []egv1a1.RateLimitSelectCondi
 }
 
 // buildStreamDoneHeaderMatchAction is like buildHeaderMatchAction but always uses
-// ExpectMatch=true. Distinct headers are treated as GenericKey.
+// ExpectMatch=true, so an inverted match still reports the cost it incurred.
 func buildStreamDoneHeaderMatchAction(
 	ruleIndex, matchIndex int, header egv1a1.HeaderMatch,
 ) *routev3.RateLimit_Action {
 	descriptorKey := translator.BucketRuleDescriptorKey(ruleIndex, matchIndex, header.Name, headerMatchKeyValue(header))
 
+	// Must mirror buildHeaderMatchAction: a descriptor that doesn't match the
+	// request-time one lands the real cost in a different bucket from the
+	// pre-flight reservation it is meant to settle.
 	if header.Type != nil && *header.Type == egv1a1.HeaderMatchDistinct {
 		return &routev3.RateLimit_Action{
-			ActionSpecifier: &routev3.RateLimit_Action_GenericKey_{
-				GenericKey: &routev3.RateLimit_Action_GenericKey{
-					DescriptorKey:   descriptorKey,
-					DescriptorValue: descriptorKey,
+			ActionSpecifier: &routev3.RateLimit_Action_RequestHeaders_{
+				RequestHeaders: &routev3.RateLimit_Action_RequestHeaders{
+					HeaderName:    header.Name,
+					DescriptorKey: descriptorKey,
 				},
 			},
 		}

--- a/internal/extensionserver/quota_ratelimit_test.go
+++ b/internal/extensionserver/quota_ratelimit_test.go
@@ -1611,6 +1611,75 @@ func TestBuildHeaderMatchAction(t *testing.T) {
 	})
 }
 
+func TestBuildStreamDoneHeaderMatchAction(t *testing.T) {
+	t.Run("distinct match reads the header value so each tenant keeps its own bucket", func(t *testing.T) {
+		header := egv1a1.HeaderMatch{Name: "x-tenant-id", Type: ptr.To(egv1a1.HeaderMatchDistinct)}
+
+		action := buildStreamDoneHeaderMatchAction(0, 0, header)
+
+		rh := action.GetRequestHeaders()
+		require.NotNil(t, rh, "a GenericKey here pools every tenant's cost into one bucket")
+		require.Equal(t, "x-tenant-id", rh.HeaderName)
+		require.Equal(t, translator.BucketRuleDescriptorKey(0, 0, "x-tenant-id", ""), rh.DescriptorKey)
+	})
+
+	t.Run("exact match keeps HeaderValueMatch with ExpectMatch true", func(t *testing.T) {
+		header := egv1a1.HeaderMatch{
+			Name:   "x-api-key",
+			Type:   ptr.To(egv1a1.HeaderMatchExact),
+			Value:  ptr.To("premium"),
+			Invert: ptr.To(true),
+		}
+
+		action := buildStreamDoneHeaderMatchAction(0, 0, header)
+
+		hvm := action.GetHeaderValueMatch()
+		require.NotNil(t, hvm)
+		require.True(t, hvm.ExpectMatch.Value, "an inverted match must still report the cost it incurred")
+		require.Equal(t, translator.BucketRuleDescriptorKey(0, 0, "x-api-key", "premium"), hvm.DescriptorKey)
+	})
+}
+
+// A stream-done descriptor that doesn't match its request-time counterpart
+// settles the real token cost against a different bucket than the one the
+// pre-flight check reserved against.
+func TestStreamDoneDescriptorsMatchRequestTime(t *testing.T) {
+	headers := []egv1a1.HeaderMatch{
+		{Name: "x-tenant-id", Type: ptr.To(egv1a1.HeaderMatchDistinct)},
+		{Name: "x-tier", Type: ptr.To(egv1a1.HeaderMatchExact), Value: ptr.To("free")},
+	}
+	for _, h := range headers {
+		t.Run(h.Name, func(t *testing.T) {
+			reqTime := buildHeaderMatchAction(1, 2, h)
+			streamDone := buildStreamDoneHeaderMatchAction(1, 2, h)
+
+			reqKind, reqKey := descriptorOf(t, reqTime)
+			doneKind, doneKey := descriptorOf(t, streamDone)
+			require.Equal(t, reqKind, doneKind, "both phases must derive the bucket the same way")
+			require.Equal(t, reqKey, doneKey)
+		})
+	}
+}
+
+// descriptorOf returns how an action derives its descriptor and the key it
+// contributes. The kind matters as much as the key: a GenericKey emits a
+// constant where RequestHeaders emits the caller's own header value, so two
+// actions sharing a key can still resolve to different buckets.
+func descriptorOf(t *testing.T, action *routev3.RateLimit_Action) (kind, key string) {
+	t.Helper()
+	switch {
+	case action.GetRequestHeaders() != nil:
+		return "RequestHeaders", action.GetRequestHeaders().DescriptorKey
+	case action.GetHeaderValueMatch() != nil:
+		return "HeaderValueMatch", action.GetHeaderValueMatch().DescriptorKey
+	case action.GetGenericKey() != nil:
+		return "GenericKey", action.GetGenericKey().DescriptorKey
+	default:
+		t.Fatalf("action carries no recognized descriptor: %v", action)
+		return "", ""
+	}
+}
+
 func TestBaseDescriptorActions(t *testing.T) {
 	actions := baseDescriptorActions()
 	require.Len(t, actions, 2)


### PR DESCRIPTION
**Description**

`buildStreamDoneHeaderMatchAction` emits a `GenericKey` action for a `Distinct`
header, whose descriptor value is a constant. The request-time builder,
`buildHeaderMatchAction`, emits `RequestHeaders` for the same header, keyed on
the caller's actual value.

The two phases of the same rule therefore never resolve to the same bucket:

| Phase | Action | Descriptor value |
|---|---|---|
| Request-time (pre-flight) | `RequestHeaders` | the caller's `x-tenant-id` |
| Stream-done (real cost) | `GenericKey` | a constant |

Each tenant's counter takes only the pre-flight increment, while the real token
cost from every tenant sharing the rule settles into one pooled generic bucket.
That matches the Redis counters described in the issue.

This mirrors the request-time action so stream-done settles against the bucket
its pre-flight check reserved. One branch in one function.

Tests: `TestBuildStreamDoneHeaderMatchAction` covers a `Distinct` header
producing `RequestHeaders`, and an inverted `Exact` header still reporting with
`ExpectMatch=true`. `TestStreamDoneDescriptorsMatchRequestTime` asserts the
request-time and stream-done actions agree on both the descriptor kind and the
key. Comparing keys alone is not enough: `GenericKey` and `RequestHeaders` share
a key and differ only in the value, which is exactly how this hid.

**Related Issues/PRs (if applicable)**

Fixes #2551

**Special notes for reviewers (if applicable)**

The comment I removed claimed the fallback was deliberate: "Distinct headers
fall back to GenericKey because per-value bucketing is not applicable at
stream-done time." I think that rationale is wrong and would rather surface the
disagreement than quietly flip it. `ApplyOnStreamDone` entries are `RateLimit`
actions on the same route as the request-time ones, so the phase controls when
the report is sent rather than which actions can be evaluated, and a
`RequestHeaders` action resolves the same way it does pre-flight.

If the intent really was that per-value bucketing is unsupported here, the
descriptors still should not silently disagree, and the better change is the
issue's second option: reject or warn on `Distinct` combined with a token-based
quota mode rather than pooling the cost. Happy to take it that way instead.

The old behavior had no test coverage. The existing stream-done assertions only
exercise `Exact` headers and the default bucket, which is why this change breaks
nothing. Both new tests fail if the `GenericKey` branch is restored, and the
`Exact` subtest correctly keeps passing.

`make precommit` is clean and `go test ./internal/...` passes. I have not run
this against a live Redis-backed cluster, so the descriptor pairing is verified
at config-generation level only. If someone has a cluster handy, confirming the
per-tenant counters would be a good extra check.

I used an AI assistant while investigating and writing this change, noted per
the generative AI policy in the contributing guide. I have reviewed and
understand the diff and can revise it in review.