### PR TITLE
feat: expose cache creation tokens by TTL to cost expressions

### DIFF
--- a/internal/apischema/anthropic/anthropic.go
+++ b/internal/apischema/anthropic/anthropic.go
@@ -1602,12 +1602,28 @@ const (
 type Usage struct {
 	// The number of input tokens used to create the cache entry.
 	CacheCreationInputTokens float64 `json:"cache_creation_input_tokens"`
+	// The breakdown of cached tokens by the cache entry's time-to-live.
+	// Optional: absent on backends that do not support the extended TTL.
+	CacheCreation *CacheCreation `json:"cache_creation,omitempty"`
 	// The number of input tokens read from the cache.
 	CacheReadInputTokens float64 `json:"cache_read_input_tokens"`
 	// The number of input tokens which were used.
 	InputTokens float64 `json:"input_tokens"`
 	// The number of output tokens which were used.
 	OutputTokens float64 `json:"output_tokens"`
+}
+
+// CacheCreation breaks CacheCreationInputTokens down by cache time-to-live.
+// https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+//
+// The two are priced differently -- a 1 hour cache write costs 2x the base
+// input rate against 1.25x for 5 minutes -- so a cost expression that sees only
+// the combined CacheCreationInputTokens cannot price a request correctly.
+type CacheCreation struct {
+	// The number of input tokens written to a cache entry with a 5 minute TTL.
+	Ephemeral5mInputTokens float64 `json:"ephemeral_5m_input_tokens"`
+	// The number of input tokens written to a cache entry with a 1 hour TTL.
+	Ephemeral1hInputTokens float64 `json:"ephemeral_1h_input_tokens"`
 }
 
 // MessagesStreamChunk represents a single event in the streaming response from the Anthropic Messages API.

--- a/internal/controller/gateway_test.go
+++ b/internal/controller/gateway_test.go
@@ -485,7 +485,7 @@ func TestGatewayController_reconcileFilterConfigSecret(t *testing.T) {
 
 		catProg, err := llmcostcel.NewProgram(wantLLMRequestCosts[6].CEL)
 		require.NoError(t, err)
-		catVal, err := llmcostcel.EvaluateProgram(catProg, "model", "foo.default", "ns/route2", 3, 0, 0, 4, 7, 0)
+		catVal, err := llmcostcel.EvaluateProgram(catProg, "model", "foo.default", "ns/route2", 3, 0, 0, 0, 0, 4, 7, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint64(7), catVal)
 
@@ -729,12 +729,12 @@ func TestGatewayController_reconcileFilterConfigSecret_RouteLevelLLMRequestCostA
 
 	freeProg, err := llmcostcel.NewProgram(wantLLMRequestCosts[0].CEL)
 	require.NoError(t, err)
-	val, err := llmcostcel.EvaluateProgram(freeProg, "model", "free-backend", "ns/free-model-route", 10, 0, 0, 5, 15, 0)
+	val, err := llmcostcel.EvaluateProgram(freeProg, "model", "free-backend", "ns/free-model-route", 10, 0, 0, 0, 0, 5, 15, 0)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), val)
 	paidProg, err := llmcostcel.NewProgram(wantLLMRequestCosts[1].CEL)
 	require.NoError(t, err)
-	val, err = llmcostcel.EvaluateProgram(paidProg, "model", "paid-backend", "ns/paid-model-route", 10, 0, 0, 5, 15, 0)
+	val, err = llmcostcel.EvaluateProgram(paidProg, "model", "paid-backend", "ns/paid-model-route", 10, 0, 0, 0, 0, 5, 15, 0)
 	require.NoError(t, err)
 	require.Equal(t, uint64(15), val)
 }

--- a/internal/extproc/processor_impl.go
+++ b/internal/extproc/processor_impl.go
@@ -886,6 +886,8 @@ func evalCost(costType filterapi.LLMRequestCostType, celProg cel.Program, costs 
 		in, _ := costs.InputTokens()
 		cachedIn, _ := costs.CachedInputTokens()
 		cacheCreation, _ := costs.CacheCreationInputTokens()
+		cacheCreation5m, _ := costs.CacheCreation5mInputTokens()
+		cacheCreation1h, _ := costs.CacheCreation1hInputTokens()
 		out, _ := costs.OutputTokens()
 		total, _ := costs.TotalTokens()
 		reasoning, _ := costs.ReasoningTokens()
@@ -897,6 +899,8 @@ func evalCost(costType filterapi.LLMRequestCostType, celProg cel.Program, costs 
 			in,
 			cachedIn,
 			cacheCreation,
+			cacheCreation5m,
+			cacheCreation1h,
 			out,
 			total,
 			reasoning,

--- a/internal/extproc/processor_impl_test.go
+++ b/internal/extproc/processor_impl_test.go
@@ -2480,3 +2480,61 @@ func mustCompileCEL(t *testing.T, expr string) cel.Program {
 	require.NoError(t, err)
 	return prog
 }
+
+// TestBuildDynamicMetadata_CacheCreationTTL exercises the whole cost pipeline
+// for a cached request: token usage in, CEL evaluated, cost out as metadata.
+//
+// It pins the reason the TTL breakdown was added. Anthropic charges 2x the base
+// input rate to create a one hour cache entry against 1.25x for five minutes, so
+// pricing both from the combined cache_creation_input_tokens under-charges the
+// longer-lived one.
+func TestBuildDynamicMetadata_CacheCreationTTL(t *testing.T) {
+	// Sonnet-like rates in units of 1e-9 USD per token: input 2.20/M,
+	// 5 minute write 2.75/M, 1 hour write 4.40/M.
+	prog, err := llmcostcel.NewProgram(
+		"cache_creation_5m_input_tokens * 2750u + cache_creation_1h_input_tokens * 4400u")
+	require.NoError(t, err)
+
+	costs := []filterapi.RuntimeRequestCost{{
+		CELProg: prog,
+		LLMRequestCost: &filterapi.LLMRequestCost{
+			RouteName: "some_route", Type: filterapi.LLMRequestCostTypeCEL, MetadataKey: "cost",
+		},
+	}}
+
+	for _, tc := range []struct {
+		name            string
+		fiveMinutes     uint32
+		oneHour         uint32
+		expectedCost    float64
+		combinedIsWrong bool
+	}{
+		{name: "five minute write", fiveMinutes: 10_000, expectedCost: 27_500_000},
+		{name: "one hour write", oneHour: 10_000, expectedCost: 44_000_000, combinedIsWrong: true},
+		{name: "mixed", fiveMinutes: 4_000, oneHour: 6_000, expectedCost: 37_400_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var usage metrics.TokenUsage
+			usage.SetCacheCreationInputTokens(tc.fiveMinutes + tc.oneHour)
+			usage.SetCacheCreation5mInputTokens(tc.fiveMinutes)
+			usage.SetCacheCreation1hInputTokens(tc.oneHour)
+
+			md, err := buildDynamicMetadata(nil, costs, &usage,
+				map[string]string{internalapi.ModelNameHeaderKeyDefault: "claude-sonnet-5"},
+				"some_backend", "some_route", "claude-sonnet-5")
+			require.NoError(t, err)
+
+			got := md.Fields[internalapi.AIGatewayFilterMetadataNamespace].
+				GetStructValue().Fields["cost"].GetNumberValue()
+			require.Equal(t, tc.expectedCost, got)
+
+			if tc.combinedIsWrong {
+				// What the same traffic would have cost when only the combined
+				// figure was available and everything was priced at 5 minutes.
+				atFiveMinuteRate := float64(tc.oneHour) * 2750
+				require.Less(t, atFiveMinuteRate, got,
+					"pricing a one hour write at the five minute rate under-charges")
+			}
+		})
+	}
+}

--- a/internal/filterapi/runtime_test.go
+++ b/internal/filterapi/runtime_test.go
@@ -59,7 +59,7 @@ func TestServer_LoadConfig(t *testing.T) {
 		require.Equal(t, "1 + 1", rc.RequestCosts[1].CEL)
 		prog := rc.RequestCosts[1].CELProg
 		require.NotNil(t, prog)
-		val, err := llmcostcel.EvaluateProgram(prog, "", "", "", 1, 1, 1, 1, 1, 0)
+		val, err := llmcostcel.EvaluateProgram(prog, "", "", "", 1, 1, 1, 0, 0, 1, 1, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), val)
 		require.Equal(t, config.Models, rc.DeclaredModels)

--- a/internal/llmcostcel/cel.go
+++ b/internal/llmcostcel/cel.go
@@ -22,9 +22,16 @@ const (
 	celInputTokensKey              = "input_tokens"
 	celCachedInputTokensKey        = "cached_input_tokens"         // #nosec G101
 	celCacheCreationInputTokensKey = "cache_creation_input_tokens" // #nosec G101
-	celOutputTokensKey             = "output_tokens"
-	celTotalTokensKey              = "total_tokens"
-	celReasoningTokensKey          = "reasoning_tokens"
+	// Breakdown of cache_creation_input_tokens by cache TTL. Providers price
+	// the two differently -- Anthropic charges 2x the base input rate for a
+	// 1 hour cache write against 1.25x for 5 minutes -- so an expression that
+	// sees only the combined figure cannot price a cached request correctly.
+	// Both are 0 on backends that do not report the breakdown.
+	celCacheCreation5mInputTokensKey = "cache_creation_5m_input_tokens" // #nosec G101
+	celCacheCreation1hInputTokensKey = "cache_creation_1h_input_tokens" // #nosec G101
+	celOutputTokensKey               = "output_tokens"
+	celTotalTokensKey                = "total_tokens"
+	celReasoningTokensKey            = "reasoning_tokens"
 )
 
 var env *cel.Env
@@ -38,6 +45,8 @@ func init() {
 		cel.Variable(celInputTokensKey, cel.UintType),
 		cel.Variable(celCachedInputTokensKey, cel.UintType),
 		cel.Variable(celCacheCreationInputTokensKey, cel.UintType),
+		cel.Variable(celCacheCreation5mInputTokensKey, cel.UintType),
+		cel.Variable(celCacheCreation1hInputTokensKey, cel.UintType),
 		cel.Variable(celOutputTokensKey, cel.UintType),
 		cel.Variable(celTotalTokensKey, cel.UintType),
 		cel.Variable(celReasoningTokensKey, cel.UintType),
@@ -60,7 +69,7 @@ func NewProgram(expr string) (prog cel.Program, err error) {
 	}
 
 	// Sanity check by evaluating the expression with some dummy values.
-	_, err = EvaluateProgram(prog, "dummy", "dummy", "dummy", 0, 0, 0, 0, 0, 0)
+	_, err = EvaluateProgram(prog, "dummy", "dummy", "dummy", 0, 0, 0, 0, 0, 0, 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate CEL expression: %w", err)
 	}
@@ -68,17 +77,19 @@ func NewProgram(expr string) (prog cel.Program, err error) {
 }
 
 // EvaluateProgram evaluates the given CEL program with the given variables.
-func EvaluateProgram(prog cel.Program, modelName, backend, routeName string, inputTokens, cachedInputTokens, cacheCreationInputTokens, outputTokens, totalTokens, reasoningTokens uint32) (uint64, error) {
+func EvaluateProgram(prog cel.Program, modelName, backend, routeName string, inputTokens, cachedInputTokens, cacheCreationInputTokens, cacheCreation5mInputTokens, cacheCreation1hInputTokens, outputTokens, totalTokens, reasoningTokens uint32) (uint64, error) {
 	out, _, err := prog.Eval(map[string]any{
-		celModelNameKey:                modelName,
-		celBackendKey:                  backend,
-		celRouteNameKey:                routeName,
-		celInputTokensKey:              inputTokens,
-		celCachedInputTokensKey:        cachedInputTokens,
-		celCacheCreationInputTokensKey: cacheCreationInputTokens,
-		celOutputTokensKey:             outputTokens,
-		celTotalTokensKey:              totalTokens,
-		celReasoningTokensKey:          reasoningTokens,
+		celModelNameKey:                  modelName,
+		celBackendKey:                    backend,
+		celRouteNameKey:                  routeName,
+		celInputTokensKey:                inputTokens,
+		celCachedInputTokensKey:          cachedInputTokens,
+		celCacheCreationInputTokensKey:   cacheCreationInputTokens,
+		celCacheCreation5mInputTokensKey: cacheCreation5mInputTokens,
+		celCacheCreation1hInputTokensKey: cacheCreation1hInputTokens,
+		celOutputTokensKey:               outputTokens,
+		celTotalTokensKey:                totalTokens,
+		celReasoningTokensKey:            reasoningTokens,
 	})
 	if err != nil || out == nil {
 		return 0, fmt.Errorf("failed to evaluate CEL expression: %w", err)

--- a/internal/llmcostcel/cel_test.go
+++ b/internal/llmcostcel/cel_test.go
@@ -28,11 +28,11 @@ func TestNewProgram(t *testing.T) {
 	t.Run("variables", func(t *testing.T) {
 		prog, err := NewProgram("model == 'cool_model' ?  (input_tokens - cached_input_tokens - cache_creation_input_tokens) * output_tokens  : total_tokens")
 		require.NoError(t, err)
-		v, err := EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 200, 100, 1, 2, 3, 0)
+		v, err := EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 200, 100, 1, 0, 0, 2, 3, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint64(198), v)
 
-		v, err = EvaluateProgram(prog, "not_cool_model", "cool_backend", "cool_route", 200, 100, 1, 2, 3, 0)
+		v, err = EvaluateProgram(prog, "not_cool_model", "cool_backend", "cool_route", 200, 100, 1, 0, 0, 2, 3, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), v)
 	})
@@ -59,21 +59,28 @@ func TestEvaluateProgram(t *testing.T) {
 	t.Run("signed integer negative", func(t *testing.T) {
 		prog, err := NewProgram("int(input_tokens) - int(output_tokens)")
 		require.NoError(t, err)
-		_, err = EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 100, 0, 0, 2000, 3, 0)
+		_, err = EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 100, 0, 0, 0, 0, 2000, 3, 0)
 		require.ErrorContains(t, err, "CEL expression result is negative (-1900)")
 	})
 	t.Run("unsigned integer overflow", func(t *testing.T) {
 		prog, err := NewProgram("input_tokens - output_tokens")
 		require.NoError(t, err)
-		_, err = EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 100, 0, 0, 2000, 3, 0)
+		_, err = EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 100, 0, 0, 0, 0, 2000, 3, 0)
 		require.ErrorContains(t, err, "failed to evaluate CEL expression: unsigned integer overflow")
 	})
 	t.Run("reasoning_tokens variable", func(t *testing.T) {
 		prog, err := NewProgram("output_tokens + reasoning_tokens")
 		require.NoError(t, err)
-		v, err := EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 0, 0, 0, 100, 0, 50)
+		v, err := EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 0, 0, 0, 0, 0, 100, 0, 50)
 		require.NoError(t, err)
 		require.Equal(t, uint64(150), v)
+	})
+	t.Run("cache creation ttl variables", func(t *testing.T) {
+		prog, err := NewProgram("cache_creation_5m_input_tokens + 2u * cache_creation_1h_input_tokens")
+		require.NoError(t, err)
+		v, err := EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 0, 0, 30, 10, 20, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, uint64(50), v)
 	})
 	t.Run("ensure concurrency safety", func(t *testing.T) {
 		prog, err := NewProgram("model == 'cool_model' ?  input_tokens * output_tokens : total_tokens")
@@ -83,7 +90,7 @@ func TestEvaluateProgram(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			for range 100 {
 				go func() {
-					v, err := EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 100, 0, 0, 2, 3, 0)
+					v, err := EvaluateProgram(prog, "cool_model", "cool_backend", "cool_route", 100, 0, 0, 0, 0, 2, 3, 0)
 					require.NoError(t, err)
 					require.Equal(t, uint64(200), v)
 				}()

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -151,10 +151,20 @@ type TokenUsage struct {
 	cachedInputTokens uint32
 	// CacheCreationInputTokens is the total number of tokens written to cache.
 	cacheCreationInputTokens uint32
+	// cacheCreation5mInputTokens is the number of tokens written to a cache
+	// entry with a 5 minute TTL. Part of cacheCreationInputTokens.
+	cacheCreation5mInputTokens uint32
+	// cacheCreation1hInputTokens is the number of tokens written to a cache
+	// entry with a 1 hour TTL. Part of cacheCreationInputTokens.
+	//
+	// Providers price the two differently, so a cost expression needs the
+	// breakdown and not just the total.
+	cacheCreation1hInputTokens uint32
 	// ReasoningTokens is the number of reasoning tokens consumed.
 	reasoningTokens uint32
 
 	inputTokenSet, outputTokenSet, totalTokenSet, cachedInputTokenSet, cacheCreationInputTokenSet, reasoningTokenSet bool
+	cacheCreation5mInputTokenSet, cacheCreation1hInputTokenSet                                                       bool
 }
 
 // InputTokens returns the number of input tokens and whether it was set.
@@ -204,6 +214,32 @@ func (u *TokenUsage) SetTotalTokens(tokens uint32) {
 func (u *TokenUsage) SetCachedInputTokens(tokens uint32) {
 	u.cachedInputTokens = tokens
 	u.cachedInputTokenSet = true
+}
+
+// CacheCreation5mInputTokens returns the number of tokens written to a cache
+// entry with a 5 minute TTL and whether it was set.
+func (u *TokenUsage) CacheCreation5mInputTokens() (uint32, bool) {
+	return u.cacheCreation5mInputTokens, u.cacheCreation5mInputTokenSet
+}
+
+// CacheCreation1hInputTokens returns the number of tokens written to a cache
+// entry with a 1 hour TTL and whether it was set.
+func (u *TokenUsage) CacheCreation1hInputTokens() (uint32, bool) {
+	return u.cacheCreation1hInputTokens, u.cacheCreation1hInputTokenSet
+}
+
+// SetCacheCreation5mInputTokens sets the number of 5 minute TTL cache creation
+// tokens and marks the field as set.
+func (u *TokenUsage) SetCacheCreation5mInputTokens(tokens uint32) {
+	u.cacheCreation5mInputTokens = tokens
+	u.cacheCreation5mInputTokenSet = true
+}
+
+// SetCacheCreation1hInputTokens sets the number of 1 hour TTL cache creation
+// tokens and marks the field as set.
+func (u *TokenUsage) SetCacheCreation1hInputTokens(tokens uint32) {
+	u.cacheCreation1hInputTokens = tokens
+	u.cacheCreation1hInputTokenSet = true
 }
 
 // SetCacheCreationInputTokens sets the number of cache creation input tokens and marks the field as set.
@@ -256,7 +292,8 @@ func (u *TokenUsage) AddReasoningTokens(tokens uint32) {
 // IsZero reports whether no token usage field has been set.
 func (u *TokenUsage) IsZero() bool {
 	return !u.inputTokenSet && !u.outputTokenSet && !u.totalTokenSet &&
-		!u.cachedInputTokenSet && !u.cacheCreationInputTokenSet && !u.reasoningTokenSet
+		!u.cachedInputTokenSet && !u.cacheCreationInputTokenSet && !u.reasoningTokenSet &&
+		!u.cacheCreation5mInputTokenSet && !u.cacheCreation1hInputTokenSet
 }
 
 // Override updates the TokenUsage fields with values from another TokenUsage instance.
@@ -282,6 +319,14 @@ func (u *TokenUsage) Override(other TokenUsage) {
 		u.cacheCreationInputTokens = other.cacheCreationInputTokens
 		u.cacheCreationInputTokenSet = true
 	}
+	if other.cacheCreation5mInputTokenSet {
+		u.cacheCreation5mInputTokens = other.cacheCreation5mInputTokens
+		u.cacheCreation5mInputTokenSet = true
+	}
+	if other.cacheCreation1hInputTokenSet {
+		u.cacheCreation1hInputTokens = other.cacheCreation1hInputTokens
+		u.cacheCreation1hInputTokenSet = true
+	}
 	if other.reasoningTokenSet {
 		u.reasoningTokens = other.reasoningTokens
 		u.reasoningTokenSet = true
@@ -296,11 +341,25 @@ func (u *TokenUsage) Override(other TokenUsage) {
 // This function works for both streaming and non-streaming responses by accepting
 // the common usage fields that exist from anthropic or AWS bedrock usage structures.
 func ExtractTokenUsageFromExplicitCaching(inputTokens, outputTokens int64, cacheReadTokens, cacheCreationTokens *int64) TokenUsage {
+	return ExtractTokenUsageFromExplicitCachingWithTTL(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, nil, nil)
+}
+
+// ExtractTokenUsageFromExplicitCachingWithTTL is ExtractTokenUsageFromExplicitCaching
+// with the optional breakdown of cache creation tokens by cache TTL, which
+// providers price differently. Pass nil for either when the backend does not
+// report it; the totals are unaffected.
+func ExtractTokenUsageFromExplicitCachingWithTTL(inputTokens, outputTokens int64, cacheReadTokens, cacheCreationTokens, cacheCreation5mTokens, cacheCreation1hTokens *int64) TokenUsage {
 	var usage TokenUsage
 	totalInputTokens := inputTokens
 	if cacheCreationTokens != nil {
 		totalInputTokens += *cacheCreationTokens
 		usage.SetCacheCreationInputTokens(uint32(*cacheCreationTokens)) //nolint:gosec
+	}
+	if cacheCreation5mTokens != nil {
+		usage.SetCacheCreation5mInputTokens(uint32(*cacheCreation5mTokens)) //nolint:gosec
+	}
+	if cacheCreation1hTokens != nil {
+		usage.SetCacheCreation1hInputTokens(uint32(*cacheCreation1hTokens)) //nolint:gosec
 	}
 	if cacheReadTokens != nil {
 		totalInputTokens += *cacheReadTokens

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"k8s.io/utils/ptr"
 
 	internaltesting "github.com/envoyproxy/ai-gateway/internal/testing"
 )
@@ -476,4 +477,59 @@ func TestTokenUsage_IsZero(t *testing.T) {
 
 	u.SetOutputTokens(1)
 	require.False(t, u.IsZero())
+}
+
+func TestExtractTokenUsageFromExplicitCachingWithTTL(t *testing.T) {
+	t.Run("splits cache creation by ttl", func(t *testing.T) {
+		usage := ExtractTokenUsageFromExplicitCachingWithTTL(
+			10, 5, ptr.To(int64(20)), ptr.To(int64(30)), ptr.To(int64(12)), ptr.To(int64(18)))
+
+		fiveMinutes, ok := usage.CacheCreation5mInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(12), fiveMinutes)
+
+		oneHour, ok := usage.CacheCreation1hInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(18), oneHour)
+
+		// The breakdown must not disturb the existing totals.
+		creation, ok := usage.CacheCreationInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(30), creation)
+		input, _ := usage.InputTokens()
+		require.Equal(t, uint32(60), input, "input + cache read + cache creation")
+	})
+
+	t.Run("absent breakdown leaves the fields unset", func(t *testing.T) {
+		usage := ExtractTokenUsageFromExplicitCachingWithTTL(
+			10, 5, ptr.To(int64(20)), ptr.To(int64(30)), nil, nil)
+
+		_, ok := usage.CacheCreation5mInputTokens()
+		require.False(t, ok, "backends that do not report the breakdown must not appear to report zero")
+		_, ok = usage.CacheCreation1hInputTokens()
+		require.False(t, ok)
+	})
+
+	t.Run("the existing entry point is unchanged", func(t *testing.T) {
+		usage := ExtractTokenUsageFromExplicitCaching(10, 5, ptr.To(int64(20)), ptr.To(int64(30)))
+		_, ok := usage.CacheCreation5mInputTokens()
+		require.False(t, ok)
+	})
+}
+
+func TestTokenUsageOverrideCarriesCacheTTL(t *testing.T) {
+	var base TokenUsage
+	base.SetCacheCreation1hInputTokens(7)
+
+	var other TokenUsage
+	other.SetCacheCreation5mInputTokens(3)
+	base.Override(other)
+
+	fiveMinutes, ok := base.CacheCreation5mInputTokens()
+	require.True(t, ok)
+	require.Equal(t, uint32(3), fiveMinutes)
+
+	oneHour, ok := base.CacheCreation1hInputTokens()
+	require.True(t, ok)
+	require.Equal(t, uint32(7), oneHour, "a field absent from the override must survive")
 }

--- a/internal/translator/anthropic_anthropic.go
+++ b/internal/translator/anthropic_anthropic.go
@@ -116,17 +116,30 @@ func (a *anthropicToAnthropicTranslator) ResponseBody(_ map[string]string, body 
 	}
 
 	usage := anthropicResp.Usage
-	tokenUsage = metrics.ExtractTokenUsageFromExplicitCaching(
+	cacheCreation5m, cacheCreation1h := cacheCreationByTTL(usage.CacheCreation)
+	tokenUsage = metrics.ExtractTokenUsageFromExplicitCachingWithTTL(
 		int64(usage.InputTokens),
 		int64(usage.OutputTokens),
 		ptr.To(int64(usage.CacheReadInputTokens)),
 		ptr.To(int64(usage.CacheCreationInputTokens)),
+		cacheCreation5m,
+		cacheCreation1h,
 	)
 	if span != nil {
 		span.RecordResponse(anthropicResp)
 	}
 	responseModel = cmp.Or(anthropicResp.Model, a.requestModel)
 	return nil, nil, tokenUsage, responseModel, nil
+}
+
+// cacheCreationByTTL splits Anthropic's cache creation tokens by cache TTL.
+// Returns (nil, nil) when the backend does not report the breakdown, leaving
+// the combined CacheCreationInputTokens as the only signal.
+func cacheCreationByTTL(cc *anthropic.CacheCreation) (fiveMinutes, oneHour *int64) {
+	if cc == nil {
+		return nil, nil
+	}
+	return ptr.To(int64(cc.Ephemeral5mInputTokens)), ptr.To(int64(cc.Ephemeral1hInputTokens))
 }
 
 // extractUsageFromBufferEvent extracts the token usage from the buffered event.
@@ -166,11 +179,14 @@ func (a *anthropicToAnthropicTranslator) reflectStreamingEvent(eventUnion *anthr
 		}
 		// Extract usage from message_start event - this sets the baseline input tokens
 		if u := message.Usage; u != nil {
-			messageStartUsage := metrics.ExtractTokenUsageFromExplicitCaching(
+			startCacheCreation5m, startCacheCreation1h := cacheCreationByTTL(u.CacheCreation)
+			messageStartUsage := metrics.ExtractTokenUsageFromExplicitCachingWithTTL(
 				int64(u.InputTokens),
 				int64(u.OutputTokens),
 				ptr.To(int64(u.CacheReadInputTokens)),
 				ptr.To(int64(u.CacheCreationInputTokens)),
+				startCacheCreation5m,
+				startCacheCreation1h,
 			)
 			// Override with message_start usage (contains input tokens and initial state)
 			a.streamingTokenUsage.Override(messageStartUsage)
@@ -214,6 +230,18 @@ func (a *anthropicToAnthropicTranslator) reflectStreamingEvent(eventUnion *anthr
 			a.streamingTokenUsage.SetCachedInputTokens(cacheRead)
 			a.streamingTokenUsage.SetCacheCreationInputTokens(cacheCreation)
 			a.streamingTokenUsage.SetInputTokens(rawInput + cacheRead + cacheCreation)
+
+			// The TTL breakdown is normally reported once, on message_start. Only
+			// overwrite it when this delta actually carries it, for the same
+			// reason the fields above are merged rather than replaced.
+			if cc := u.CacheCreation; cc != nil {
+				if cc.Ephemeral5mInputTokens > 0 {
+					a.streamingTokenUsage.SetCacheCreation5mInputTokens(uint32(cc.Ephemeral5mInputTokens)) //nolint:gosec
+				}
+				if cc.Ephemeral1hInputTokens > 0 {
+					a.streamingTokenUsage.SetCacheCreation1hInputTokens(uint32(cc.Ephemeral1hInputTokens)) //nolint:gosec
+				}
+			}
 		}
 	}
 }

--- a/internal/translator/anthropic_anthropic_test.go
+++ b/internal/translator/anthropic_anthropic_test.go
@@ -136,7 +136,10 @@ func TestAnthropicToAnthropic_ResponseBody_non_streaming(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, headerMutation)
 	require.Nil(t, bodyMutation)
-	expected := tokenUsageFrom(9, 0, 0, 16, 25, -1)
+	// The fixture reports `cache_creation` explicitly, so both TTL buckets are
+	// present and zero -- which is not the same as the backend omitting them.
+	expected := tokenUsageFrom(9, 0, 0, 16, 25, -1,
+		cacheTTLTokens{cacheTTL5m, 0}, cacheTTLTokens{cacheTTL1h, 0})
 	require.Equal(t, expected, tokenUsage)
 	require.Equal(t, "claude-sonnet-4-5-20250929", responseModel)
 }
@@ -182,7 +185,8 @@ data: {"type":"message_stop"       }`
 	require.NoError(t, err)
 	require.Nil(t, headerMutation)
 	require.Nil(t, bodyMutation)
-	expected := tokenUsageFrom(10, 1, 0, 0, 10, -1)
+	expected := tokenUsageFrom(10, 1, 0, 0, 10, -1,
+		cacheTTLTokens{cacheTTL5m, 0}, cacheTTLTokens{cacheTTL1h, 0})
 	require.Equal(t, expected, tokenUsage)
 	require.Equal(t, "claude-sonnet-4-5-20250929", responseModel)
 
@@ -190,7 +194,8 @@ data: {"type":"message_stop"       }`
 	require.NoError(t, err)
 	require.Nil(t, headerMutation)
 	require.Nil(t, bodyMutation)
-	expected = tokenUsageFrom(10, 1, 0, 16, 26, -1)
+	expected = tokenUsageFrom(10, 1, 0, 16, 26, -1,
+		cacheTTLTokens{cacheTTL5m, 0}, cacheTTLTokens{cacheTTL1h, 0})
 	require.Equal(t, expected, tokenUsage)
 	require.Equal(t, "claude-sonnet-4-5-20250929", responseModel)
 }
@@ -328,4 +333,52 @@ data:{"type":"message_stop"}`
 	require.NoError(t, err)
 	require.Equal(t, tokenUsageFrom(10, 1, 0, 16, 26, -1), tokenUsage)
 	require.Equal(t, "claude-sonnet-4-5-20250929", responseModel)
+}
+
+// TestAnthropicToAnthropic_CacheCreationTTLBreakdown pins that the cache TTL
+// split survives the translator. Anthropic prices a 1 hour cache write at 2x
+// the base input rate against 1.25x for 5 minutes, so a cost expression that
+// only sees the combined cache_creation_input_tokens cannot price the request.
+func TestAnthropicToAnthropic_CacheCreationTTLBreakdown(t *testing.T) {
+	// Captured from Vertex AI, claude-sonnet-5, with cache_control ttl "1h".
+	const body = `{"model":"claude-sonnet-5","id":"msg_1","type":"message","role":"assistant",
+		"content":[{"type":"text","text":"ok"}],
+		"usage":{"input_tokens":6,"cache_creation_input_tokens":8754,"cache_read_input_tokens":0,
+		"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":8754},
+		"output_tokens":16}}`
+
+	tr := &anthropicToAnthropicTranslator{requestModel: "claude-sonnet-5"}
+	_, _, usage, _, err := tr.ResponseBody(nil, strings.NewReader(body), true, nil)
+	require.NoError(t, err)
+
+	oneHour, ok := usage.CacheCreation1hInputTokens()
+	require.True(t, ok, "the 1 hour breakdown must reach the cost expression")
+	require.Equal(t, uint32(8754), oneHour)
+
+	fiveMinutes, ok := usage.CacheCreation5mInputTokens()
+	require.True(t, ok)
+	require.Zero(t, fiveMinutes)
+
+	// Unchanged behaviour: the combined figure and the unified input total.
+	creation, _ := usage.CacheCreationInputTokens()
+	require.Equal(t, uint32(8754), creation)
+	input, _ := usage.InputTokens()
+	require.Equal(t, uint32(8760), input)
+}
+
+// TestAnthropicToAnthropic_NoCacheCreationBreakdown covers backends that do not
+// report the split: the fields must stay unset rather than reporting zero.
+func TestAnthropicToAnthropic_NoCacheCreationBreakdown(t *testing.T) {
+	const body = `{"model":"claude-sonnet-5","id":"msg_1","type":"message","role":"assistant",
+		"content":[{"type":"text","text":"ok"}],
+		"usage":{"input_tokens":6,"cache_creation_input_tokens":8754,"cache_read_input_tokens":0,"output_tokens":16}}`
+
+	tr := &anthropicToAnthropicTranslator{requestModel: "claude-sonnet-5"}
+	_, _, usage, _, err := tr.ResponseBody(nil, strings.NewReader(body), true, nil)
+	require.NoError(t, err)
+
+	_, ok := usage.CacheCreation1hInputTokens()
+	require.False(t, ok)
+	creation, _ := usage.CacheCreationInputTokens()
+	require.Equal(t, uint32(8754), creation, "the combined figure is unaffected")
 }

--- a/internal/translator/anthropic_gcpanthropic_test.go
+++ b/internal/translator/anthropic_gcpanthropic_test.go
@@ -659,7 +659,21 @@ func TestAnthropicToGCPAnthropicTranslator_ResponseBody_StreamingEdgeCases(t *te
 	}
 }
 
-func tokenUsageFrom(in, cachedInput, cacheCreationInput, out, total, reasoning int32) metrics.TokenUsage {
+type cacheTTLWindow int
+
+const (
+	cacheTTL5m cacheTTLWindow = iota
+	cacheTTL1h
+)
+
+// cacheTTLTokens expresses "the response reported this many tokens for this
+// TTL", which is distinct from the field being absent.
+type cacheTTLTokens struct {
+	window cacheTTLWindow
+	tokens uint32
+}
+
+func tokenUsageFrom(in, cachedInput, cacheCreationInput, out, total, reasoning int32, cacheCreationByTTL ...cacheTTLTokens) metrics.TokenUsage {
 	var usage metrics.TokenUsage
 	if in >= 0 {
 		usage.SetInputTokens(uint32(in))
@@ -669,6 +683,14 @@ func tokenUsageFrom(in, cachedInput, cacheCreationInput, out, total, reasoning i
 	}
 	if cacheCreationInput >= 0 {
 		usage.SetCacheCreationInputTokens(uint32(cacheCreationInput))
+	}
+	for _, ttl := range cacheCreationByTTL {
+		switch ttl.window {
+		case cacheTTL5m:
+			usage.SetCacheCreation5mInputTokens(ttl.tokens)
+		case cacheTTL1h:
+			usage.SetCacheCreation1hInputTokens(ttl.tokens)
+		}
 	}
 	if out >= 0 {
 		usage.SetOutputTokens(uint32(out))

--- a/site/docs/capabilities/traffic/quota-policy.md
+++ b/site/docs/capabilities/traffic/quota-policy.md
@@ -118,17 +118,34 @@ By default, a request's cost is its `total_tokens`. You can override this with a
 [CEL](https://github.com/google/cel-spec) expression that weights token types differently. The
 following variables are available in a `costExpression`:
 
-| Variable                      | Type   | Description                                      |
-| ----------------------------- | ------ | ------------------------------------------------ |
-| `input_tokens`                | uint   | Prompt / input tokens.                           |
-| `output_tokens`               | uint   | Completion / output tokens.                      |
-| `total_tokens`                | uint   | Total tokens (the default cost).                 |
-| `cached_input_tokens`         | uint   | Input tokens served from the provider's cache.   |
-| `cache_creation_input_tokens` | uint   | Input tokens charged for writing to the cache.   |
-| `reasoning_tokens`            | uint   | Reasoning tokens (for reasoning-capable models). |
-| `model`                       | string | The resolved model name.                         |
-| `backend`                     | string | The serving backend name.                        |
-| `route_name`                  | string | The route name.                                  |
+| Variable                         | Type   | Description                                      |
+| -------------------------------- | ------ | ------------------------------------------------ |
+| `input_tokens`                   | uint   | Prompt / input tokens.                           |
+| `output_tokens`                  | uint   | Completion / output tokens.                      |
+| `total_tokens`                   | uint   | Total tokens (the default cost).                 |
+| `cached_input_tokens`            | uint   | Input tokens served from the provider's cache.   |
+| `cache_creation_input_tokens`    | uint   | Input tokens charged for writing to the cache.   |
+| `cache_creation_5m_input_tokens` | uint   | Of the above, those written with a 5 minute TTL. |
+| `cache_creation_1h_input_tokens` | uint   | Of the above, those written with a 1 hour TTL.   |
+| `reasoning_tokens`               | uint   | Reasoning tokens (for reasoning-capable models). |
+| `model`                          | string | The resolved model name.                         |
+| `backend`                        | string | The serving backend name.                        |
+| `route_name`                     | string | The route name.                                  |
+
+:::note Cache writes are not all priced the same
+Providers charge more to create a longer-lived cache entry: Anthropic bills a
+1 hour cache write at 2x the base input rate against 1.25x for 5 minutes. A
+`costExpression` using only `cache_creation_input_tokens` therefore under-charges
+long-lived cache writes, which for cache-heavy clients can be a large share of a
+bill. Use the two TTL variables to price them apart:
+
+```
+cache_creation_5m_input_tokens * 275u + cache_creation_1h_input_tokens * 440u
+```
+
+Both are `0` on backends that do not report the breakdown, so an existing
+expression keeps working unchanged.
+:::
 
 ```yaml
 perModelQuotas:


### PR DESCRIPTION
**Description**

Creating a cache entry is not priced at a single rate. Anthropic charges twice the
base input rate for an entry that lives an hour, against 1.25x for one that lives
five minutes. Responses already report which was used, in `usage.cache_creation`,
but only the combined `cache_creation_input_tokens` was read — so a
`costExpression` cannot tell the two apart and under-charges the longer-lived
writes. On cache-heavy clients those writes can be the largest single item on a
bill, so the gap is not a rounding difference.

This adds `cache_creation_5m_input_tokens` and `cache_creation_1h_input_tokens`
as CEL variables, populated from `usage.cache_creation` on both the streaming and
non-streaming Anthropic paths. They can be used instead of the combined figure:

```
cache_creation_5m_input_tokens * 275u + cache_creation_1h_input_tokens * 440u
```

Nothing changes for existing users: the combined field keeps its meaning, and the
two new variables are `0` when a backend does not report the breakdown.

**Related Issues/PRs (if applicable)**

None.

**Special notes for reviewers (if applicable)**

- `IsZero()` and `Override()` were extended to cover the new fields, for
  consistency with the existing ones.
- Where a response reports `cache_creation` with zero values, the fields are
  marked as set rather than absent — present-and-zero is a different statement
  from not reported. Two existing test fixtures include that block, so their
  expectations were updated.
- Verified against live Vertex AI responses for both TTLs, streaming and not.
  `make precommit` and `go test ./internal/...` pass.
- Written with AI assistance; I have reviewed and tested the change.
