### PR TITLE
fix(mcpproxy): preserve valid SEP-2549 cache metadata in merged list responses

### DIFF
--- a/internal/mcpproxy/handlers.go
+++ b/internal/mcpproxy/handlers.go
@@ -386,6 +386,56 @@ type (
 	broadCastResponseMergeFn[T any] func(*session, []broadCastResponse[T]) T
 )
 
+// cacheableResult is the subset of mcp.Cacheable (mcp.CacheableResult) needed
+// to aggregate SEP-2549 cache metadata across backend responses.
+type cacheableResult interface {
+	GetTTLMs() int
+	GetCacheScope() string
+}
+
+// aggregateCacheable returns the conservative SEP-2549 cache metadata for an
+// aggregated list response. The proxy must never emit an empty cacheScope:
+// under SEP-2549 "cacheScope" is only valid as "public", "private", or
+// omitted, and the SDK marshals the zero value as an invalid "".
+//   - TTLMs: the minimum of all backends' TTL values, clamped to >= 0, so the
+//     aggregated response is never cached longer than any contributor's
+//     advertised freshness. 0 (immediately stale) is the safe default when no
+//     backend advertises freshness.
+//   - CacheScope: "private" if ANY backend scope is private (the most
+//     restrictive scope wins); otherwise the first non-empty backend scope;
+//     otherwise "public", which is the SEP-2549 default when the field is
+//     absent and therefore always safe to emit explicitly.
+func aggregateCacheable[T cacheableResult](responses []broadCastResponse[T]) mcp.Cacheable {
+	aggregated := mcp.Cacheable{CacheScope: "public"} // SEP-2549 default
+	if len(responses) == 0 {
+		return aggregated
+	}
+	minTTL := responses[0].res.GetTTLMs()
+	firstScope := responses[0].res.GetCacheScope()
+	anyPrivate := firstScope == "private"
+	for _, r := range responses[1:] {
+		if t := r.res.GetTTLMs(); t < minTTL {
+			minTTL = t
+		}
+		if s := r.res.GetCacheScope(); s == "private" {
+			anyPrivate = true
+		} else if firstScope == "" && s != "" {
+			firstScope = s
+		}
+	}
+	if minTTL < 0 {
+		minTTL = 0
+	}
+	aggregated.TTLMs = minTTL
+	switch {
+	case anyPrivate:
+		aggregated.CacheScope = "private"
+	case firstScope != "":
+		aggregated.CacheScope = firstScope
+	}
+	return aggregated
+}
+
 // mergeToolsList merges the list of tools from all backends and prepare the response message to be sent back to the client.
 func (m *mcpRequestContext) mergeToolsList(s *session, responses []broadCastResponse[mcp.ListToolsResult]) mcp.ListToolsResult {
 	// Use a non-nil empty slice so JSON encodes as [] not null; some clients reject tools:null.
@@ -439,6 +489,7 @@ func (m *mcpRequestContext) mergeToolsList(s *session, responses []broadCastResp
 			resp.Tools = append(resp.Tools, tool)
 		}
 	}
+	resp.Cacheable = aggregateCacheable(responses)
 
 	return resp
 }
@@ -456,6 +507,7 @@ func (m *mcpRequestContext) mergeResourceList(_ *session, responses []broadCastR
 			resp.Resources = append(resp.Resources, res)
 		}
 	}
+	resp.Cacheable = aggregateCacheable(responses)
 	return resp
 }
 
@@ -469,6 +521,7 @@ func (m *mcpRequestContext) mergeResourcesTemplateList(_ *session, responses []b
 			resp.ResourceTemplates = append(resp.ResourceTemplates, res)
 		}
 	}
+	resp.Cacheable = aggregateCacheable(responses)
 	return resp
 }
 
@@ -513,6 +566,7 @@ func (m *mcpRequestContext) mergePromptsList(s *session, responses []broadCastRe
 			aggregatedResponse.Prompts = append(aggregatedResponse.Prompts, res)
 		}
 	}
+	aggregatedResponse.Cacheable = aggregateCacheable(responses)
 
 	return aggregatedResponse
 }

--- a/internal/mcpproxy/handlers_test.go
+++ b/internal/mcpproxy/handlers_test.go
@@ -1048,3 +1048,168 @@ func TestMergePromptsList_PerBackendPrefixMode(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeToolsList_CacheableMetadata(t *testing.T) {
+	t.Run("single backend preserves metadata", func(t *testing.T) {
+		responses := []broadCastResponse[mcp.ListToolsResult]{
+			{
+				backendName: "backend1",
+				res: mcp.ListToolsResult{
+					Cacheable: mcp.Cacheable{TTLMs: 5000, CacheScope: "private"},
+					Tools:     []*mcp.Tool{{Name: "test-tool"}},
+				},
+			},
+		}
+		proxy := newTestMCPProxy()
+		proxy.routes["test-route"].toolSelectors = nil
+		proxy.requestHeaders = http.Header{}
+		result := proxy.mergeToolsList(&session{route: "test-route"}, responses)
+		require.Equal(t, 5000, result.TTLMs)
+		require.Equal(t, "private", result.CacheScope)
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"cacheScope":""`)
+		require.Contains(t, string(encoded), `"cacheScope":"private"`)
+		require.Contains(t, string(encoded), `"ttlMs":5000`)
+	})
+
+	t.Run("multi-backend conservative aggregation", func(t *testing.T) {
+		responses := []broadCastResponse[mcp.ListToolsResult]{
+			{
+				backendName: "backend1",
+				res: mcp.ListToolsResult{
+					Cacheable: mcp.Cacheable{TTLMs: 60000, CacheScope: "public"},
+					Tools:     []*mcp.Tool{{Name: "test-tool"}},
+				},
+			},
+			{
+				backendName: "backend2",
+				res: mcp.ListToolsResult{
+					Cacheable: mcp.Cacheable{TTLMs: 1000, CacheScope: "private"},
+					Tools:     []*mcp.Tool{{Name: "other-tool"}},
+				},
+			},
+		}
+		proxy := newTestMCPProxy()
+		proxy.routes["test-route"].toolSelectors = nil
+		proxy.requestHeaders = http.Header{}
+		result := proxy.mergeToolsList(&session{route: "test-route"}, responses)
+		require.Equal(t, 1000, result.TTLMs)
+		require.Equal(t, "private", result.CacheScope)
+	})
+
+	t.Run("no upstream metadata yields valid default", func(t *testing.T) {
+		responses := []broadCastResponse[mcp.ListToolsResult]{
+			{
+				backendName: "backend1",
+				res:         mcp.ListToolsResult{Tools: []*mcp.Tool{{Name: "test-tool"}}},
+			},
+		}
+		proxy := newTestMCPProxy()
+		proxy.routes["test-route"].toolSelectors = nil
+		proxy.requestHeaders = http.Header{}
+		result := proxy.mergeToolsList(&session{route: "test-route"}, responses)
+		require.Equal(t, 0, result.TTLMs)
+		require.Equal(t, "public", result.CacheScope)
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"cacheScope":""`)
+	})
+
+	t.Run("empty responses slice", func(t *testing.T) {
+		proxy := newTestMCPProxy()
+		proxy.routes["test-route"].toolSelectors = nil
+		proxy.requestHeaders = http.Header{}
+		result := proxy.mergeToolsList(&session{route: "test-route"}, nil)
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"cacheScope":""`)
+	})
+}
+
+func TestMergeListResults_NeverEmitEmptyCacheScope(t *testing.T) {
+	t.Run("resources", func(t *testing.T) {
+		proxy := newTestMCPProxy()
+		session := &session{route: "test-route"}
+		responses := []broadCastResponse[mcp.ListResourcesResult]{
+			{
+				backendName: "backend1",
+				res: mcp.ListResourcesResult{
+					Cacheable: mcp.Cacheable{TTLMs: 1234, CacheScope: "public"},
+					Resources: []*mcp.Resource{{Name: "r1", URI: "test://r1"}},
+				},
+			},
+		}
+		result := proxy.mergeResourceList(session, responses)
+		require.Equal(t, 1234, result.TTLMs)
+		require.Equal(t, "public", result.CacheScope)
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"cacheScope":""`)
+
+		empty := proxy.mergeResourceList(session, nil)
+		encodedEmpty, err := json.Marshal(empty)
+		require.NoError(t, err)
+		require.NotContains(t, string(encodedEmpty), `"cacheScope":""`)
+	})
+
+	t.Run("resource templates", func(t *testing.T) {
+		proxy := newTestMCPProxy()
+		session := &session{route: "test-route"}
+		responses := []broadCastResponse[mcp.ListResourceTemplatesResult]{
+			{
+				backendName: "backend1",
+				res: mcp.ListResourceTemplatesResult{
+					Cacheable:         mcp.Cacheable{TTLMs: 1234, CacheScope: "public"},
+					ResourceTemplates: []*mcp.ResourceTemplate{{Name: "t1", URITemplate: "test://{id}"}},
+				},
+			},
+		}
+		result := proxy.mergeResourcesTemplateList(session, responses)
+		require.Equal(t, 1234, result.TTLMs)
+		require.Equal(t, "public", result.CacheScope)
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"cacheScope":""`)
+
+		empty := proxy.mergeResourcesTemplateList(session, nil)
+		encodedEmpty, err := json.Marshal(empty)
+		require.NoError(t, err)
+		require.NotContains(t, string(encodedEmpty), `"cacheScope":""`)
+	})
+
+	t.Run("prompts", func(t *testing.T) {
+		proxy := newTestMCPProxy()
+		session := &session{route: "test-route"}
+		responses := []broadCastResponse[mcp.ListPromptsResult]{
+			{
+				backendName: "backend1",
+				res: mcp.ListPromptsResult{
+					Cacheable: mcp.Cacheable{TTLMs: 1234, CacheScope: "public"},
+					Prompts:   []*mcp.Prompt{{Name: "p1"}},
+				},
+			},
+		}
+		result := proxy.mergePromptsList(session, responses)
+		require.Equal(t, 1234, result.TTLMs)
+		require.Equal(t, "public", result.CacheScope)
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"cacheScope":""`)
+
+		empty := proxy.mergePromptsList(session, nil)
+		encodedEmpty, err := json.Marshal(empty)
+		require.NoError(t, err)
+		require.NotContains(t, string(encodedEmpty), `"cacheScope":""`)
+	})
+
+	t.Run("tools empty responses slice", func(t *testing.T) {
+		proxy := newTestMCPProxy()
+		proxy.routes["test-route"].toolSelectors = nil
+		proxy.requestHeaders = http.Header{}
+		result := proxy.mergeToolsList(&session{route: "test-route"}, nil)
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"cacheScope":""`)
+	})
+}


### PR DESCRIPTION
**Description**

Fixes #2665. The MCP proxy's aggregated list responses (`tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`) now emit valid SEP-2549 cache metadata instead of the invalid `{"ttlMs":0,"cacheScope":""}` payload that strict MCP clients (e.g. Codex CLI 0.148-0.152) reject during tool discovery.

**What**

Added a small unexported helper `aggregateCacheable` in `internal/mcpproxy/handlers.go` that computes conservative cache metadata from the backend responses, and wired it into all four merge functions (`mergeToolsList`, `mergeResourceList`, `mergeResourcesTemplateList`, `mergePromptsList`):

- `ttlMs` - the minimum of all backends' TTL values (clamped to >= 0), so the aggregated response is never cached longer than any contributor's advertised freshness; `0` (immediately stale) when no backend advertises freshness.
- `cacheScope` - `"private"` if any backend's scope is private (most restrictive wins); otherwise the first non-empty backend scope; otherwise `"public"`, which is the SEP-2549 default when the field is absent and is always valid to emit explicitly.

The SDK's `Cacheable` struct (github.com/modelcontextprotocol/go-sdk v1.7.0) has no `omitempty` on `ttlMs`/`cacheScope`, so the previously-built fresh result structs marshaled the zero value as the invalid empty `cacheScope: ""` (verified: `{"ttlMs":0,"cacheScope":"","tools":[]}`). No other behavior changed: prefixing, selectors, authorization, and meta-URI rewriting are untouched.

**Why**

Under MCP 2026-07-28 / SEP-2549, `cacheScope` is only valid as `"public"`, `"private"`, or omitted - an empty string is not valid. Aggregated list responses are rebuilt from scratch in the merge functions, dropping upstream cache metadata and emitting an invalid document, which strict clients reject.

**Tests**

Added to `internal/mcpproxy/handlers_test.go`:

- `TestMergeToolsList_CacheableMetadata` - single-backend metadata preserved end-to-end (including `json.Marshal` shape), multi-backend conservative aggregation (min TTL + private-wins), no-upstream-metadata to valid public default, empty-responses slice validity.
- `TestMergeListResults_NeverEmitEmptyCacheScope` - `resources/list`, `resources/templates/list`, and `prompts/list` merges never marshal `"cacheScope":""` and preserve upstream values.

Verification run: `go test -count=1 ./internal/mcpproxy/...` returned ok (full package suite, ~3.0s). `gofmt -l` clean, `go vet` clean, go.mod/go.sum untouched.

**Mutation check**

Removing the four `Cacheable = aggregateCacheable(...)` wirings makes the new tests fail with exactly the reported symptom (`{"ttlMs":0,"cacheScope":"","tools":[]}` should not contain `"cacheScope":""`), then restoring the fix turns them green - the tests genuinely guard the fix.

**AI-generated code disclosure**

The change was implemented with AI assistance (OpenCode + muse-spark 1.3), then reviewed and verified for correctness, protocol conformance, and test coverage. The submitter understands the change and takes full ownership as required by CONTRIBUTING.md.

Fixes #2665
