### PR TITLE
fix(translator): accept CRLF SSE framing in the Responses usage parser

### DIFF
--- a/internal/translator/openai_responses.go
+++ b/internal/translator/openai_responses.go
@@ -172,14 +172,15 @@ func setTokenUsageFromResponse(tokenUsage *metrics.TokenUsage, resp *openai.Resp
 // response.incomplete or response.failed events.
 func (o *openAIToOpenAITranslatorV1Responses) extractUsageFromBufferEvent(span tracingapi.ResponsesSpan) (tokenUsage metrics.TokenUsage) {
 	for {
-		// SSE event boundary is a blank line: "data: {json}\n\n".
-		i := bytes.Index(o.buffered, []byte("\n\n"))
+		// SSE event boundaries are blank lines: "data: {json}\n\n" (LF) or "data: {json}\r\n\r\n" (CRLF).
+		i, sepLen := indexSSEEventBoundary(o.buffered)
 		if i == -1 {
 			return tokenUsage
 		}
 		event := o.buffered[:i]
-		o.buffered = o.buffered[i+2:]
+		o.buffered = o.buffered[i+sepLen:]
 		for line := range bytes.SplitSeq(event, []byte("\n")) {
+			line = bytes.TrimSuffix(line, []byte("\r"))
 			// Look for lines carrying the "data" field.
 			data, ok := cutSSEDataPrefix(line)
 			if !ok {

--- a/internal/translator/openai_responses_test.go
+++ b/internal/translator/openai_responses_test.go
@@ -512,6 +512,136 @@ data: [DONE]
 		require.True(t, ok)
 		require.Equal(t, uint32(10), inputTokens)
 	})
+
+	t.Run("streaming response with CRLF framing", func(t *testing.T) {
+		translator := NewResponsesOpenAIToOpenAITranslator("v1", "").(*openAIToOpenAITranslatorV1Responses)
+
+		req := &openai.ResponseRequest{
+			Model:  "gpt-4o",
+			Stream: true,
+			Input: openai.ResponseNewParamsInputUnion{
+				OfString: ptr.To("Hi"),
+			},
+		}
+		original := []byte(`{"model":"gpt-4o","input":"Hi","stream":true}`)
+		_, _, err := translator.RequestBody(original, req, false)
+		require.NoError(t, err)
+		require.True(t, translator.stream)
+
+		// Simulate SSE stream with response events
+		sseChunks := `data: {"type":"response.created","response":{"model":"gpt-4o-2024-11-20"}}
+
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","type":"message","status":"in_progress","role":"assistant","content":[]}}
+
+data: {"type":"response.content_part.added","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}
+
+data: {"type":"response.output_text.delta","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"delta":"Hello"}
+
+data: {"type":"response.output_text.done","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"text":"Hello, how can I help?"}
+
+data: {"type":"response.content_part.done","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello, how can I help?","annotations":[]}}
+
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, how can I help?","annotations":[]}]}}
+
+data: {"type":"response.completed","response":{"id":"resp_67ccd2bed1ec8190b14f964abc0542670bb6a6b452d3795b","object":"response","created_at":1741476542,"status":"completed","model":"","output":[{"type":"message","id":"msg_67ccd2bf17f0819081ff3bb2cf6508e60bb6a6b452d3795b","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, how can I help?"}]}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":2},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}
+
+data: [DONE]
+
+`
+		crlfChunks := bytes.ReplaceAll([]byte(sseChunks), []byte("\n"), []byte("\r\n"))
+		_, _, tokenUsage, responseModel, err := translator.ResponseBody(nil, bytes.NewReader(crlfChunks), true, nil)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o-2024-11-20", responseModel)
+
+		inputTokens, ok := tokenUsage.InputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(10), inputTokens)
+
+		outputTokens, ok := tokenUsage.OutputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(5), outputTokens)
+
+		totalTokens, ok := tokenUsage.TotalTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(15), totalTokens)
+
+		cachedTokens, ok := tokenUsage.CachedInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(2), cachedTokens)
+
+		cacheCreationTokens, ok := tokenUsage.CacheCreationInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(0), cacheCreationTokens)
+
+		reasoningTokens, ok := tokenUsage.ReasoningTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(0), reasoningTokens)
+	})
+
+	t.Run("streaming response with data field without space", func(t *testing.T) {
+		translator := NewResponsesOpenAIToOpenAITranslator("v1", "").(*openAIToOpenAITranslatorV1Responses)
+
+		req := &openai.ResponseRequest{
+			Model:  "gpt-4o",
+			Stream: true,
+			Input: openai.ResponseNewParamsInputUnion{
+				OfString: ptr.To("Hi"),
+			},
+		}
+		original := []byte(`{"model":"gpt-4o","input":"Hi","stream":true}`)
+		_, _, err := translator.RequestBody(original, req, false)
+		require.NoError(t, err)
+		require.True(t, translator.stream)
+
+		// Simulate SSE stream with response events
+		sseChunks := `data: {"type":"response.created","response":{"model":"gpt-4o-2024-11-20"}}
+
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","type":"message","status":"in_progress","role":"assistant","content":[]}}
+
+data: {"type":"response.content_part.added","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}
+
+data: {"type":"response.output_text.delta","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"delta":"Hello"}
+
+data: {"type":"response.output_text.done","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"text":"Hello, how can I help?"}
+
+data: {"type":"response.content_part.done","item_id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello, how can I help?","annotations":[]}}
+
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_67c9fdcf37fc8190ba82116e33fb28c507b8b0ad4e5eb654","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, how can I help?","annotations":[]}]}}
+
+data: {"type":"response.completed","response":{"id":"resp_67ccd2bed1ec8190b14f964abc0542670bb6a6b452d3795b","object":"response","created_at":1741476542,"status":"completed","model":"","output":[{"type":"message","id":"msg_67ccd2bf17f0819081ff3bb2cf6508e60bb6a6b452d3795b","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, how can I help?"}]}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":2},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}
+
+data: [DONE]
+
+`
+		noSpaceChunks := bytes.ReplaceAll([]byte(sseChunks), []byte("data: "), []byte("data:"))
+		_, _, tokenUsage, responseModel, err := translator.ResponseBody(nil, bytes.NewReader(noSpaceChunks), true, nil)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o-2024-11-20", responseModel)
+
+		inputTokens, ok := tokenUsage.InputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(10), inputTokens)
+
+		outputTokens, ok := tokenUsage.OutputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(5), outputTokens)
+
+		totalTokens, ok := tokenUsage.TotalTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(15), totalTokens)
+
+		cachedTokens, ok := tokenUsage.CachedInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(2), cachedTokens)
+
+		cacheCreationTokens, ok := tokenUsage.CacheCreationInputTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(0), cacheCreationTokens)
+
+		reasoningTokens, ok := tokenUsage.ReasoningTokens()
+		require.True(t, ok)
+		require.Equal(t, uint32(0), reasoningTokens)
+	})
 }
 
 func TestResponses_HandleStreamingResponse(t *testing.T) {

--- a/internal/translator/util.go
+++ b/internal/translator/util.go
@@ -51,6 +51,24 @@ func cutSSEDataPrefix(line []byte) ([]byte, bool) {
 	return cutSSEFieldPrefix(line, sseDataPrefix)
 }
 
+// indexSSEEventBoundary returns the index and length of the first blank-line
+// boundary that terminates an SSE event in buf, or (-1, 0) when no complete
+// event is buffered yet. SSE permits either LF or CRLF line endings, so both
+// "\n\n" and "\r\n\r\n" are recognized:
+// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+func indexSSEEventBoundary(buf []byte) (idx, sepLen int) {
+	lf := bytes.Index(buf, []byte("\n\n"))
+	crlf := bytes.Index(buf, []byte("\r\n\r\n"))
+	switch {
+	case lf == -1 && crlf == -1:
+		return -1, 0
+	case crlf == -1 || (lf != -1 && lf < crlf):
+		return lf, len("\n\n")
+	default:
+		return crlf, len("\r\n\r\n")
+	}
+}
+
 // regDataURI follows the web uri regex definition.
 // https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data#syntax
 var regDataURI = regexp.MustCompile(`\Adata:(.+?)?(;base64)?,`)

--- a/internal/translator/util_test.go
+++ b/internal/translator/util_test.go
@@ -6,6 +6,7 @@
 package translator
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,52 @@ func TestCutSSEDataPrefix(t *testing.T) {
 			if tc.ok {
 				require.Equal(t, tc.expected, string(data))
 			}
+		})
+	}
+}
+
+func TestIndexSSEEventBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		buf         string
+		expectedIdx int
+		expectedSep int
+	}{
+		{
+			name:        "LF framing",
+			buf:         "data: a\n\n",
+			expectedIdx: bytes.Index([]byte("data: a\n\n"), []byte("\n\n")),
+			expectedSep: 2,
+		},
+		{
+			name:        "CRLF framing",
+			buf:         "data: a\r\n\r\n",
+			expectedIdx: bytes.Index([]byte("data: a\r\n\r\n"), []byte("\r\n\r\n")),
+			expectedSep: 4,
+		},
+		{
+			name:        "LF boundary before a later CRLF boundary",
+			buf:         "data: a\n\ndata: b\r\n\r\n",
+			expectedIdx: bytes.Index([]byte("data: a\n\ndata: b\r\n\r\n"), []byte("\n\n")),
+			expectedSep: 2,
+		},
+		{
+			name:        "CRLF boundary before a later LF boundary",
+			buf:         "data: a\r\n\r\ndata: b\n\n",
+			expectedIdx: bytes.Index([]byte("data: a\r\n\r\ndata: b\n\n"), []byte("\r\n\r\n")),
+			expectedSep: 4,
+		},
+		{
+			name:        "incomplete event",
+			buf:         "data: a\n",
+			expectedIdx: -1,
+			expectedSep: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			idx, sepLen := indexSSEEventBoundary([]byte(tc.buf))
+			require.Equal(t, tc.expectedIdx, idx)
+			require.Equal(t, tc.expectedSep, sepLen)
 		})
 	}
 }


### PR DESCRIPTION
**Description**

The Responses passthrough translator parses the upstream SSE stream to recover token usage, the resolved response model, and tracing chunks. Its parser only split events on LF blank lines, so a spec-compliant upstream that frames its stream with CRLF was never parsed at all: `extractUsageFromBufferEvent` kept the whole stream buffered and returned no usage.

`internal/translator/openai_responses.go` now resolves the event boundary through a helper that accepts both LF (`\n\n`) and CRLF (`\r\n\r\n`) blank lines, and each line of a CRLF-framed event has its trailing CR stripped before the `data:` field is read. The optional space after `data:` was already accepted by `cutSSEDataPrefix`.

Fixes https://github.com/theagentrouter/agent-router/issues/2463

**Why**

SSE permits CRLF line endings, so this is a framing bug rather than upstream non-compliance. The response bytes reach the client either way; what is lost is Gateway's own observability: `gen_ai.usage.*` metrics, access-log token fields, the resolved model, and tracing chunks were all missing for CRLF-framed streams.

**How**

- `internal/translator/util.go`: added `indexSSEEventBoundary`, which returns the first blank-line event boundary and the length of that boundary, preferring whichever of the LF and CRLF forms appears first in the buffer.
- `internal/translator/openai_responses.go`: `extractUsageFromBufferEvent` uses that helper and trims one trailing CR from each line inside an event, so a CRLF-framed event no longer leaves a CR on the `data:` payload or on the `[DONE]` sentinel.

**Tests**

- `TestIndexSSEEventBoundary` in `util_test.go`: LF framing, CRLF framing, LF boundary before a later CRLF boundary, CRLF boundary before a later LF boundary, and a partial event that must stay buffered.
- `TestResponsesOpenAIToOpenAITranslator_ResponseBody`: new subtests `streaming response with CRLF framing` and `streaming response with data field without space`, asserting the resolved model and input, output, total, cached and reasoning token usage.

Verification on the branch:

- `go test ./internal/translator/... -count=1` passes.
- Mutation check: reverting only the parser change makes the CRLF subtest fail with empty token usage, and restoring it makes the suite pass again, so the new test guards the fix.
- `golangci-lint fmt --diff`, `golangci-lint run` with the repository's test build tags, and `misspell -error` are clean on the touched files.

**AI disclosure**

The change was authored with AI assistance (OpenCode driving an open-source coding model) and reviewed and verified locally by the submitter for correctness, scope, and licensing (Apache-2.0) before submission, in line with the repository's generative AI policy.
