### PR TITLE
fix: update usage chunk for openai models

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -130,7 +130,7 @@ type LLMRequestCost struct {
 	//
 	// 	* "model == 'llama' ?  input_tokens + output_token * 0.5 : total_tokens"
 	//	* "backend == 'foo.default' ?  input_tokens + output_tokens : total_tokens"
-	//	* "backend == 'bar.default' ?  (input_tokens - cached_input_tokens) + cached_input_tokens * 0.1 + cache_creation_input_tokens * 1.25 + output_tokens : total_tokens"
+	//	* "backend == 'bar.default' ?  (input_tokens - cached_input_tokens - cache_creation_input_tokens) + cached_input_tokens * 0.1 + cache_creation_input_tokens * 1.25 + output_tokens : total_tokens"
 	//	* "input_tokens + output_tokens + total_tokens"
 	//	* "input_tokens * output_tokens"
 	//

--- a/api/v1beta1/shared_types.go
+++ b/api/v1beta1/shared_types.go
@@ -134,7 +134,7 @@ type LLMRequestCost struct {
 	//
 	// 	* "model == 'llama' ?  input_tokens + output_token * 0.5 : total_tokens"
 	//	* "backend == 'foo.default' ?  input_tokens + output_tokens : total_tokens"
-	//	* "backend == 'bar.default' ?  (input_tokens - cached_input_tokens) + cached_input_tokens * 0.1 + cache_creation_input_tokens * 1.25 + output_tokens : total_tokens"
+	//	* "backend == 'bar.default' ?  (input_tokens - cached_input_tokens - cache_creation_input_tokens) + cached_input_tokens * 0.1 + cache_creation_input_tokens * 1.25 + output_tokens : total_tokens"
 	//	* "input_tokens + output_tokens + total_tokens"
 	//	* "input_tokens * output_tokens"
 	//

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1576,8 +1576,7 @@ type PromptTokensDetails struct {
 	AudioTokens int `json:"audio_tokens,omitzero"`
 	// Cached tokens present in the prompt.
 	CachedTokens int `json:"cached_tokens,omitzero"`
-	// Tokens written to the cache. OpenAI names this field cache_write_tokens;
-	// cache_creation_input_tokens is Anthropic's name for the same quantity.
+	// Tokens written to the cache.
 	CacheCreationTokens int `json:"cache_write_tokens,omitzero"`
 }
 

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1576,8 +1576,9 @@ type PromptTokensDetails struct {
 	AudioTokens int `json:"audio_tokens,omitzero"`
 	// Cached tokens present in the prompt.
 	CachedTokens int `json:"cached_tokens,omitzero"`
-	// Tokens written to the cache.
-	CacheCreationTokens int `json:"cache_creation_input_tokens,omitzero"`
+	// Tokens written to the cache. OpenAI names this field cache_write_tokens;
+	// cache_creation_input_tokens is Anthropic's name for the same quantity.
+	CacheCreationTokens int `json:"cache_write_tokens,omitzero"`
 }
 
 // ChatCompletionResponseChunk is described in the OpenAI API documentation:
@@ -7283,7 +7284,7 @@ type ResponseUsageInputTokensDetails struct {
 	CachedTokens int64 `json:"cached_tokens"`
 
 	// The number of tokens that were written to the cache.
-	CacheCreationTokens int64 `json:"cache_creation_input_tokens"`
+	CacheCreationTokens int64 `json:"cache_write_tokens"`
 }
 
 // A detailed breakdown of the output tokens.
@@ -7298,7 +7299,7 @@ type ResponseTokensDetails struct {
 	CachedTokens int `json:"cached_tokens,omitempty"` //nolint:tagliatelle //follow openai api
 
 	// CacheCreationTokens: number of tokens that were written to the cache.
-	CacheCreationTokens int64 `json:"cache_creation_input_tokens"` //nolint:tagliatelle
+	CacheCreationTokens int64 `json:"cache_write_tokens"` //nolint:tagliatelle //follow openai api
 
 	// ReasoningTokens: Number of reasoning tokens (for reasoning models).
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"` //nolint:tagliatelle //follow openai api

--- a/internal/apischema/openai/openai_test.go
+++ b/internal/apischema/openai/openai_test.go
@@ -1888,7 +1888,7 @@ func TestPromptTokensDetails(t *testing.T) {
 				"text_tokens": 15,
 				"audio_tokens": 8,
 				"cached_tokens": 384,
-				"cache_creation_input_tokens": 10
+				"cache_write_tokens": 10
 			}`,
 		},
 		{
@@ -1902,7 +1902,7 @@ func TestPromptTokensDetails(t *testing.T) {
 			expected: `{
 				"audio_tokens": 8,
 				"cached_tokens": 384,
-				"cache_creation_input_tokens": 10
+				"cache_write_tokens": 10
 			}`,
 		},
 	}
@@ -1975,7 +1975,7 @@ func TestChatCompletionResponseUsage(t *testing.T) {
 				"prompt_tokens_details": {
 					"audio_tokens": 8,
 					"cached_tokens": 384,
-					"cache_creation_input_tokens": 13
+					"cache_write_tokens": 13
 				}
 			}`,
 		},
@@ -2012,7 +2012,7 @@ func TestChatCompletionResponseUsage(t *testing.T) {
 					"text_tokens": 15,
 					"audio_tokens": 8,
 					"cached_tokens": 384,
-					"cache_creation_input_tokens": 21
+					"cache_write_tokens": 21
 				}
 			}`,
 		},

--- a/internal/tracing/otelgenai/responses.go
+++ b/internal/tracing/otelgenai/responses.go
@@ -29,7 +29,7 @@ func responsesResponseAttrs(resp *openai.Response) []attribute.KeyValue {
 	if u := resp.Usage; u != nil {
 		attrs = append(attrs, usageAttrs(int(u.InputTokens), int(u.OutputTokens))...)
 		attrs = append(attrs, usageDetailAttrs(
-			int(u.InputTokensDetails.CachedTokens), 0,
+			int(u.InputTokensDetails.CachedTokens), int(u.InputTokensDetails.CacheCreationTokens),
 			int(u.OutputTokensDetails.ReasoningTokens))...)
 	}
 	return attrs

--- a/internal/tracing/otelgenai/responses_test.go
+++ b/internal/tracing/otelgenai/responses_test.go
@@ -74,7 +74,7 @@ func TestResponsesResponseAttrs(t *testing.T) {
 			Usage: &openai.ResponseUsage{
 				InputTokens:         100,
 				OutputTokens:        50,
-				InputTokensDetails:  openai.ResponseUsageInputTokensDetails{CachedTokens: 80},
+				InputTokensDetails:  openai.ResponseUsageInputTokensDetails{CachedTokens: 70, CacheCreationTokens: 10},
 				OutputTokensDetails: openai.ResponseUsageOutputTokensDetails{ReasoningTokens: 30},
 			},
 		})...)
@@ -86,7 +86,8 @@ func TestResponsesResponseAttrs(t *testing.T) {
 		attribute.String(ResponseModel, "gpt-5-nano"),
 		attribute.Int(UsageInputTokens, 100),
 		attribute.Int(UsageOutputTokens, 50),
-		attribute.Int(UsageCacheReadInputTokens, 80),
+		attribute.Int(UsageCacheReadInputTokens, 70),
+		attribute.Int(UsageCacheCreationInputTokens, 10),
 		attribute.Int(UsageReasoningOutputTokens, 30),
 	}, span.Attributes)
 }

--- a/internal/translator/openai_completions_test.go
+++ b/internal/translator/openai_completions_test.go
@@ -156,7 +156,7 @@ func TestOpenAIToOpenAITranslatorV1CompletionResponseBody(t *testing.T) {
 					"total_tokens": 13,
 					"prompt_tokens_details": {
 						"cached_tokens": 2,
-						"cache_creation_input_tokens": 1
+						"cache_write_tokens": 1
 					}
 				}
 			}`,

--- a/internal/translator/openai_helper_test.go
+++ b/internal/translator/openai_helper_test.go
@@ -647,7 +647,7 @@ func TestOpenAIStreamToAnthropicState_ProcessBuffer_TextStreaming(t *testing.T) 
 }
 
 // TestOpenAIStreamToAnthropicState_ProcessBuffer_CachedTokens is a regression test guarding
-// against double-counting OpenAI's cached_tokens/cache_creation_input_tokens (a breakdown
+// against double-counting OpenAI's cached_tokens/cache_write_tokens (a breakdown
 // within prompt_tokens) as if they were additive, Anthropic-native cache usage fields.
 func TestOpenAIStreamToAnthropicState_ProcessBuffer_CachedTokens(t *testing.T) {
 	state := &openAIStreamToAnthropicState{
@@ -665,7 +665,7 @@ func TestOpenAIStreamToAnthropicState_ProcessBuffer_CachedTokens(t *testing.T) {
 	input := fmt.Sprintf(
 		"data: {\"id\":\"chatcmpl-cache\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"}}],\"model\":\"gpt-4o\"}\n\n"+
 			"data: {\"id\":\"chatcmpl-cache\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"+
-			"data: {\"id\":\"chatcmpl-cache\",\"choices\":[],\"usage\":{\"prompt_tokens\":%d,\"completion_tokens\":%d,\"prompt_tokens_details\":{\"cached_tokens\":%d,\"cache_creation_input_tokens\":%d}}}\n\n"+
+			"data: {\"id\":\"chatcmpl-cache\",\"choices\":[],\"usage\":{\"prompt_tokens\":%d,\"completion_tokens\":%d,\"prompt_tokens_details\":{\"cached_tokens\":%d,\"cache_write_tokens\":%d}}}\n\n"+
 			"data: [DONE]\n\n",
 		promptTokens, completionTokens, cachedTokens, cacheCreationTokens,
 	)

--- a/internal/translator/openai_openai_test.go
+++ b/internal/translator/openai_openai_test.go
@@ -466,7 +466,7 @@ func TestExtractUsageFromBufferEvent(t *testing.T) {
 
 	t.Run("valid usage data with cached tokens", func(t *testing.T) {
 		o := &openAIToOpenAITranslatorV1ChatCompletion{}
-		o.buffered = []byte("data: {\"usage\": {\"prompt_tokens\": 5, \"completion_tokens\": 3, \"total_tokens\": 8, \"prompt_tokens_details\": {\"cached_tokens\": 2, \"cache_creation_input_tokens\": 1}}}\n")
+		o.buffered = []byte("data: {\"usage\": {\"prompt_tokens\": 5, \"completion_tokens\": 3, \"total_tokens\": 8, \"prompt_tokens_details\": {\"cached_tokens\": 2, \"cache_write_tokens\": 1}}}\n")
 		usedToken := o.extractUsageFromBufferEvent(nil)
 		require.Equal(t, tokenUsageFrom(5, 2, 1, 3, 8, -1), usedToken)
 		require.Empty(t, o.buffered)

--- a/internal/translator/openai_responses.go
+++ b/internal/translator/openai_responses.go
@@ -158,13 +158,12 @@ func setTokenUsageFromResponse(tokenUsage *metrics.TokenUsage, resp *openai.Resp
 	if resp == nil || resp.Usage == nil {
 		return
 	}
-	tokenUsage.SetInputTokens(uint32(resp.Usage.InputTokens))                           // #nosec G115
-	tokenUsage.SetOutputTokens(uint32(resp.Usage.OutputTokens))                         // #nosec G115
-	tokenUsage.SetTotalTokens(uint32(resp.Usage.TotalTokens))                           // #nosec G115
-	tokenUsage.SetCachedInputTokens(uint32(resp.Usage.InputTokensDetails.CachedTokens)) // #nosec G115
-	// Openai does not support cache creation response.
-	tokenUsage.SetCacheCreationInputTokens(uint32(0))                                     // #nosec G115
-	tokenUsage.SetReasoningTokens(uint32(resp.Usage.OutputTokensDetails.ReasoningTokens)) // #nosec G115
+	tokenUsage.SetInputTokens(uint32(resp.Usage.InputTokens))                                         // #nosec G115
+	tokenUsage.SetOutputTokens(uint32(resp.Usage.OutputTokens))                                       // #nosec G115
+	tokenUsage.SetTotalTokens(uint32(resp.Usage.TotalTokens))                                         // #nosec G115
+	tokenUsage.SetCachedInputTokens(uint32(resp.Usage.InputTokensDetails.CachedTokens))               // #nosec G115
+	tokenUsage.SetCacheCreationInputTokens(uint32(resp.Usage.InputTokensDetails.CacheCreationTokens)) // #nosec G115
+	tokenUsage.SetReasoningTokens(uint32(resp.Usage.OutputTokensDetails.ReasoningTokens))             // #nosec G115
 }
 
 // extractUsageFromBufferEvent extracts the token usage and model from the buffered SSE events.

--- a/internal/translator/openai_responses_test.go
+++ b/internal/translator/openai_responses_test.go
@@ -954,6 +954,46 @@ data: [DONE]
 		require.Equal(t, uint32(4), reasoningTokens)
 	})
 
+	t.Run("response.completed carries cache write tokens", func(t *testing.T) {
+		// Regression: OpenAI reports cache writes as input_tokens_details.cache_write_tokens.
+		// The schema previously tagged this field cache_creation_input_tokens (Anthropic's
+		// name), and the streaming path hardcoded zero, so cache writes were silently billed
+		// as ordinary input. Payload shape and values are taken from a real gpt-5.6-sol response.
+		translator := NewResponsesOpenAIToOpenAITranslator("v1", "").(*openAIToOpenAITranslatorV1Responses)
+
+		chunks := []byte(`data: {"type":"response.created","response":{"model":"gpt-5.6-sol"}}
+
+data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","model":"gpt-5.6-sol","usage":{"input_tokens":26836,"input_tokens_details":{"cache_write_tokens":3455,"cached_tokens":23378},"output_tokens":125,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":26961}}}
+
+data: [DONE]
+
+`)
+
+		translator.buffered = chunks
+		tokenUsage := translator.extractUsageFromBufferEvent(nil)
+
+		inputTokens, ok := tokenUsage.InputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(26836), inputTokens)
+
+		cachedTokens, ok := tokenUsage.CachedInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(23378), cachedTokens)
+
+		cacheCreationTokens, ok := tokenUsage.CacheCreationInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(3455), cacheCreationTokens)
+
+		outputTokens, ok := tokenUsage.OutputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(125), outputTokens)
+
+		// input_tokens is inclusive of both cache buckets, so what remains after
+		// subtracting them is the genuinely uncached input the cost expression charges
+		// at the plain input rate.
+		require.Equal(t, uint32(3), inputTokens-cachedTokens-cacheCreationTokens)
+	})
+
 	t.Run("response.failed carries usage when present", func(t *testing.T) {
 		translator := NewResponsesOpenAIToOpenAITranslator("v1", "").(*openAIToOpenAITranslatorV1Responses)
 


### PR DESCRIPTION
**Description**

The cache write tokens should be `cache_write_tokens` according to https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(model)%20response%20%3E%20(schema)%20%3E%20(property)%20usage%20%2B%20(resource)%20responses%20%3E%20(model)%20response_usage%20%3E%20(schema)%20%3E%20(property)%20output_tokens_details. Currrently it's using the field of anthropic.
