### PR TITLE
fix(anthropic): avoid quadratic stream folding allocation

### DIFF
--- a/internal/apischema/anthropic/stream_fold.go
+++ b/internal/apischema/anthropic/stream_fold.go
@@ -5,7 +5,11 @@
 
 package anthropic
 
-import "github.com/envoyproxy/ai-gateway/internal/json"
+import (
+	"strings"
+
+	"github.com/envoyproxy/ai-gateway/internal/json"
+)
 
 // MessagesResponseFromStream folds a complete stream of chunks back into the
 // MessagesResponse the provider sent, so a streamed response can be recorded
@@ -16,6 +20,9 @@ import "github.com/envoyproxy/ai-gateway/internal/json"
 func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse {
 	var response MessagesResponse
 	toolInputs := make(map[int]string)
+	textBuffers := make(map[int]*strings.Builder)
+	thinkingBuffers := make(map[int]*strings.Builder)
+	toolBuffers := make(map[int]*strings.Builder)
 
 	for _, event := range chunks {
 		if event == nil {
@@ -23,6 +30,8 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 		}
 		switch {
 		case event.MessageStart != nil:
+			clear(textBuffers)
+			clear(thinkingBuffers)
 			response = *(*MessagesResponse)(event.MessageStart)
 			// Ensure Content is initialized if nil.
 			if response.Content == nil {
@@ -58,6 +67,8 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 			// append to it in place, which would otherwise mutate the input and
 			// make a second fold of the same chunks produce doubled content.
 			response.Content[idx] = copyContentBlock(event.ContentBlockStart.ContentBlock)
+			delete(textBuffers, idx)
+			delete(thinkingBuffers, idx)
 
 		case event.ContentBlockDelta != nil:
 			idx := event.ContentBlockDelta.Index
@@ -66,14 +77,14 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 				delta := event.ContentBlockDelta.Delta
 
 				if block.Text != nil && delta.Text != "" {
-					block.Text.Text += delta.Text
+					block.Text.Text = appendStreamText(textBuffers, idx, block.Text.Text, delta.Text)
 				}
 				if block.Tool != nil && delta.PartialJSON != "" {
-					toolInputs[idx] += delta.PartialJSON
+					toolInputs[idx] = appendStreamText(toolBuffers, idx, toolInputs[idx], delta.PartialJSON)
 				}
 				if block.Thinking != nil {
 					if delta.Thinking != "" {
-						block.Thinking.Thinking += delta.Thinking
+						block.Thinking.Thinking = appendStreamText(thinkingBuffers, idx, block.Thinking.Thinking, delta.Thinking)
 					}
 					if delta.Signature != "" {
 						block.Thinking.Signature = delta.Signature
@@ -91,6 +102,7 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 					}
 				}
 				delete(toolInputs, idx)
+				delete(toolBuffers, idx)
 			}
 
 		case event.MessageStop != nil:
@@ -98,6 +110,19 @@ func MessagesResponseFromStream(chunks []*MessagesStreamChunk) *MessagesResponse
 		}
 	}
 	return &response
+}
+
+// Keep one buffer per interleaved block so appending a delta does not copy the
+// entire accumulated prefix. Builders are pointers because they cannot be copied.
+func appendStreamText(buffers map[int]*strings.Builder, idx int, initial, delta string) string {
+	buffer := buffers[idx]
+	if buffer == nil {
+		buffer = &strings.Builder{}
+		buffer.WriteString(initial)
+		buffers[idx] = buffer
+	}
+	buffer.WriteString(delta)
+	return buffer.String()
 }
 
 // copyContentBlock deep-copies the fields the fold mutates, so folding does not

--- a/internal/apischema/anthropic/stream_fold_bench_test.go
+++ b/internal/apischema/anthropic/stream_fold_bench_test.go
@@ -1,0 +1,37 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package anthropic
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// BenchmarkMessagesResponseFromStream isolates folding allocation from event
+// decoding and span export. Each text fragment owns its backing storage.
+func BenchmarkMessagesResponseFromStream(b *testing.B) {
+	const deltaBytes = 128
+	for _, count := range []int{128, 1024, 8192} {
+		b.Run(fmt.Sprintf("chunks=%d", count), func(b *testing.B) {
+			chunks := []*MessagesStreamChunk{{ContentBlockStart: &MessagesStreamChunkContentBlockStart{
+				ContentBlock: MessagesContentBlock{Text: &TextBlock{}},
+			}}}
+			for range count {
+				chunks = append(chunks, &MessagesStreamChunk{ContentBlockDelta: &MessagesStreamChunkContentBlockDelta{
+					Delta: ContentBlockDelta{Text: strings.Repeat("x", deltaBytes)},
+				}})
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(count * deltaBytes))
+			for b.Loop() {
+				response := MessagesResponseFromStream(chunks)
+				runtime.KeepAlive(response)
+			}
+		})
+	}
+}

--- a/internal/apischema/anthropic/stream_fold_buffers_test.go
+++ b/internal/apischema/anthropic/stream_fold_buffers_test.go
@@ -1,0 +1,49 @@
+// Copyright Envoy AI Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessagesResponseFromStream_interleavedBuffers(t *testing.T) {
+	chunks := []*MessagesStreamChunk{
+		{ContentBlockStart: &MessagesStreamChunkContentBlockStart{Index: 0, ContentBlock: MessagesContentBlock{Text: &TextBlock{Text: "prefix "}}}},
+		{ContentBlockStart: &MessagesStreamChunkContentBlockStart{Index: 1, ContentBlock: MessagesContentBlock{Thinking: &ThinkingBlock{Thinking: "reason "}}}},
+		{ContentBlockStart: &MessagesStreamChunkContentBlockStart{Index: 2, ContentBlock: MessagesContentBlock{Tool: &ToolUseBlock{}}}},
+	}
+	for _, part := range []string{"a", "b", "c"} {
+		chunks = append(chunks,
+			&MessagesStreamChunk{ContentBlockDelta: &MessagesStreamChunkContentBlockDelta{Index: 0, Delta: ContentBlockDelta{Text: part}}},
+			&MessagesStreamChunk{ContentBlockDelta: &MessagesStreamChunkContentBlockDelta{Index: 1, Delta: ContentBlockDelta{Thinking: part, Signature: "sig"}}},
+		)
+	}
+	for _, part := range []string{`{"value":`, `"abc"`, `}`} {
+		chunks = append(chunks, &MessagesStreamChunk{ContentBlockDelta: &MessagesStreamChunkContentBlockDelta{Index: 2, Delta: ContentBlockDelta{PartialJSON: part}}})
+	}
+	chunks = append(chunks, &MessagesStreamChunk{ContentBlockStop: &MessagesStreamChunkContentBlockStop{Index: 2}})
+	for range 2 {
+		response := MessagesResponseFromStream(chunks)
+		require.Equal(t, "prefix abc", response.Content[0].Text.Text)
+		require.Equal(t, "reason abc", response.Content[1].Thinking.Thinking)
+		require.Equal(t, "sig", response.Content[1].Thinking.Signature)
+		require.Equal(t, map[string]any{"value": "abc"}, response.Content[2].Tool.Input)
+	}
+	require.Equal(t, "prefix ", chunks[0].ContentBlockStart.ContentBlock.Text.Text)
+	require.Equal(t, "reason ", chunks[1].ContentBlockStart.ContentBlock.Thinking.Thinking)
+}
+
+func TestMessagesResponseFromStream_replacedBlockBuffer(t *testing.T) {
+	response := MessagesResponseFromStream([]*MessagesStreamChunk{
+		{ContentBlockStart: &MessagesStreamChunkContentBlockStart{ContentBlock: MessagesContentBlock{Text: &TextBlock{Text: "old"}}}},
+		{ContentBlockDelta: &MessagesStreamChunkContentBlockDelta{Delta: ContentBlockDelta{Text: " discarded"}}},
+		{ContentBlockStart: &MessagesStreamChunkContentBlockStart{ContentBlock: MessagesContentBlock{Text: &TextBlock{Text: "new"}}}},
+		{ContentBlockDelta: &MessagesStreamChunkContentBlockDelta{Delta: ContentBlockDelta{Text: " kept"}}},
+	})
+	require.Equal(t, "new kept", response.Content[0].Text.Text)
+}


### PR DESCRIPTION
**Description**

Anthropic stream folding repeatedly concatenates growing text, thinking, and tool-argument strings. Each delta copies the entire accumulated prefix, causing quadratic allocation for long responses, including GenAI traces with message-content capture disabled.

Accumulate fragments in per-block `strings.Builder` buffers while preserving initial content, interleaved indices, block replacement, and tool argument parsing at block stop. Add regression tests and a fold-only benchmark. This removes repeated prefix copies but does not implement a bounded-memory recorder or stop retaining source chunks.

**Related Issues/PRs (if applicable)**

Concrete performance improvement supporting #2668. Independent of the proposed configuration and recorder-interface changes, and of the usage-alias fix in #2635.

**Special notes for reviewers (if applicable)**

Using the same sampled-span benchmark from #2668 (1 MiB text, 8,192 deltas, content capture off), cumulative allocation fell from 4,330,508,344 B/op to 8,048,784 B/op, approximately a 99.8% reduction. These are second runs with `-benchtime=1x -count=2`, not peak heap or statistically rigorous latency claims.

Local validation uses Go 1.26.6 / Windows amd64 in the isolated `1899d8d4` checkout used for the proposal baseline, with this implementation and tests applied. `go test ./internal/apischema/anthropic ./internal/tracing -count=1` and the full-span benchmark pass. The PR is based on current main; its Go 1.27.1 validation remains for CI.

Developed with assistance from OpenAI Codex.
